### PR TITLE
refactor(hermeneia): Socratic Questioning Style progressive disclosure

### DIFF
--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue — /clarify (ἑρμηνεία: interpretation)",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -217,7 +217,7 @@ Which best captures your intent?
 - **Escape hatch**: Include "something else" option when appropriate
 - **Minimal options**: 2-4 choices maximum per gap
 
-<!-- See references/socratic-style.md for: maieutic framing examples, Socratic elements, example transformation -->
+Consult `references/socratic-style.md` for maieutic framing examples, Socratic elements, and example transformation.
 
 ### Phase 3: Integration
 

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -217,54 +217,7 @@ Which best captures your intent?
 - **Escape hatch**: Include "something else" option when appropriate
 - **Minimal options**: 2-4 choices maximum per gap
 
-### Socratic Questioning Style
-
-Hermeneia resolves **IntentMisarticulated → ClarifiedIntent**. The user already possesses the knowledge; they struggle to articulate it. Apply **maieutic questioning** (Socratic midwifery) to help users "give birth" to their own intent.
-
-**Maieutic framing for AskUserQuestion**:
-
-Instead of:
-```
-Options:
-1. Option A: [interpretation]
-2. Option B: [interpretation]
-```
-
-Use consequential framing:
-```
-Options:
-1. Option A: [interpretation] — if this, then [implication for your goal]
-2. Option B: [interpretation] — if this, then [implication for your goal]
-3. "Let me reconsider" — take time to reflect on underlying intent
-```
-
-**Socratic elements**:
-
-| Element | Implementation |
-|---------|----------------|
-| **Consequential thinking** | Each option shows downstream effects |
-| **Goal alignment** | Ask "which serves your underlying objective?" |
-| **Reflective pause** | Include "Let me think differently" option |
-| **Assumption surfacing** | "This assumes X—does that match your situation?" |
-
-**Example transformation**:
-
-Before (standard):
-```
-Did you mean:
-1. Delete all files
-2. Delete only selected files
-```
-
-After (Socratic):
-```
-To clarify your intent:
-1. "All files" — this would clear the workspace entirely; is starting fresh your goal?
-2. "Selected files" — this preserves structure; is targeted cleanup your goal?
-3. "Let me reconsider" — reflect on what outcome you're actually seeking
-```
-
-**Principle**: Questions guide discovery, not merely gather information
+<!-- See references/socratic-style.md for: maieutic framing examples, Socratic elements, example transformation -->
 
 ### Phase 3: Integration
 

--- a/hermeneia/skills/clarify/references/socratic-style.md
+++ b/hermeneia/skills/clarify/references/socratic-style.md
@@ -1,0 +1,50 @@
+# Socratic Questioning Style
+
+These examples are not required for standard protocol execution — consult when deeper understanding of maieutic framing is needed.
+
+Hermeneia resolves **IntentMisarticulated → ClarifiedIntent**. The user already possesses the knowledge; they struggle to articulate it. Apply **maieutic questioning** (Socratic midwifery) to help users "give birth" to their own intent.
+
+**Maieutic framing for AskUserQuestion**:
+
+Instead of:
+```
+Options:
+1. Option A: [interpretation]
+2. Option B: [interpretation]
+```
+
+Use consequential framing:
+```
+Options:
+1. Option A: [interpretation] — if this, then [implication for your goal]
+2. Option B: [interpretation] — if this, then [implication for your goal]
+3. "Let me reconsider" — take time to reflect on underlying intent
+```
+
+**Socratic elements**:
+
+| Element | Implementation |
+|---------|----------------|
+| **Consequential thinking** | Each option shows downstream effects |
+| **Goal alignment** | Ask "which serves your underlying objective?" |
+| **Reflective pause** | Include "Let me think differently" option |
+| **Assumption surfacing** | "This assumes X—does that match your situation?" |
+
+**Example transformation**:
+
+Before (standard):
+```
+Did you mean:
+1. Delete all files
+2. Delete only selected files
+```
+
+After (Socratic):
+```
+To clarify your intent:
+1. "All files" — this would clear the workspace entirely; is starting fresh your goal?
+2. "Selected files" — this preserves structure; is targeted cleanup your goal?
+3. "Let me reconsider" — reflect on what outcome you're actually seeking
+```
+
+**Principle**: Questions guide discovery, not merely gather information


### PR DESCRIPTION
## Summary

- Hermeneia SKILL.md의 Socratic Questioning Style 섹션(48줄)을 `references/socratic-style.md`로 분리
- 원 위치에 HTML 주석 포인터(`<\!-- See references/... -->`) 배치
- SKILL.md 337줄 → 290줄 (-47줄)

## 범위 결정 근거

| 후보 | 줄 수 | Rules 요약 | 판정 |
|------|-------|-----------|------|
| **Hermeneia** Socratic Questioning Style | 48줄 | Rules 4,7,10,11 | ✅ 이동 |
| **Katalepsis** Verification Style | 19줄 | Rules 3,4,6 | ⬜ 경계선 — references/ 생성 오버헤드 대비 효과 미미 |
| **Telos** Epistemic Distinction from RE | 6줄 | 없음 | ⬜ 포인터 ~3줄 대비 순 절감 ~3줄 |

## 로딩 타이밍 분석

- SKILL.md: `/clarify` 호출 시 전체 즉시 로드
- `references/`: 에이전트가 HTML 주석을 보고 명시적으로 Read 호출해야 로드
- Rules 4,7,10,11이 Phase 2 실행에 충분한 지침 제공 → 예시 비참조 시에도 실행 품질 유지

## Checklist

- [x] `references/socratic-style.md` 생성 (Prothesis 패턴 준수)
- [x] SKILL.md에서 섹션 교체 → HTML 주석 포인터
- [x] plugin.json 버전 범프 (1.8.3 → 1.8.4)
- [x] `/verify` 통과 (0 failures, 2 pre-existing warnings)

## Test Plan

- [ ] `/clarify` 호출 후 Phase 2에서 maieutic framing 품질 확인
- [ ] HTML 주석 포인터가 정상적으로 참조 경로 표시하는지 확인

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)