### PR TITLE
fix(protocols): remove command invokers to ensure full SKILL.md injection

### DIFF
--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue (ἑρμηνεία: interpretation)",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/hermeneia/commands/clarify.md
+++ b/hermeneia/commands/clarify.md
@@ -1,8 +1,0 @@
----
-argument-hint: [expression]
-description: Clarify intent-expression mismatches (/hermeneia alias)
----
-
-# /clarify
-
-Call the hermeneia skill with: $ARGUMENTS

--- a/hermeneia/commands/hermeneia.md
+++ b/hermeneia/commands/hermeneia.md
@@ -1,8 +1,0 @@
----
-argument-hint: [expression]
-description: Clarify intent-expression mismatches (Hermeneia protocol)
----
-
-# /hermeneia
-
-Call the hermeneia skill with: $ARGUMENTS

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Place epistemic perspectives before inquiry (πρόθεσις: a placing before)",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/commands/lens.md
+++ b/prothesis/commands/lens.md
@@ -1,8 +1,0 @@
----
-argument-hint: [topic]
-description: Analyze from multiple perspectives (/prothesis alias)
----
-
-# /lens
-
-Call the prothesis skill with: $ARGUMENTS

--- a/prothesis/commands/prothesis.md
+++ b/prothesis/commands/prothesis.md
@@ -1,8 +1,0 @@
----
-argument-hint: [topic]
-description: Analyze from multiple perspectives (Prothesis protocol)
----
-
-# /prothesis
-
-Call the prothesis skill with: $ARGUMENTS

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points (συνείδησις: knowing-together)",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/commands/gap.md
+++ b/syneidesis/commands/gap.md
@@ -1,8 +1,0 @@
----
-argument-hint: [decision]
-description: Surface potential gaps before decisions (/syneidesis alias)
----
-
-# /gap
-
-Call the syneidesis skill with: $ARGUMENTS

--- a/syneidesis/commands/syneidesis.md
+++ b/syneidesis/commands/syneidesis.md
@@ -1,8 +1,0 @@
----
-argument-hint: [decision]
-description: Surface potential gaps before decisions (Syneidesis protocol)
----
-
-# /syneidesis
-
-Call the syneidesis skill with: $ARGUMENTS


### PR DESCRIPTION
## Summary
- Command invokers (`commands/*.md`) only inject short instructions, preventing full protocol content from loading
- This caused protocol violations (e.g., AskUserQuestion not called because SKILL.md rules not in context)
- Removed redundant command files from syneidesis, prothesis, and hermeneia
- Skills remain directly invocable via `user-invocable: true` frontmatter

## Test plan
- [x] Invoke `/syneidesis` in a new session and verify full SKILL.md content is injected
- [x] Confirm AskUserQuestion is called during gap surfacing (not text-only output)
- [x] Test `/prothesis` and `/hermeneia` similarly

🤖 Generated with [Claude Code](https://claude.com/claude-code)