### PR TITLE
refactor: Rules 섹션 위치 재배치 (#30)

### DIFF
--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue — /clarify (ἑρμηνεία: interpretation)",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -146,6 +146,21 @@ When multiple gaps detected:
 3. **Expression**: Core articulation gaps
 4. **Precision** (lowest): Refinement after core is clear
 
+## Rules
+
+1. **User-initiated only**: Activate only when user signals awareness of ambiguity
+2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation)
+3. **Selection over Detection**: Present options for user to select, not auto-diagnose internally
+4. **Maieutic over Informational**: Frame questions to guide discovery, not merely gather data
+5. **Articulation support**: Help user express what they know, don't guess what they mean
+6. **Minimal questioning**: Surface only gaps that affect execution
+7. **Consequential options**: Each option shows interpretation with downstream implications
+8. **User authority**: User's choice is final; no second-guessing selected interpretation
+9. **Convergence persistence**: Mode remains active until convergence (|G| = 0, cycle, or user exit)
+10. **Reflective pause**: Include "reconsider" option for complex intent clarification
+11. **Escape hatch**: Always allow user to provide their own phrasing
+12. **Small phases**: Prefer granular phases with user checkpoints over large autonomous phases
+
 ## Protocol
 
 ### Phase 0: Trigger Recognition
@@ -321,17 +336,3 @@ When multiple gaps detected:
 - Ask user to rephrase if stuck
 - Proceed with best interpretation if user approves
 
-## Rules
-
-1. **User-initiated only**: Activate only when user signals awareness of ambiguity
-2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation)
-3. **Selection over Detection**: Present options for user to select, not auto-diagnose internally
-4. **Maieutic over Informational**: Frame questions to guide discovery, not merely gather data
-5. **Articulation support**: Help user express what they know, don't guess what they mean
-6. **Minimal questioning**: Surface only gaps that affect execution
-7. **Consequential options**: Each option shows interpretation with downstream implications
-8. **User authority**: User's choice is final; no second-guessing selected interpretation
-9. **Convergence persistence**: Mode remains active until convergence (|G| = 0, cycle, or user exit)
-10. **Reflective pause**: Include "reconsider" option for complex intent clarification
-11. **Escape hatch**: Always allow user to provide their own phrasing
-12. **Small phases**: Prefer granular phases with user checkpoints over large autonomous phases

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -159,6 +159,20 @@ Comprehension gaps within each category:
 | **Scope** | User doesn't see full impact | "Did you notice this also affects Y?" |
 | **Sequence** | User doesn't understand execution order | "Do you see that A happens before B?" |
 
+## Rules
+
+1. **User-initiated only**: Activate only when user signals desire to understand
+2. **Recognition over Recall**: Always **call** AskUserQuestion with Socratic probing questions — comprehension-testing options, not meta-selection (text presentation = protocol violation)
+3. **Verify, don't lecture**: Confirm understanding through questions, not explanations
+4. **Chunk complexity**: Break large changes into digestible categories
+5. **Task tracking**: Call TaskCreate/TaskUpdate for progress visibility
+6. **Code grounding**: Reference specific code locations
+7. **User authority**: User's "I understand" is final
+8. **Convergence persistence**: Mode remains active until all selected tasks completed
+9. **Escape hatch**: User can exit at any time
+10. **Phantasia update**: Each verification updates internal model of user's understanding
+11. **Proposal ejection**: When user answer `A` drifts from comprehension toward knowledge capture (suggesting changes/improvements to the system), acknowledge briefly, call TaskCreate to externalize the proposal, and return to verification. This preserves user-generated insights without disrupting the comprehension loop. The protocol does not track ejected proposals in its own state.
+
 ## Protocol
 
 ### Phase 0: Categorization (Silent)
@@ -310,16 +324,3 @@ Use:
 | Medium | Moderate complexity | "If [input], what would you expect this to return?" |
 | Heavy | Complex architecture or unfamiliar pattern | "Let's take this step by step. Why does [A] call [B] here?" |
 
-## Rules
-
-1. **User-initiated only**: Activate only when user signals desire to understand
-2. **Recognition over Recall**: Always **call** AskUserQuestion with Socratic probing questions — comprehension-testing options, not meta-selection (text presentation = protocol violation)
-3. **Verify, don't lecture**: Confirm understanding through questions, not explanations
-4. **Chunk complexity**: Break large changes into digestible categories
-5. **Task tracking**: Call TaskCreate/TaskUpdate for progress visibility
-6. **Code grounding**: Reference specific code locations
-7. **User authority**: User's "I understand" is final
-8. **Convergence persistence**: Mode remains active until all selected tasks completed
-9. **Escape hatch**: User can exit at any time
-10. **Phantasia update**: Each verification updates internal model of user's understanding
-11. **Proposal ejection**: When user answer `A` drifts from comprehension toward knowledge capture (suggesting changes/improvements to the system), acknowledge briefly, call TaskCreate to externalize the proposal, and return to verification. This preserves user-generated insights without disrupting the comprehension loop. The protocol does not track ejected proposals in its own state.

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -185,6 +185,21 @@ False positive (unnecessary question) < False negative (missed perspective)
 
 <!-- See references/conceptual-foundations.md for: Plan Mode Integration, Distinction from Socratic Method -->
 
+## Rules
+
+1. **Mission Brief confirmation**: Always call AskUserQuestion to confirm Mission Brief before context gathering (Phase 0 → Phase 1 gate). Pre-filled text (`/mission "text"`) still requires confirmation. Modify loops re-present until confirmed.
+2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation)
+3. **Epistemic Integrity**: Each perspective analyzes in isolated teammate context within an agent team; main agent direct analysis = protocol violation (violates isolation requirement). Phase 3: cross-dialogue is coordinator-mediated only. Phase 7: peer-to-peer allowed between praxis and originating perspectives for verification
+4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis
+5. **Verbatim Transmission**: Pass original question unchanged to each perspective
+6. **Convergence persistence**: Mode loops until user confirms sufficiency or ESC
+7. **Sufficiency check**: Always call AskUserQuestion after synthesis to confirm or extend analysis
+8. **Minimum perspectives**: Total perspectives (|Pᵦ| + n) must be ≥ 2; when Pᵦ ≠ ∅, present only novel perspectives (Pᵢ ∉ Pᵦ, n ≥ 1) — re-presenting user-supplied perspectives saturates option space and conceals unknown unknowns
+9. **Team persistence**: Team persists across Phase 5a/5b loop iterations and through Phase 6-7 action chain; TeamDelete only at terminal states (sufficient/ESC from Phase 5b or Phase 5')
+10. **Classification authority**: Coordinator proposes initial classification; user confirms or modifies (final authority). Conservative default applies to initial proposal: ambiguous → Fᵈ
+11. **Phase-dependent topology**: Analysis (Phase 3) enforces strict isolation; action (Phase 7) allows peer-to-peer between praxis and originating perspectives only
+12. **Praxis scope**: Limited to actionable findings (Fₐ); design-level (Fᵈ) and surfaced-unknown (Fᵤ) are deferred to post-TeamDelete recommendations
+
 ## Protocol
 
 ### Phase 0: Intent Confirmation (Mission Brief)
@@ -534,18 +549,4 @@ Prothesis does **not** apply to **closed-world** cognition:
 
 <!-- See references/conceptual-foundations.md for: Parametric Nature, Specialization -->
 
-## Rules
-
-1. **Mission Brief confirmation**: Always call AskUserQuestion to confirm Mission Brief before context gathering (Phase 0 → Phase 1 gate). Pre-filled text (`/mission "text"`) still requires confirmation. Modify loops re-present until confirmed.
-2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation)
-3. **Epistemic Integrity**: Each perspective analyzes in isolated teammate context within an agent team; main agent direct analysis = protocol violation (violates isolation requirement). Phase 3: cross-dialogue is coordinator-mediated only. Phase 7: peer-to-peer allowed between praxis and originating perspectives for verification
-4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis
-5. **Verbatim Transmission**: Pass original question unchanged to each perspective
-6. **Convergence persistence**: Mode loops until user confirms sufficiency or ESC
-7. **Sufficiency check**: Always call AskUserQuestion after synthesis to confirm or extend analysis
-8. **Minimum perspectives**: Total perspectives (|Pᵦ| + n) must be ≥ 2; when Pᵦ ≠ ∅, present only novel perspectives (Pᵢ ∉ Pᵦ, n ≥ 1) — re-presenting user-supplied perspectives saturates option space and conceals unknown unknowns
-9. **Team persistence**: Team persists across Phase 5a/5b loop iterations and through Phase 6-7 action chain; TeamDelete only at terminal states (sufficient/ESC from Phase 5b or Phase 5')
-10. **Classification authority**: Coordinator proposes initial classification; user confirms or modifies (final authority). Conservative default applies to initial proposal: ambiguous → Fᵈ
-11. **Phase-dependent topology**: Analysis (Phase 3) enforces strict isolation; action (Phase 7) allows peer-to-peer between praxis and originating perspectives only
-12. **Praxis scope**: Limited to actionable findings (Fₐ); design-level (Fᵈ) and surfaced-unknown (Fᵤ) are deferred to post-TeamDelete recommendations
 

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -159,6 +159,18 @@ This cycle repeats per planning phase or domain area.
 | **Assumption** | Unstated premise inferred from framing | "Are you assuming [X]?" |
 | **Alternative** | Known option not referenced | "Was [alternative] considered?" |
 
+## Rules
+
+1. **Question > Assertion**: Ask "was X considered?", never "you missed X"
+2. **Batch registration**: Register ALL detected gaps via TaskCreate before surfacing any
+3. **Observable evidence**: Surface only gaps with concrete indicators
+4. **User authority**: Dismissal is final
+5. **Minimal intrusion**: Lightest intervention that achieves awareness
+6. **Stakes calibration**: Intensity follows stakes matrix above
+7. **Convergence persistence**: Mode remains active until all gaps resolved or user ESC
+8. **Dynamic discovery**: Re-scan after each response; new gaps → TaskCreate
+9. **Gap dependencies**: Use task blocking when gaps have logical order
+
 ## Protocol
 
 ### Detection (Silent)
@@ -276,14 +288,3 @@ Note: Esc key → unconditional loop termination (LOOP level). Silence (no respo
 | Medium | Reversible + high impact, OR Irreversible + low impact | "[X] reviewed? (rationale)" |
 | Heavy | Irreversible + high impact | "Before proceeding, [X]? (rationale)" |
 
-## Rules
-
-1. **Question > Assertion**: Ask "was X considered?", never "you missed X"
-2. **Batch registration**: Register ALL detected gaps via TaskCreate before surfacing any
-3. **Observable evidence**: Surface only gaps with concrete indicators
-4. **User authority**: Dismissal is final
-5. **Minimal intrusion**: Lightest intervention that achieves awareness
-6. **Stakes calibration**: Intensity follows stakes matrix above
-7. **Convergence persistence**: Mode remains active until all gaps resolved or user ESC
-8. **Dynamic discovery**: Re-scan after each response; new gaps → TaskCreate
-9. **Gap dependencies**: Use task blocking when gaps have logical order

--- a/telos/.claude-plugin/plugin.json
+++ b/telos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "telos",
   "description": "Co-construct defined goals from vague intent — /goal (τέλος: end, purpose)",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/telos/skills/goal/SKILL.md
+++ b/telos/skills/goal/SKILL.md
@@ -166,6 +166,21 @@ When multiple dimensions are undefined:
 
 Outcome is always included in applicable dimensions (minimum `|Dₐ| ≥ 1`).
 
+## Rules
+
+1. **AI-detected, user-confirmed**: AI recognizes goal indeterminacy; activation requires user approval via AskUserQuestion (Phase 0)
+2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation). Modify options use structured sub-choices, not free text
+3. **Selection over Detection**: User selects applicable dimensions in Phase 1; AI does not auto-sequence or force all 4
+4. **Construction over Extraction**: AI proposes falsifiable candidates, not abstract questions
+5. **Concrete proposals**: Every proposal must be specific enough to accept or reject
+6. **User authority**: User shapes, accepts, or rejects; AI does not override
+7. **Progress visibility**: Show GoalContract completion status (defined/total selected) at each Phase 1
+8. **Convergence persistence**: Mode active until GoalContract approved or user ESC
+9. **Early exit**: User can declare sufficient at any point (any progress level permitted)
+10. **Context grounding**: Proposals based on Read/Grep when available; template fallback when not
+11. **Small phases**: One dimension per cycle; no bundling unless user requests
+12. **Escape hatch**: User can provide own definition for any field directly
+
 ## Protocol
 
 ### Phase 0: Trigger Recognition + Confirmation
@@ -282,17 +297,3 @@ Options:
 | Medium | Multiple undefined dimensions | "[Dimension]. Proposal: [X]. Accept/Modify?" |
 | Heavy | Core outcome undefined, high stakes | "Before proceeding: [detailed proposal with trade-offs]" |
 
-## Rules
-
-1. **AI-detected, user-confirmed**: AI recognizes goal indeterminacy; activation requires user approval via AskUserQuestion (Phase 0)
-2. **Recognition over Recall**: Always **call** AskUserQuestion tool to present options (text presentation = protocol violation). Modify options use structured sub-choices, not free text
-3. **Selection over Detection**: User selects applicable dimensions in Phase 1; AI does not auto-sequence or force all 4
-4. **Construction over Extraction**: AI proposes falsifiable candidates, not abstract questions
-5. **Concrete proposals**: Every proposal must be specific enough to accept or reject
-6. **User authority**: User shapes, accepts, or rejects; AI does not override
-7. **Progress visibility**: Show GoalContract completion status (defined/total selected) at each Phase 1
-8. **Convergence persistence**: Mode active until GoalContract approved or user ESC
-9. **Early exit**: User can declare sufficient at any point (any progress level permitted)
-10. **Context grounding**: Proposals based on Read/Grep when available; template fallback when not
-11. **Small phases**: One dimension per cycle; no bundling unless user requests
-12. **Escape hatch**: User can provide own definition for any field directly


### PR DESCRIPTION
## Summary
- 5개 프로토콜 SKILL.md에서 `## Rules` 섹션을 파일 끝에서 `## Protocol` 직전으로 일괄 이동
- LLM attention decay로 인해 파일 후반부의 하드 제약이 약하게 적용되는 문제를 해소 (PR #29 power-user 관점 발견)
- `structure` static check는 섹션 존재만 검증하므로 코드 수정 없이 통과

## Changes
| Protocol | Rules Before | Rules After |
|----------|-------------|-------------|
| Prothesis | L537 | L188 |
| Syneidesis | L279 | L162 |
| Hermeneia | L324 | L149 |
| Katalepsis | L313 | L162 |
| Telos | L285 | L169 |

## Checklist
- [x] `/verify` 통과 (0 failures, 1 pre-existing warning)
- [x] 5개 프로토콜 일관성 확인 (모두 Taxonomy → Rules → Protocol 순서)
- [x] plugin.json 버전 bump (patch)
- [ ] Cold content는 #31에서 별도 처리 (scope 분리)

## Test plan
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 통과
- [ ] 각 프로토콜 `/mission`, `/gap`, `/clarify`, `/grasp`, `/goal` 실행 시 Rules 정상 적용 확인

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)