### PR TITLE
docs(readme): add epistemic matrix diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Claude Code plugins for epistemic dialogue — transforming **unknown unknowns**
 
 All protocols share a core transformation pattern:
 
+<p align="center">
+  <img src="./assets/epistemic-matrix.svg" alt="Epistemic Matrix - Rumsfeld quadrant showing protocol transitions" width="500">
+</p>
+
 - **Prothesis**: "Which lens?" → AI presents options, you choose (**Unknown Unknown → Known Unknown**)
 - **Syneidesis**: "What's missing?" → AI surfaces gaps as questions, you judge (**Unknown Unknown → Known Unknown**)
 - **Hermeneia**: "What do I mean?" → AI presents interpretations, you recognize your intent (**Known Unknown → Known Known**)

--- a/README_ko.md
+++ b/README_ko.md
@@ -15,7 +15,11 @@
 
 ## 핵심 아이디어
 
-세 프로토콜 모두 핵심 변환 패턴을 공유합니다:
+네 프로토콜 모두 핵심 변환 패턴을 공유합니다:
+
+<p align="center">
+  <img src="./assets/epistemic-matrix-ko.svg" alt="인식론적 매트릭스 - Rumsfeld 사분면과 프로토콜 전환" width="500">
+</p>
 
 - **Prothesis**: "어떤 렌즈로?" → AI가 선택지 제시, 사용자가 선택 (**Unknown Unknown → Known Unknown**)
 - **Syneidesis**: "뭘 놓쳤지?" → AI가 갭을 질문으로 표면화, 사용자가 판단 (**Unknown Unknown → Known Unknown**)

--- a/assets/epistemic-matrix-ko.svg
+++ b/assets/epistemic-matrix-ko.svg
@@ -1,0 +1,54 @@
+<svg viewBox="0 0 480 340" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M 0 0 L 8 3 L 0 6 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="480" height="340" fill="#f5f5f0"/>
+
+  <!-- Quadrants with soft pastel colors -->
+  <!-- II: Unknown Knowns (top-left) - peach -->
+  <rect x="60" y="50" width="170" height="115" rx="8" fill="#fce8dc"/>
+
+  <!-- I: Known Knowns (top-right) - soft green -->
+  <rect x="250" y="50" width="170" height="115" rx="8" fill="#d4edda"/>
+
+  <!-- III: Unknown Unknowns (bottom-left) - mint/teal -->
+  <rect x="60" y="175" width="170" height="115" rx="8" fill="#d1ecf1"/>
+
+  <!-- IV: Known Unknowns (bottom-right) - soft yellow -->
+  <rect x="250" y="175" width="170" height="115" rx="8" fill="#fff3cd"/>
+
+  <!-- Quadrant labels -->
+  <text x="145" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Unknown Knowns</text>
+  <text x="145" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">암묵지 / AI 작업 미파악</text>
+
+  <text x="335" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Known Knowns</text>
+  <text x="335" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">검증된 이해</text>
+
+  <text x="145" y="225" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Unknown Unknowns</text>
+  <text x="145" y="243" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">미지의 미지</text>
+
+  <text x="335" y="225" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Known Unknowns</text>
+  <text x="335" y="243" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">인식된 무지</text>
+
+  <!-- Protocol arrows -->
+
+  <!-- Katalepsis: II → I (top, curved over) -->
+  <path d="M 175 50 Q 240 20 305 50" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="240" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Katalepsis</text>
+
+  <!-- Hermeneia: IV → I (right side, curved) -->
+  <path d="M 420 220 Q 450 170 420 107" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="455" y="165" text-anchor="start" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Hermeneia</text>
+
+  <!-- Prothesis: III → IV (bottom, from deep left) -->
+  <path d="M 100 290 Q 180 315 305 290" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="200" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Prothesis</text>
+
+  <!-- Syneidesis: III → IV (middle, shorter path) -->
+  <path d="M 230 232 Q 250 240 270 232" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="250" y="255" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Syneidesis</text>
+</svg>

--- a/assets/epistemic-matrix.svg
+++ b/assets/epistemic-matrix.svg
@@ -1,0 +1,54 @@
+<svg viewBox="0 0 480 340" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M 0 0 L 8 3 L 0 6 z" fill="#6b7280"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="480" height="340" fill="#f5f5f0"/>
+
+  <!-- Quadrants with soft pastel colors -->
+  <!-- II: Unknown Knowns (top-left) - peach -->
+  <rect x="60" y="50" width="170" height="115" rx="8" fill="#fce8dc"/>
+
+  <!-- I: Known Knowns (top-right) - soft green -->
+  <rect x="250" y="50" width="170" height="115" rx="8" fill="#d4edda"/>
+
+  <!-- III: Unknown Unknowns (bottom-left) - mint/teal -->
+  <rect x="60" y="175" width="170" height="115" rx="8" fill="#d1ecf1"/>
+
+  <!-- IV: Known Unknowns (bottom-right) - soft yellow -->
+  <rect x="250" y="175" width="170" height="115" rx="8" fill="#fff3cd"/>
+
+  <!-- Quadrant labels -->
+  <text x="145" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Unknown Knowns</text>
+  <text x="145" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">Implicit/Tacit Knowledge</text>
+
+  <text x="335" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Known Knowns</text>
+  <text x="335" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">Conscious Knowledge</text>
+
+  <text x="145" y="225" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Unknown Unknowns</text>
+  <text x="145" y="243" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">Unrecognized Ignorance</text>
+
+  <text x="335" y="225" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#4a5568">Known Unknowns</text>
+  <text x="335" y="243" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#718096">Conscious Ignorance</text>
+
+  <!-- Protocol arrows -->
+
+  <!-- Katalepsis: II → I (top, curved over) -->
+  <path d="M 175 50 Q 240 20 305 50" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="240" y="28" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Katalepsis</text>
+
+  <!-- Hermeneia: IV → I (right side, curved) -->
+  <path d="M 420 220 Q 450 170 420 107" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="455" y="165" text-anchor="start" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Hermeneia</text>
+
+  <!-- Prothesis: III → IV (bottom, from deep left) -->
+  <path d="M 100 290 Q 180 315 305 290" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="200" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Prothesis</text>
+
+  <!-- Syneidesis: III → IV (middle, shorter path) -->
+  <path d="M 230 232 Q 250 240 270 232" stroke="#6b7280" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
+  <text x="250" y="255" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#4a5568">Syneidesis</text>
+</svg>


### PR DESCRIPTION
## Summary
- README에 Rumsfeld 사분면 기반 인식론적 매트릭스 다이어그램 추가
- 각 프로토콜의 epistemic transition을 시각적으로 표현
- 한국어 README "세 프로토콜" → "네 프로토콜" 수정

## Changes
- `assets/epistemic-matrix.svg` - 영문 다이어그램
- `assets/epistemic-matrix-ko.svg` - 한국어 다이어그램
- README.md, README_ko.md에 이미지 참조 추가

## Test plan
- [x] SVG가 GitHub README에서 렌더링되는지 확인
- [x] 한국어/영문 버전 모두 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.ai/code)