### PR TITLE
fix(hermeneia): Phase 1b gap type multiSelect 지원

### DIFF
--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue — /clarify (ἑρμηνεία: interpretation)",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -18,7 +18,7 @@ E → Eᵥ → Gₛ → Q → A → Î' → (loop until converge)
 ── TYPES ──
 E  = User's expression (the prompt to clarify)
 Eᵥ = Verified expression (user-confirmed binding)
-Gₛ = User-selected gap type ∈ {Expression, Precision, Coherence, Context}
+Gₛ = User-selected gap types ⊆ {Expression, Precision, Coherence, Context}
 Q  = Clarification question (via AskUserQuestion)
 A  = User's answer
 Î  = Inferred intent (AI's model of user's goal)
@@ -175,12 +175,12 @@ Options:
 
 ### Phase 1b: Gap Type Selection
 
-**Call the AskUserQuestion tool** to let user select the gap type.
+**Call the AskUserQuestion tool** with `multiSelect: true` to let user select gap types.
 
-**Do NOT auto-diagnose.** Present gap types for user selection:
+**Do NOT auto-diagnose.** Present gap types for user selection (multiple selection allowed):
 
 ```
-What kind of difficulty are you experiencing with this expression?
+What kinds of difficulty are you experiencing with this expression?
 
 Options:
 1. **Expression** — I couldn't fully articulate what I meant
@@ -189,7 +189,7 @@ Options:
 4. **Context** — Background information is missing
 ```
 
-User selection determines the clarification strategy in Phase 2.
+User selection determines the clarification strategy in Phase 2. If multiple selected, address in priority order (Coherence → Context → Expression → Precision).
 
 ### Phase 2: Clarification
 


### PR DESCRIPTION
## Summary

- Phase 1b gap type 선택 시 `multiSelect: true`를 사용하도록 SKILL.md 수정
- `Gₛ` 타입 시그니처를 단수(`∈`)에서 복수(`⊆`)로 변경하여 MODE STATE의 `gaps: Set(Gap)`과 정합성 확보
- 복수 선택 시 Gap Priority 순서(Coherence → Context → Expression → Precision)로 처리하도록 명시

## Test plan

- [x] `/clarify` 실행 후 Phase 1b에서 복수 gap type 선택 가능 확인
- [x] 복수 선택 시 priority 순서대로 Phase 2 진행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

