### PR TITLE
feat: Prothesis Phase 5-6 action extension (3.1.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ epistemic-protocols/
 
 ### Prothesis (πρόθεσις) — alias: `lens`
 Present perspective options before analysis begins. Injected into main agent context.
-- **Flow**: `U → C → P → Pₛ → T(Pₛ) → ∥I(T) → R → L → (sufficiency check → act? → K → ∥F → V → L' → loop)`
+- **Flow**: `U → C → P → Pₛ → T(Pₛ) → ∥I(T) → R → L → (sufficiency check → K? → ∥F → V → L' → loop)`
 - **Key**: Phase 1 calls `AskUserQuestion` for perspective selection; Phase 4 calls `AskUserQuestion` for sufficiency check with `act` option; Phase 5-6 classify findings and execute fixes with peer verification; loop until user satisfied or ESC
 - **Phase 2**: Agent team via TeamCreate (mandatory); teammate isolation prevents cross-perspective contamination and confirmation bias; coordinator-mediated cross-dialogue; team persists across Phase 4 loop and through Phase 5-6
 - **Phase 5-6**: 3-tier finding classification (actionable/surfaced-unknown/design-level) + fixer with peer verification; peer-to-peer in Phase 6 only; post-TeamDelete recommends follow-up protocols for deferred findings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,19 @@ epistemic-protocols/
 - References directory: `skills/*/references/` for detailed documentation
 - No external dependencies; Node.js standard library only
 
+**SKILL.md Formal Block Anatomy** (all protocols share this structure within `Definition` code block):
+```
+── FLOW ──              One-line formula: full protocol path with symbols
+── TYPES ──             Symbol definitions with type signatures and comments
+── ACTION TYPES ──      (if applicable) Extended types for action phases
+── PHASE TRANSITIONS ── Phase-by-phase state transitions; [Tool] suffix marks external operations
+── LOOP ──              Post-phase control flow (J values → next phase or terminal)
+── BOUNDARY ──          Purpose annotations for key operations
+── TOOL GROUNDING ──    Symbol → concrete Claude Code tool mapping
+── MODE STATE ──        Runtime state type (Λ) with nested state types
+```
+Static checks (`structure`, `tool-grounding`) validate this anatomy. New phases must appear in PHASE TRANSITIONS with `[Tool]` suffix AND in TOOL GROUNDING with concrete tool mapping.
+
 ## Plugins
 
 ### Prothesis (πρόθεσις) — alias: `lens`
@@ -164,3 +177,13 @@ node .claude/skills/verify/scripts/static-checks.js .
 - Bump version in `.claude-plugin/plugin.json` on changes
 - `call` (not `invoke` or `use`) for tool-calling instructions—strongest binding with zero polysemy
 - Skills frontmatter: `name` (required), `description` (required), `user-invocable` (boolean), `allowed-tools` (optional)
+
+**Co-change pattern** (protocol modifications require synchronized edits):
+
+| Change | Files to update |
+|--------|----------------|
+| New/modified phase | SKILL.md (formal block + prose), CLAUDE.md (flow formula + key behaviors) |
+| New tool usage | SKILL.md (PHASE TRANSITIONS `[Tool]` + TOOL GROUNDING entry) |
+| New loop option | SKILL.md (LOOP + Phase 4 prose + Rules), CLAUDE.md (key behaviors) |
+| Delegation change | SKILL.md (isolation section), CLAUDE.md (delegation constraint) |
+| Any protocol change | `plugin.json` version bump, then `/verify` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Present perspective options before analysis begins. Injected into main agent con
 - **Flow**: `U → C → P → Pₛ → T(Pₛ) → ∥I(T) → R → L → (sufficiency check → K? → ∥F → V → L' → loop)`
 - **Key**: Phase 1 calls `AskUserQuestion` for perspective selection; Phase 4 calls `AskUserQuestion` for sufficiency check with `act` option; Phase 5-6 classify findings and execute fixes with peer verification; loop until user satisfied or ESC
 - **Phase 2**: Agent team via TeamCreate (mandatory); teammate isolation prevents cross-perspective contamination and confirmation bias; coordinator-mediated cross-dialogue; team persists across Phase 4 loop and through Phase 5-6
-- **Phase 5-6**: 3-tier finding classification (actionable/surfaced-unknown/design-level) + fixer with peer verification; peer-to-peer in Phase 6 only; post-TeamDelete recommends follow-up protocols for deferred findings
+- **Phase 5-6**: 3-tier finding classification (actionable/surfaced-unknown/design-level) + praxis agent with peer verification; peer-to-peer in Phase 6 only; post-TeamDelete recommends follow-up protocols for deferred findings
 - **Invocation**: `/prothesis` or use "lens" in conversation
 
 ### Syneidesis (συνείδησις) — alias: `gap`
@@ -166,7 +166,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 ## Delegation Constraint
 
 - **Prothesis Phase 2**: MUST use agent team (TeamCreate + Task teammates)—isolated context required for unbiased perspective analysis; cross-dialogue is coordinator-mediated
-- **Prothesis Phase 5-6**: Fixer spawned via Task into existing team T; Phase 6 allows peer-to-peer (fixer ↔ originating perspective) for verification
+- **Prothesis Phase 5-6**: Praxis agent spawned via Task into existing team T; Phase 6 allows peer-to-peer (praxis ↔ originating perspective) for verification
 - **Syneidesis/Hermeneia/Katalepsis**: No Task delegation—must run in main agent to call AskUserQuestion
 - **Telos**: No Task delegation—must run in main agent to call AskUserQuestion
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,10 @@ epistemic-protocols/
 
 ### Prothesis (πρόθεσις) — alias: `lens`
 Present perspective options before analysis begins. Injected into main agent context.
-- **Flow**: `U → C → P → Pₛ → T(Pₛ) → ∥I(T) → R → L → (sufficiency check → loop)`
-- **Key**: Phase 1 calls `AskUserQuestion` for perspective selection; Phase 4 calls `AskUserQuestion` for sufficiency check; loop until user satisfied or ESC
-- **Phase 2**: Agent team via TeamCreate (mandatory); teammate isolation prevents cross-perspective contamination and confirmation bias; coordinator-mediated cross-dialogue; team persists across Phase 4 loop
+- **Flow**: `U → C → P → Pₛ → T(Pₛ) → ∥I(T) → R → L → (sufficiency check → act? → K → ∥F → V → L' → loop)`
+- **Key**: Phase 1 calls `AskUserQuestion` for perspective selection; Phase 4 calls `AskUserQuestion` for sufficiency check with `act` option; Phase 5-6 classify findings and execute fixes with peer verification; loop until user satisfied or ESC
+- **Phase 2**: Agent team via TeamCreate (mandatory); teammate isolation prevents cross-perspective contamination and confirmation bias; coordinator-mediated cross-dialogue; team persists across Phase 4 loop and through Phase 5-6
+- **Phase 5-6**: 3-tier finding classification (actionable/surfaced-unknown/design-level) + fixer with peer verification; peer-to-peer in Phase 6 only; post-TeamDelete recommends follow-up protocols for deferred findings
 - **Invocation**: `/prothesis` or use "lens" in conversation
 
 ### Syneidesis (συνείδησις) — alias: `gap`
@@ -152,6 +153,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 ## Delegation Constraint
 
 - **Prothesis Phase 2**: MUST use agent team (TeamCreate + Task teammates)—isolated context required for unbiased perspective analysis; cross-dialogue is coordinator-mediated
+- **Prothesis Phase 5-6**: Fixer spawned via Task into existing team T; Phase 6 allows peer-to-peer (fixer ↔ originating perspective) for verification
 - **Syneidesis/Hermeneia/Katalepsis**: No Task delegation—must run in main agent to call AskUserQuestion
 - **Telos**: No Task delegation—must run in main agent to call AskUserQuestion
 

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Place epistemic perspectives before inquiry (πρόθεσις: a placing before)",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Place epistemic perspectives before inquiry (πρόθεσις: a placing before)",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/prothesis/SKILL.md
+++ b/prothesis/skills/prothesis/SKILL.md
@@ -423,7 +423,7 @@ After Phase 6, **call the AskUserQuestion tool** to confirm action sufficiency.
 
 **Post-TeamDelete recommendations** (when Fᵤ ∪ Fᵈ ≠ ∅):
 
-**Before** TeamDelete, read deferred findings (`tier ≠ actionable`) from TaskList into L'.deferred — this applies to both the Fₐ≠∅ path (after Phase 6) and the Fₐ=∅ path (skipping Phase 6). TaskList is the canonical source for L'.deferred in all paths. **After** TeamDelete, present them with protocol suggestions:
+**Before** TeamDelete, read deferred findings (`tier ≠ actionable`) from TaskList into L'.deferred — this applies to both the Fₐ≠∅ path (after Phase 6) and the Fₐ=∅ path (skipping Phase 6). TaskList is the canonical source for L'.deferred in all paths. **After** TeamDelete, call TaskCreate for each item in L'.deferred to re-register them in the session task list (bridging team → session context), then present them with protocol suggestions:
 - **Surfaced unknowns** (Fᵤ): Priority — adversarial perspectives identified blind spots. Suggest `/syneidesis`.
 - **Design-level** (Fᵈ): Suggest `/syneidesis` (gap-shaped) or `/telos` (goal-shaped).
 


### PR DESCRIPTION
## Summary

- Prothesis Phase 4에 act 옵션 추가 — 분석 완료 후 팀 내에서 actionable findings 실행 경로
- 3-tier finding classification: actionable (Fa) / surfaced unknown (Fu) / design-level (Fd)
- Phase 6: fixer agent + peer-to-peer verification (phase-dependent topology shift)
- Post-TeamDelete: deferred findings에 대한 follow-up protocol 추천 (Syneidesis/Telos)

## Changes

| File | Change |
|------|--------|
| prothesis/skills/prothesis/SKILL.md | Phase 5-6 formal definition, prose, isolation, rules (9->11) |
| CLAUDE.md | Flow formula, key behaviors, delegation constraint 업데이트 |
| prothesis/.claude-plugin/plugin.json | 3.0.0 -> 3.1.0 |

## Design Decisions

- **Option C (Internal phase boundary)**: Prothesis가 전체 team lifecycle 소유
- **Phase 4 as cognitive gate**: 사용자가 분석->행동 전환을 명시적으로 결정
- **Conservative default**: ambiguous(f) -> Fd (false actionable cost > false deferred cost)
- **Phase-dependent topology**: Phase 2 격리 유지, Phase 6 peer-to-peer 허용

## Test Plan

- [x] /verify static checks 통과 확인
- [x] Phase 4 act 옵션 -> Phase 5 classification 흐름 검증
- [x] Phase 6 fixer spawn + peer verification 검증
- [x] Phase 4 prime action sufficiency check + post-TeamDelete recommendation 검증
- [x] 기존 Phase 4 경로 (sufficient/add/refine/ESC) 호환성 확인

Generated with [Claude Code](https://claude.com/claude-code)