### PR TITLE
fix(prothesis): Phase 5 옵션 exhaustiveness 규칙 추가

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -390,6 +390,8 @@ Options:
 4. **Wrap up** — preserve deferred findings (Fᵤ/Fᵈ) and dissolve team
 ```
 
+**Option exhaustiveness**: Present exactly the options listed above. Do not generate, substitute, or reorder options beyond this template.
+
 **"Act on findings" availability**: Only present when Fₐ ≠ ∅ in the proposed classification. When all findings are deferred (Fₐ = ∅), omit this option.
 
 **Classification loop**: When the user selects "Modify classification", update the tiers per user specification → re-present the table with updated classification → await new decision. The modification loop stays within Phase 5.


### PR DESCRIPTION
## Summary

- Phase 5 옵션 템플릿에 exhaustiveness 제약 추가 — AI가 스펙 외 옵션을 런타임 생성하는 것을 방지
- 실증: AI가 `Modify classification` 자리에 `Sufficient`를 생성하여 분류 조정 기능이 누락되는 문제 확인 (Syneidesis gap surfacing으로 근본 원인 식별)

### 배경

PR #42에서 Phase 5 옵션을 4개로 간소화 (`act`, `modify`, `extend`, `wrap_up`). 이후 런타임에서 AI가 `Modify classification`을 `Sufficient`로 대체하여:
1. `Sufficient` ≈ `Wrap up` 중복 발생
2. 분류 조정(`modify`) 기능 소실

Syneidesis 분석 결과, 문제가 스펙 중복이 아닌 **런타임 일탈**임을 확인 → exhaustiveness 규칙으로 해결.

## Test plan

- [x] Static checks 통과
- [ ] 다음 Prothesis 세션에서 Phase 5 옵션이 정확히 4개(Act/Modify/Extend/Wrap up)인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)