### PR TITLE
fix: skill description에 Greek alias 추가로 검색 가능성 개선

### DIFF
--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clarify
-description: Clarify intent-expression gaps. Extracts clarified intent when what you mean differs from what you said.
+description: Clarify intent-expression gaps. Extracts clarified intent when what you mean differs from what you said. Alias: Hermeneia(ἑρμηνεία).
 user-invocable: true
 ---
 

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grasp
-description: Achieve certain comprehension after AI work. Verifies understanding when results remain ungrasped, producing verified understanding.
+description: Achieve certain comprehension after AI work. Verifies understanding when results remain ungrasped, producing verified understanding. Alias: Katalepsis(κατάληψις).
 user-invocable: true
 ---
 

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mission
-description: Multi-perspective investigation and execution. Assembles a team to analyze from selected viewpoints and act on findings when the right framework is absent, producing a framed inquiry.
+description: Multi-perspective investigation and execution. Assembles a team to analyze from selected viewpoints and act on findings when the right framework is absent, producing a framed inquiry. Alias: Prothesis(πρόθεσις).
 user-invocable: true
 ---
 

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gap
-description: Gap surfacing before decisions. Raises procedural, consideration, assumption, and alternative gaps as questions when gaps go unnoticed, producing an audited decision.
+description: Gap surfacing before decisions. Raises procedural, consideration, assumption, and alternative gaps as questions when gaps go unnoticed, producing an audited decision. Alias: Syneidesis(συνείδησις).
 user-invocable: true
 ---
 

--- a/telos/skills/goal/SKILL.md
+++ b/telos/skills/goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal
-description: Co-construct defined goals from vague intent. Builds a GoalContract when neither party has a clear end state.
+description: Co-construct defined goals from vague intent. Builds a GoalContract when neither party has a clear end state. Alias: Telos(τέλος).
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary
- 5개 프로토콜 SKILL.md의 `description` frontmatter 끝에 `Alias: Name(Greek).` 추가
- skill name(`mission`), romanized name(`Prothesis`), Greek 원본(`πρόθεσις`) 세 가지 경로로 검색 가능
- `plugin.json`에는 이미 Greek 표기가 있으나 SKILL.md description에는 없어 CLI skill 목록에서 발견 불가했던 문제 해결

### 변경 파일
| Skill | Alias 추가 |
|-------|-----------|
| `prothesis/skills/mission/SKILL.md` | `Alias: Prothesis(πρόθεσις).` |
| `syneidesis/skills/gap/SKILL.md` | `Alias: Syneidesis(συνείδησις).` |
| `hermeneia/skills/clarify/SKILL.md` | `Alias: Hermeneia(ἑρμηνεία).` |
| `katalepsis/skills/grasp/SKILL.md` | `Alias: Katalepsis(κατάληψις).` |
| `telos/skills/goal/SKILL.md` | `Alias: Telos(τέλος).` |

## Test plan
- [x] CLI에서 Greek 이름(`πρόθεσις`)으로 skill 매칭 확인
- [x] Romanized 이름(`Prothesis`)으로 skill 매칭 확인
- [x] 기존 skill name(`mission`)으로의 매칭이 변함없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)