### PR TITLE
fix(telos): Phase 1 dimension 선택에 multiSelect 지원 추가

### DIFF
--- a/telos/.claude-plugin/plugin.json
+++ b/telos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "telos",
   "description": "Co-construct defined goals from vague intent — /goal (τέλος: end, purpose)",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/telos/skills/goal/SKILL.md
+++ b/telos/skills/goal/SKILL.md
@@ -189,7 +189,7 @@ Options:
 
 ### Phase 1: Dimension Selection
 
-**Call the AskUserQuestion tool** to let user select applicable dimensions.
+**Call the AskUserQuestion tool** with `multiSelect: true` to let user select applicable dimensions.
 
 Present dimensions with current GoalContract progress:
 


### PR DESCRIPTION
## Summary

- Telos Phase 1 (Dimension Selection)에 multiSelect: true 지시 추가
- Hermeneia Phase 1b 수정(PR #62)과 동일한 패턴 적용
- formal definition의 Da = Applicable dimensions (user-selected subset) set 타입과 prose 지시 일치시킴

## 변경 전/후

**변경 전**: 미리 조합된 옵션 나열 (Outcome + Boundary, Outcome + Boundary + Priority, All 4 dimensions)
**변경 후**: 개별 dimension 체크박스로 사용자가 원하는 조합 직접 선택

## Test plan

- [x] /goal 실행 시 Phase 1에서 multiSelect 체크박스 표시 확인
- [x] 복수 dimension 선택 후 Phase 2 정상 진행 확인

Generated with [Claude Code](https://claude.com/claude-code)