### PR TITLE
fix(prothesis): add preserve_deferred to ESC paths in LOOP formal block

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation and execution — /mission (πρόθεσις: a placing before)",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/mission/SKILL.md
+++ b/prothesis/skills/mission/SKILL.md
@@ -76,12 +76,12 @@ After Phase 5 (classification + routing):
   J = modify(finding)  → re-classify → re-present K_i → await
   J = extend           → Q[AskUserQuestion](add new perspective | deepen existing) → Phase 2 or Phase 3 inquiry (team retained)
   J = wrap_up          → Ω(T, shutdown) → preserve_deferred(Fᵤ ∪ Fᵈ) → TeamDelete → terminate with L
-  J = ESC              → Ω(T, shutdown) → TeamDelete → terminate with current L
+  J = ESC              → Ω(T, shutdown) → preserve_deferred(Fᵤ ∪ Fᵈ) → TeamDelete → terminate with current L
 
 After Phase 5' (action sufficiency):
-  J' = sufficient     → Ω(T, shutdown) → TeamDelete → terminate with L'
+  J' = sufficient     → Ω(T, shutdown) → preserve_deferred(Fᵤ ∪ Fᵈ) → TeamDelete → terminate with L'
                          → recommend_protocols(Fᵤ ∪ Fᵈ)
-  J' = ESC            → Ω(T, shutdown) → TeamDelete → terminate with current L'
+  J' = ESC            → Ω(T, shutdown) → preserve_deferred(Fᵤ ∪ Fᵈ) → TeamDelete → terminate with current L'
                          → recommend_protocols(Fᵤ ∪ Fᵈ)
 
 After Phase 6 (classification guard):


### PR DESCRIPTION
The formal block omitted preserve_deferred(Fᵤ ∪ Fᵈ) from ESC paths in
Phase 5 and both terminal paths in Phase 5', contradicting the prose
which states "All terminal paths (wrap_up and ESC, from both Phase 5
and Phase 5') read deferred findings from TaskList before TeamDelete."
This caused TeamDelete to destroy deferred findings before migration
to the session task list. All four terminal paths now consistently
preserve deferred findings before team deletion.

https://claude.ai/code/session_013jn99cmC4jMxJBtuejNFBf