### PR TITLE
refactor(prothesis): Phase 4 → 4a/4b cross-dialogue 검사 단계 분리 (#27)

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -364,10 +364,10 @@ function checkToolGrounding() {
     const groundingSection = groundingMatch[1];
     const toolBindings = [];
 
-    // Parse lines like: "S (extern)     → AskUserQuestion tool"
+    // Parse lines like: "S (extern) → ..." or "Phase 4a Δ (detect) → ..."
     // Capture: operation, classification, tool
-    // Unicode support: [\w\u0370-\u03FF] matches Greek letters (Λ, Σ, Ω, etc.)
-    const bindingPattern = /^([∥]?[\w\u0370-\u03FF]+)\s*\((\w+)\)\s*→\s*(\w+)/gm;
+    // Supports: Phase prefix, qualifier word (e.g., "praxis"), Greek letters, ?'/
+    const bindingPattern = /^(?:Phase\s+\S+\s+)?([∥]?[\w\u0370-\u03FF?'\/]+)(?:\s+\w+)?\s*\((\w+)\)\s*→\s*(\w+)/gm;
     let match;
     while ((match = bindingPattern.exec(groundingSection)) !== null) {
       toolBindings.push({

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/README.md
+++ b/prothesis/README.md
@@ -31,7 +31,7 @@ Users often lack the analytical framework for their question (`FrameworkAbsent`)
 Phase 0: Gather       → Context acquisition for perspective formulation
 Phase 1: Prothesis    → Present 2-4 perspectives (call AskUserQuestion)
 Phase 2: Inquiry      → Agent team analysis per selected perspective (TeamCreate + teammates)
-Phase 3: Synthesis    → Organize convergences/divergences → Integrated answer
+Phase 3: Synthesis    → Cross-dialogue check → Convergence/divergence → Integrated answer
 ```
 
 ## When to Use

--- a/prothesis/README_ko.md
+++ b/prothesis/README_ko.md
@@ -31,7 +31,7 @@
 Phase 0: Gather       → 관점 형성을 위한 맥락 수집
 Phase 1: Prothesis    → 관점 2-4개 제시 (call AskUserQuestion)
 Phase 2: Inquiry      → 선택된 관점별 에이전트 팀 분석 (TeamCreate + teammates)
-Phase 3: Synthesis    → 수렴점/발산점 정리 → 통합 답변
+Phase 3: Synthesis    → 교차 대화 확인 → 수렴점/발산점 정리 → 통합 답변
 ```
 
 ## 사용 시점

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -33,7 +33,7 @@ T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with 
 R      = Set(Result)                                  -- raw inquiry outputs
 R'     = Set(Result) post-collection                  -- after Phase 3c collection
 R''    = Set(Result) post-cross-dialogue              -- R' ∪ dialogue responses (R'' = R' when Δ = ∅)
-Δ      = Trigger detection: R' → Set(Trigger)         -- contradictions, horizon intersections, adversarial needs
+Δ      = Trigger detection: R' → Set(Trigger)         -- contradictions, horizon intersections, uncorroborated high-stakes
 D?     = Conditional dialogue: Δ ≠ ∅ → coordinator-mediated challenge; Δ = ∅ → skip
 Syn    = Synthesis: R'' → (∩, D, A)
 L      = Lens { convergence: ∩, divergence: D, assessment: A }
@@ -109,7 +109,7 @@ S (extern)               → AskUserQuestion tool (mandatory; multiSelect: true;
 T (parallel)             → TeamCreate tool (creates team with shared task list)
 ∥Spawn (parallel)        → Task tool (team_name, name: spawn perspective teammates)
 ∥I (parallel)            → TaskCreate/TaskUpdate (shared task list for inquiry coordination)
-Phase 4a Δ (detect)      → Internal operation (trigger check: contradictions, horizon intersections, adversarial needs)
+Phase 4a Δ (detect)      → Internal operation (trigger check: contradictions, horizon intersections, uncorroborated high-stakes)
 Phase 4a D? (conditional) → SendMessage tool (type: "message", coordinator-mediated cross-dialogue; skip if Δ = ∅)
 Ω (extern)               → SendMessage tool (type: "shutdown_request", graceful teammate termination)
 Phase 5 K_i/Q            → AskUserQuestion (classification + routing: act/modify/extend/wrap_up; extend triggers follow-up AskUserQuestion; Escape → terminate)
@@ -340,14 +340,14 @@ After collecting all perspective results (R'), the coordinator reviews for cross
 **Trigger conditions** (all coordinator-detected from R'):
 - Contradictory conclusions between perspectives
 - One perspective's horizon limit intersects another's core finding
-- A finding needs adversarial testing
+- A high-stakes finding is supported by a single perspective with no corroboration
 
 **If triggers detected**: Coordinator mediates cross-dialogue via SendMessage:
 - Relay the challenging finding to the target perspective
 - 1 exchange per pair: challenge + response (no extended debate)
 - Coordinator controls what information crosses perspective boundaries
 
-**If no triggers**: Skip directly to Phase 4b.
+**If no triggers**: Skip to Phase 4b with brief justification (e.g., "No contradictions, horizon intersections, or uncorroborated high-stakes findings detected").
 
 **Design rationale**: Cross-dialogue is placed after collection (Phase 3c) and before synthesis (Phase 4b) so the coordinator evaluates all perspectives before deciding which contradictions warrant live challenge. This makes trigger detection an explicit step — the coordinator checks for contradictions rather than relying on incidental discovery during synthesis.
 

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -14,7 +14,7 @@ Resolve absent frameworks by placing available epistemic perspectives before the
 
 ```
 ── FLOW ──
-Prothesis(U) → Q(MB(U)) → MBᵥ → G(MBᵥ) → C → {P₁...Pₙ}(C, MBᵥ) → S → Pₛ → T(Pₛ) → ∥I(T) → Ω(T) → R' → Δ?(R') → Syn(R'') → L → K_i(L) → ∥F(T) → V(T) → L'
+Prothesis(U) → Q(MB(U)) → MBᵥ → G(MBᵥ) → C → {P₁...Pₙ}(C, MBᵥ) → S → Pₛ → T(Pₛ) → ∥I(T) → R → Ω(T) → R' → Δ(R') → D?(T) → R'' → Syn(R'') → L → K_i(L) → ∥F(T) → V(T) → L'
 
 ── TYPES ──
 U      = Underspecified request (purpose clear, approach unclear)
@@ -29,10 +29,13 @@ S      = Selection: {P₁...Pₙ} → Pₛ             -- extern (user choice; P
 Pₛ     = Selected perspectives (Pₛ = Pᵦ ∪ sel({P₁...Pₙ}), |Pₛ| ≥ 2)
 T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with shared task list
 ∥I     = Parallel inquiry: (∥ p∈T. Inquiry(p)) → R
-Δ?     = Conditional cross-dialogue: trigger check → coordinator-mediated challenge (Phase 4a)
-Ω      = Collection: T → R, shutdown(T) ∨ retain(T)  -- conditional on loop
-R      = Set(Result)                           -- inquiry outputs
-Syn    = Synthesis: R → (∩, D, A)
+Ω      = Collection: R → R', retain(T)               -- finalize results; team lifecycle deferred to loop
+R      = Set(Result)                                  -- raw inquiry outputs
+R'     = Set(Result) post-collection                  -- after Phase 3c collection
+R''    = Set(Result) post-cross-dialogue              -- R' ∪ dialogue responses (R'' = R' when Δ = ∅)
+Δ      = Trigger detection: R' → Set(Trigger)         -- contradictions, horizon intersections, adversarial needs
+D?     = Conditional dialogue: Δ ≠ ∅ → coordinator-mediated challenge; Δ = ∅ → skip
+Syn    = Synthesis: R'' → (∩, D, A)
 L      = Lens { convergence: ∩, divergence: D, assessment: A }
 FramedInquiry = L where (|Pₛ| ≥ 1 ∧ user_confirmed(sufficiency)) ∨ user_esc
 
@@ -243,7 +246,7 @@ options:
 **Perspective selection criteria**:
 - Each offers a **distinct epistemic framework** (not variations of same view)
 - **Productive tension**: Perspectives should enable meaningful disagreement—differing in interpretation, weighing, or application, even if sharing some evidence
-- **Commensurability minimum**: At least one shared referent, standard, or vocabulary must exist between perspectives to enable Phase 4 synthesis
+- **Commensurability minimum**: At least one shared referent, standard, or vocabulary must exist between perspectives to enable Phase 4b synthesis
 - **Deliverable-aligned**: Perspectives should produce assessments relevant to MBᵥ.expected_deliverable
 - **Critical viewpoint** (when applicable): Include when genuine alternatives exist; omit when perspectives legitimately converge
 - Specific enough to guide analysis (not "general expert")
@@ -313,7 +316,7 @@ Teammates analyze independently. Results arrive via idle notifications. Proceed 
 
 #### Phase 3c: Collection
 
-Collect all results (initial analyses + any dialogue responses) into R'. Team remains active — shutdown/retain decisions are deferred to the LOOP section after Phase 5, where the user's sufficiency judgment determines team lifecycle.
+Collect inquiry results into R'. Team remains active — shutdown/retain decisions are deferred to the LOOP section after Phase 5, where the user's sufficiency judgment determines team lifecycle.
 
 #### Isolated Context Requirement
 

--- a/prothesis/skills/mission/references/agent-teams-bp-applicability.md
+++ b/prothesis/skills/mission/references/agent-teams-bp-applicability.md
@@ -2,7 +2,7 @@
 
 Not all agent-teams best practices apply uniformly across Prothesis phases. This reference table maps which BPs are active, intentionally restricted, or not yet applicable at each phase — preventing compliance frame mismatch when evaluating phase-specific sessions.
 
-| Best Practice | Phase 0-2 (Setup) | Phase 3 (Theoria) | Phase 4-5 (Synthesis) | Phase 6-7 (Praxis) |
+| Best Practice | Phase 0-2 (Setup) | Phase 3 (Theoria) | Phase 4a-5 (Cross-Dialogue + Synthesis + Routing) | Phase 6-7 (Praxis) |
 |---------------|-------------------|-------------------|----------------------|---------------------|
 | BP1: Context in spawn prompts | — | **Active** (Mission Brief in prompt) | — | **Active** (finding context in praxis prompt) |
 | BP2: Distinct teammate roles | — | **Active** (perspective = role) | — | **Active** (praxis = role) |
@@ -10,7 +10,7 @@ Not all agent-teams best practices apply uniformly across Prothesis phases. This
 | BP4: Research-oriented tasks | — | **Active** (perspectives analyze) | — | Partial (praxis reads then acts) |
 | BP5: Scope-limited tasks | — | **Active** (1 perspective = 1 scope) | — | **Active** (1 finding = 1 fix) |
 | BP6: Mid-flight monitoring | — | Optional (coordinator may check) | — | Optional |
-| BP7: Cross-dialogue | — | **Restricted** (coordinator-mediated) | — | Phase-shifted (peer-to-peer for verification) |
+| BP7: Cross-dialogue | — | **Restricted** (coordinator-mediated) | **Active** (Phase 4a coordinator-mediated triggers) | Phase-shifted (peer-to-peer for verification) |
 | BP8: Graceful shutdown | — | — | Deferred to terminal | **Active** at terminal |
 | BP9: Shared task list | — | **Active** (TaskCreate per perspective) | — | **Active** (TaskCreate per finding) |
 | BP10: Cross-team communication | — | **Restricted** (isolation required) | — | **Active** (praxis ↔ perspectives) |


### PR DESCRIPTION
## Summary

- Phase 3b에서 12회 연속 미발동된 cross-dialogue를 Phase 4a로 분리하여 coordinator의 트리거 검사를 명시적 단계로 구조화
- Phase 4b는 기존 Phase 4 synthesis를 유지
- Syneidesis gap surfacing을 통해 6건의 gap을 검토한 결과, 근본 원인이 "트리거 미충족"이 아닌 "검사 미수행"임을 확인

### 변경 사항

| Before | After |
|--------|-------|
| Phase 3b: inquiry + optional dialogue | Phase 3b: inquiry only |
| Phase 4: internal synthesis | Phase 4a: cross-dialogue check |
| — | Phase 4b: synthesis (internal) |
| 2단계 topology (Phase 3 → Phase 7) | 3단계 topology (Phase 3 → Phase 4a → Phase 7) |

### 근거 (Syneidesis 분석)

12건 Prothesis 세션 분석 결과:
- Cross-dialogue 트리거 조건 충족: 3+ 세션 (62c52088, 94ed74ac, d817f234)
- 실제 발동: 0회 — 모든 모순은 Phase 4 합성에서 사후 해소
- 원인: coordinator 흐름에 명시적 검사 단계 부재

## Test plan

- [x] Static checks 통과 (`node .claude/skills/verify/scripts/static-checks.js .`)
- [ ] PHASE TRANSITIONS에 Phase 4a `[Tool]` suffix 존재
- [ ] TOOL GROUNDING에 Phase 4a D? 매핑 존재
- [ ] Phase 3b에서 cross-dialogue 관련 내용 제거 확인
- [x] Topology table 3단계 확인 (Phase 3 → Phase 4a → Phase 7)

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

