### PR TITLE
chore: plugin.json version bump — alias-first 스킬 디렉토리 반영

### DIFF
--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue — /clarify (ἑρμηνεία: interpretation)",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/telos/.claude-plugin/plugin.json
+++ b/telos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "telos",
   "description": "Co-construct defined goals from vague intent — /goal (τέλος: end, purpose)",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## Summary

- PR #23 (alias-first 스킬 디렉토리 리네이밍) 머지 후 누락된 plugin.json version bump
- prothesis 3.3.1, syneidesis 2.12.1, hermeneia 1.8.1, katalepsis 1.5.1, telos 1.2.1
- 플러그인 시스템이 버전 변경을 감지해야 스킬 재등록이 트리거됨

## Test plan

- [x] 새 세션에서 `/mission` → `prothesis:mission` 등록 확인
- [x] `/gap`, `/clarify`, `/grasp`, `/goal` 각각 매칭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)