### PR TITLE
feat: add Telos (τέλος) protocol — GoalIndeterminate → DefinedEndState

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Claude Code plugins for epistemic dialogue — each protocol resolves a specific
 | **[Syneidesis](./syneidesis)** (συνείδησις) | Surface potential gaps at decision points | At decision time |
 | **[Hermeneia](./hermeneia)** (ἑρμηνεία) | Clarify intent-expression gaps via dialogue | Before action |
 | **[Katalepsis](./katalepsis)** (κατάληψις) | Achieve certain comprehension of AI work | After AI action |
+| **[Telos](./telos)** (τέλος) | Co-construct defined goals from vague intent | Pre-action |
 
 ## Core Idea
 
@@ -27,6 +28,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 | **Syneidesis** | GapUnnoticed | AI-detected | SURFACE | `GapUnnoticed → AuditedDecision` |
 | **Hermeneia** | IntentMisarticulated | User-initiated | EXTRACT | `IntentMisarticulated → ClarifiedIntent` |
 | **Katalepsis** | ResultUngrasped | User-initiated | VERIFY | `ResultUngrasped → VerifiedUnderstanding` |
+| **Telos** | GoalIndeterminate | AI-detected | CO-CONSTRUCT | `GoalIndeterminate → DefinedEndState` |
 
 <img src="./assets/epistemic-matrix.svg" alt="Epistemic Type Transformations" width="560">
 
@@ -34,6 +36,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 - **Syneidesis**: "What's missing?" → AI surfaces gaps as questions, you judge (`GapUnnoticed → AuditedDecision`)
 - **Hermeneia**: "What do I mean?" → AI presents interpretations, you recognize your intent (`IntentMisarticulated → ClarifiedIntent`)
 - **Katalepsis**: "What did you do?" → AI verifies your understanding through questions (`ResultUngrasped → VerifiedUnderstanding`)
+- **Telos**: "What do I actually want?" → AI proposes goals, you shape and approve (`GoalIndeterminate → DefinedEndState`)
 
 The key insight: **Recognition over Recall**. It's easier to select from presented options than to generate questions from scratch.
 
@@ -48,6 +51,7 @@ The key insight: **Recognition over Recall**. It's easier to select from present
 /plugin install syneidesis
 /plugin install hermeneia
 /plugin install katalepsis
+/plugin install telos
 ```
 
 ## Usage
@@ -57,6 +61,7 @@ The key insight: **Recognition over Recall**. It's easier to select from present
 /syneidesis [your task]       # Enable gap surfacing during execution
 /hermeneia [your expression]  # Clarify ambiguous intent
 /katalepsis                   # Verify understanding of AI work
+/telos [your vague idea]      # Co-construct defined goals from intent
 ```
 
 ## License

--- a/README_ko.md
+++ b/README_ko.md
@@ -12,6 +12,7 @@
 | **[Syneidesis](./syneidesis)** (συνείδησις) | 결정 지점에서 잠재적 갭 표면화 | 의사결정 시점 |
 | **[Hermeneia](./hermeneia)** (ἑρμηνεία) | 의도-표현 갭을 대화로 명확화 | 실행 전 |
 | **[Katalepsis](./katalepsis)** (κατάληψις) | AI 작업에 대한 확실한 이해 달성 | AI 작업 완료 후 |
+| **[Telos](./telos)** (τέλος) | 모호한 의도에서 정의된 목표 공동 구성 | 실행 전 |
 
 ## 핵심 아이디어
 
@@ -27,6 +28,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 | **Syneidesis** | GapUnnoticed | AI-detected | SURFACE | `GapUnnoticed → AuditedDecision` |
 | **Hermeneia** | IntentMisarticulated | User-initiated | EXTRACT | `IntentMisarticulated → ClarifiedIntent` |
 | **Katalepsis** | ResultUngrasped | User-initiated | VERIFY | `ResultUngrasped → VerifiedUnderstanding` |
+| **Telos** | GoalIndeterminate | AI-detected | CO-CONSTRUCT | `GoalIndeterminate → DefinedEndState` |
 
 <img src="./assets/epistemic-matrix-ko.svg" alt="인식론적 타입 변환" width="560">
 
@@ -34,6 +36,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 - **Syneidesis**: "뭘 놓쳤지?" → AI가 갭을 질문으로 표면화, 사용자가 판단 (`GapUnnoticed → AuditedDecision`)
 - **Hermeneia**: "내가 뭘 말하려는 거지?" → AI가 해석 선택지 제시, 사용자가 의도 인식 (`IntentMisarticulated → ClarifiedIntent`)
 - **Katalepsis**: "뭘 한 거야?" → AI가 질문으로 사용자의 이해를 검증 (`ResultUngrasped → VerifiedUnderstanding`)
+- **Telos**: "내가 진짜 원하는 게 뭐지?" → AI가 목표를 제안, 사용자가 형성하고 승인 (`GoalIndeterminate → DefinedEndState`)
 
 핵심 통찰: **Recall(회상)보다 Recognition(인지)**. 빈칸을 채우는 것보다 선택지에서 고르는 게 쉽습니다.
 
@@ -48,6 +51,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 /plugin install syneidesis
 /plugin install hermeneia
 /plugin install katalepsis
+/plugin install telos
 ```
 
 ## 사용법
@@ -57,6 +61,7 @@ Protocol = (Deficit, Initiator, Operation, Operand) → Resolution
 /syneidesis [작업]   # 실행 중 갭 표면화 활성화
 /hermeneia [표현]    # 모호한 의도 명확화
 /katalepsis          # AI 작업에 대한 이해 검증
+/telos [모호한 아이디어]  # 의도에서 정의된 목표 공동 구성
 ```
 
 ## 라이선스

--- a/assets/epistemic-matrix-ko.svg
+++ b/assets/epistemic-matrix-ko.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 560 460" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 560 520" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <path d="M 0 0 L 8 3 L 0 6 z" fill="#6b7280"/>
@@ -6,15 +6,15 @@
   </defs>
 
   <!-- Background -->
-  <rect width="560" height="460" fill="#f5f5f0"/>
+  <rect width="560" height="520" fill="#f5f5f0"/>
 
   <!-- Title -->
   <text x="280" y="30" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="700" fill="#2d3748">인식론적 타입 변환</text>
 
   <!-- Group labels -->
-  <text x="44" y="66" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">AI 감지</text>
-  <text x="44" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">사용자 개시</text>
-  <text x="44" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">사용자 호출</text>
+  <text x="44" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">AI 감지</text>
+  <text x="44" y="297" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">사용자 개시</text>
+  <text x="44" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">사용자 호출</text>
 
   <!-- Row 1: AI-detected -->
   <!-- Prothesis -->
@@ -45,77 +45,91 @@
 
   <text x="500" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Syneidesis</text>
 
+  <!-- Telos -->
+  <rect x="88" y="168" width="145" height="50" rx="8" fill="#d1ecf1"/>
+  <text x="160" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">GoalIndeterminate</text>
+  <text x="160" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">목표 미정의</text>
+
+  <line x1="233" y1="193" x2="293" y2="193" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CO-CONSTRUCT</text>
+
+  <rect x="295" y="168" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">DefinedEndState</text>
+  <text x="367" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">목표 계약 수립</text>
+
+  <text x="500" y="193" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Telos</text>
+
   <!-- Separator -->
-  <line x1="88" y1="172" x2="440" y2="172" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="88" y1="232" x2="440" y2="232" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
 
   <!-- Row 2: User-initiated -->
   <!-- Hermeneia -->
-  <rect x="88" y="182" width="145" height="50" rx="8" fill="#fce8dc"/>
-  <text x="160" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">IntentMisarticulated</text>
-  <text x="160" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">표현-의도 불일치</text>
-
-  <line x1="233" y1="207" x2="293" y2="207" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTRACT</text>
-
-  <rect x="295" y="182" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ClarifiedIntent</text>
-  <text x="367" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">의도 명시화 완료</text>
-
-  <text x="500" y="207" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Hermeneia</text>
-
-  <!-- Katalepsis -->
   <rect x="88" y="242" width="145" height="50" rx="8" fill="#fce8dc"/>
-  <text x="160" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ResultUngrasped</text>
-  <text x="160" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI 작업 미파악</text>
+  <text x="160" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">IntentMisarticulated</text>
+  <text x="160" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">표현-의도 불일치</text>
 
   <line x1="233" y1="267" x2="293" y2="267" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">VERIFY</text>
+  <text x="263" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTRACT</text>
 
   <rect x="295" y="242" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">VerifiedUnderstanding</text>
-  <text x="367" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">이해 검증 완료</text>
+  <text x="367" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ClarifiedIntent</text>
+  <text x="367" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">의도 명시화 완료</text>
 
-  <text x="500" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Katalepsis</text>
+  <text x="500" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Hermeneia</text>
+
+  <!-- Katalepsis -->
+  <rect x="88" y="302" width="145" height="50" rx="8" fill="#fce8dc"/>
+  <text x="160" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ResultUngrasped</text>
+  <text x="160" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI 작업 미파악</text>
+
+  <line x1="233" y1="327" x2="293" y2="327" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">VERIFY</text>
+
+  <rect x="295" y="302" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">VerifiedUnderstanding</text>
+  <text x="367" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">이해 검증 완료</text>
+
+  <text x="500" y="327" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Katalepsis</text>
 
   <!-- Separator -->
-  <line x1="88" y1="302" x2="440" y2="302" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="88" y1="362" x2="440" y2="362" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
 
   <!-- Row 3: User-invoked -->
   <!-- Reflexion -->
-  <rect x="88" y="312" width="145" height="50" rx="8" fill="#fff3cd"/>
-  <text x="160" y="334" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">KnowledgeTacit</text>
-  <text x="160" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">세션 한정 인사이트</text>
-
-  <line x1="233" y1="337" x2="293" y2="337" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CRYSTALLIZE</text>
-
-  <rect x="295" y="312" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="334" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">PersistedKnowledge</text>
-  <text x="367" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">메모리 통합 완료</text>
-
-  <text x="500" y="337" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Reflexion</text>
-
-  <!-- Write -->
   <rect x="88" y="372" width="145" height="50" rx="8" fill="#fff3cd"/>
-  <text x="160" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">InsightInternal</text>
-  <text x="160" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">미표현 지식</text>
+  <text x="160" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">KnowledgeTacit</text>
+  <text x="160" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">세션 한정 인사이트</text>
 
   <line x1="233" y1="397" x2="293" y2="397" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="390" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTERNALIZE</text>
+  <text x="263" y="390" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CRYSTALLIZE</text>
 
   <rect x="295" y="372" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ExternalizedKnowledge</text>
-  <text x="367" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">출판물 생성 완료</text>
+  <text x="367" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">PersistedKnowledge</text>
+  <text x="367" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">메모리 통합 완료</text>
 
-  <text x="500" y="397" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Write</text>
+  <text x="500" y="397" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Reflexion</text>
+
+  <!-- Write -->
+  <rect x="88" y="432" width="145" height="50" rx="8" fill="#fff3cd"/>
+  <text x="160" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">InsightInternal</text>
+  <text x="160" y="470" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">미표현 지식</text>
+
+  <line x1="233" y1="457" x2="293" y2="457" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="450" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTERNALIZE</text>
+
+  <rect x="295" y="432" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ExternalizedKnowledge</text>
+  <text x="367" y="470" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">출판물 생성 완료</text>
+
+  <text x="500" y="457" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Write</text>
 
   <!-- Legend -->
-  <rect x="88" y="435" width="10" height="10" rx="2" fill="#d1ecf1"/>
-  <text x="103" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI 감지 결핍</text>
-  <rect x="175" y="435" width="10" height="10" rx="2" fill="#d4edda"/>
-  <text x="190" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">해소 (출력)</text>
-  <rect x="270" y="435" width="10" height="10" rx="2" fill="#fce8dc"/>
-  <text x="285" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">사용자 개시 결핍</text>
-  <rect x="385" y="435" width="10" height="10" rx="2" fill="#fff3cd"/>
-  <text x="400" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">사용자 호출 결핍</text>
+  <rect x="88" y="495" width="10" height="10" rx="2" fill="#d1ecf1"/>
+  <text x="103" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI 감지 결핍</text>
+  <rect x="175" y="495" width="10" height="10" rx="2" fill="#d4edda"/>
+  <text x="190" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">해소 (출력)</text>
+  <rect x="270" y="495" width="10" height="10" rx="2" fill="#fce8dc"/>
+  <text x="285" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">사용자 개시 결핍</text>
+  <rect x="385" y="495" width="10" height="10" rx="2" fill="#fff3cd"/>
+  <text x="400" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">사용자 호출 결핍</text>
 </svg>

--- a/assets/epistemic-matrix.svg
+++ b/assets/epistemic-matrix.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 560 460" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 560 520" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
       <path d="M 0 0 L 8 3 L 0 6 z" fill="#6b7280"/>
@@ -6,15 +6,15 @@
   </defs>
 
   <!-- Background -->
-  <rect width="560" height="460" fill="#f5f5f0"/>
+  <rect width="560" height="520" fill="#f5f5f0"/>
 
   <!-- Title -->
   <text x="280" y="30" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="700" fill="#2d3748">Epistemic Type Transformations</text>
 
   <!-- Group labels -->
-  <text x="44" y="66" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">AI-detected</text>
-  <text x="44" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">User-initiated</text>
-  <text x="44" y="316" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">User-invoked</text>
+  <text x="44" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">AI-detected</text>
+  <text x="44" y="297" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">User-initiated</text>
+  <text x="44" y="427" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="600" fill="#718096">User-invoked</text>
 
   <!-- Row 1: AI-detected -->
   <!-- Prothesis -->
@@ -45,77 +45,91 @@
 
   <text x="500" y="133" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Syneidesis</text>
 
+  <!-- Telos -->
+  <rect x="88" y="168" width="145" height="50" rx="8" fill="#d1ecf1"/>
+  <text x="160" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">GoalIndeterminate</text>
+  <text x="160" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Undefined end state</text>
+
+  <line x1="233" y1="193" x2="293" y2="193" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="186" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CO-CONSTRUCT</text>
+
+  <rect x="295" y="168" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="190" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">DefinedEndState</text>
+  <text x="367" y="206" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Goal contract defined</text>
+
+  <text x="500" y="193" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Telos</text>
+
   <!-- Separator -->
-  <line x1="88" y1="172" x2="440" y2="172" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="88" y1="232" x2="440" y2="232" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
 
   <!-- Row 2: User-initiated -->
   <!-- Hermeneia -->
-  <rect x="88" y="182" width="145" height="50" rx="8" fill="#fce8dc"/>
-  <text x="160" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">IntentMisarticulated</text>
-  <text x="160" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Expression-intent gap</text>
-
-  <line x1="233" y1="207" x2="293" y2="207" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="200" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTRACT</text>
-
-  <rect x="295" y="182" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="204" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ClarifiedIntent</text>
-  <text x="367" y="220" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Intent made explicit</text>
-
-  <text x="500" y="207" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Hermeneia</text>
-
-  <!-- Katalepsis -->
   <rect x="88" y="242" width="145" height="50" rx="8" fill="#fce8dc"/>
-  <text x="160" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ResultUngrasped</text>
-  <text x="160" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI work not understood</text>
+  <text x="160" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">IntentMisarticulated</text>
+  <text x="160" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Expression-intent gap</text>
 
   <line x1="233" y1="267" x2="293" y2="267" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">VERIFY</text>
+  <text x="263" y="260" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTRACT</text>
 
   <rect x="295" y="242" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">VerifiedUnderstanding</text>
-  <text x="367" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Comprehension confirmed</text>
+  <text x="367" y="264" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ClarifiedIntent</text>
+  <text x="367" y="280" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Intent made explicit</text>
 
-  <text x="500" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Katalepsis</text>
+  <text x="500" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Hermeneia</text>
+
+  <!-- Katalepsis -->
+  <rect x="88" y="302" width="145" height="50" rx="8" fill="#fce8dc"/>
+  <text x="160" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ResultUngrasped</text>
+  <text x="160" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI work not understood</text>
+
+  <line x1="233" y1="327" x2="293" y2="327" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="320" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">VERIFY</text>
+
+  <rect x="295" y="302" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="324" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">VerifiedUnderstanding</text>
+  <text x="367" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Comprehension confirmed</text>
+
+  <text x="500" y="327" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Katalepsis</text>
 
   <!-- Separator -->
-  <line x1="88" y1="302" x2="440" y2="302" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
+  <line x1="88" y1="362" x2="440" y2="362" stroke="#cbd5e0" stroke-width="0.5" stroke-dasharray="4,3"/>
 
   <!-- Row 3: User-invoked -->
   <!-- Reflexion -->
-  <rect x="88" y="312" width="145" height="50" rx="8" fill="#fff3cd"/>
-  <text x="160" y="334" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">KnowledgeTacit</text>
-  <text x="160" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Session-bound insight</text>
-
-  <line x1="233" y1="337" x2="293" y2="337" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CRYSTALLIZE</text>
-
-  <rect x="295" y="312" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="334" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">PersistedKnowledge</text>
-  <text x="367" y="350" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Memory integrated</text>
-
-  <text x="500" y="337" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Reflexion</text>
-
-  <!-- Write -->
   <rect x="88" y="372" width="145" height="50" rx="8" fill="#fff3cd"/>
-  <text x="160" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">InsightInternal</text>
-  <text x="160" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Unexpressed knowledge</text>
+  <text x="160" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">KnowledgeTacit</text>
+  <text x="160" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Session-bound insight</text>
 
   <line x1="233" y1="397" x2="293" y2="397" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="263" y="390" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTERNALIZE</text>
+  <text x="263" y="390" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">CRYSTALLIZE</text>
 
   <rect x="295" y="372" width="145" height="50" rx="8" fill="#d4edda"/>
-  <text x="367" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ExternalizedKnowledge</text>
-  <text x="367" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Published artifact</text>
+  <text x="367" y="394" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">PersistedKnowledge</text>
+  <text x="367" y="410" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Memory integrated</text>
 
-  <text x="500" y="397" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Write</text>
+  <text x="500" y="397" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Reflexion</text>
+
+  <!-- Write -->
+  <rect x="88" y="432" width="145" height="50" rx="8" fill="#fff3cd"/>
+  <text x="160" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">InsightInternal</text>
+  <text x="160" y="470" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Unexpressed knowledge</text>
+
+  <line x1="233" y1="457" x2="293" y2="457" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="263" y="450" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" font-weight="600" fill="#4a5568">EXTERNALIZE</text>
+
+  <rect x="295" y="432" width="145" height="50" rx="8" fill="#d4edda"/>
+  <text x="367" y="454" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="600" fill="#4a5568">ExternalizedKnowledge</text>
+  <text x="367" y="470" text-anchor="middle" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Published artifact</text>
+
+  <text x="500" y="457" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-style="italic" fill="#805ad5">Write</text>
 
   <!-- Legend -->
-  <rect x="88" y="435" width="10" height="10" rx="2" fill="#d1ecf1"/>
-  <text x="103" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI-detected deficit</text>
-  <rect x="175" y="435" width="10" height="10" rx="2" fill="#d4edda"/>
-  <text x="190" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Resolved (output)</text>
-  <rect x="270" y="435" width="10" height="10" rx="2" fill="#fce8dc"/>
-  <text x="285" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">User-initiated deficit</text>
-  <rect x="385" y="435" width="10" height="10" rx="2" fill="#fff3cd"/>
-  <text x="400" y="444" font-family="system-ui, sans-serif" font-size="8" fill="#718096">User-invoked deficit</text>
+  <rect x="88" y="495" width="10" height="10" rx="2" fill="#d1ecf1"/>
+  <text x="103" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">AI-detected deficit</text>
+  <rect x="175" y="495" width="10" height="10" rx="2" fill="#d4edda"/>
+  <text x="190" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">Resolved (output)</text>
+  <rect x="270" y="495" width="10" height="10" rx="2" fill="#fce8dc"/>
+  <text x="285" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">User-initiated deficit</text>
+  <rect x="385" y="495" width="10" height="10" rx="2" fill="#fff3cd"/>
+  <text x="400" y="504" font-family="system-ui, sans-serif" font-size="8" fill="#718096">User-invoked deficit</text>
 </svg>


### PR DESCRIPTION
## Summary

- Telos 프로토콜 추가: 모호한 의도에서 정의된 목표를 공동 구성 (`GoalIndeterminate → DefinedEndState`)
- SKILL.md, plugin.json, README, SVG 에셋 등 전체 에코시스템 통합
- 기존 4개 프로토콜 SKILL.md에 5-프로토콜 precedence chain 반영 완료

## Changes

### Protocol Definition
- `telos/skills/telos/SKILL.md`: 전체 프로토콜 정의 (Phase 0~4, TOOL GROUNDING, MODE STATE)
- `telos/.claude-plugin/plugin.json`: 플러그인 매니페스트
- `telos/README.md`, `telos/README_ko.md`: 프로토콜 문서

### Documentation Sync
- `README.md`, `README_ko.md`: Protocols 테이블, Core Idea, Installation, Usage에 Telos 추가
- `assets/epistemic-matrix.svg`, `assets/epistemic-matrix-ko.svg`: AI-detected 그룹에 Telos 행 삽입 (viewBox 460→520)
- `CLAUDE.md`: Telos 섹션, Epistemic Workflow Timeline, Protocol Precedence 업데이트

### Ecosystem Integration
- `.claude-plugin/marketplace.json`: Telos 등록
- `.claude/skills/verify/scripts/static-checks.js`: Telos 검증 대상 추가
- 기존 4개 SKILL.md: precedence chain `Hermeneia → Telos → Prothesis → Syneidesis → Katalepsis` 반영

## Checklist
- [x] SKILL.md 필수 섹션 (Definition, Mode Activation, Protocol, Rules, PHASE TRANSITIONS, MODE STATE)
- [x] plugin.json 필수 필드 (name, version, description, author)
- [x] README.md / README_ko.md 동기화
- [x] SVG 에셋에 Telos 행 추가
- [x] marketplace.json 등록
- [x] static-checks.js에 telos 추가
- [x] 기존 프로토콜 precedence 업데이트
- [x] `/verify` 실행하여 정합성 최종 확인

## Test Plan
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 실행 — 0 fail 확인
- [x] SVG 렌더링 확인 — Telos 행이 AI-detected 그룹 3번째에 표시
- [x] `/telos` 호출 테스트 — Phase 0 AskUserQuestion 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)