### PR TITLE
feat(katalepsis): Category Taxonomy에 Deletion 카테고리 추가

### DIFF
--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -146,6 +146,7 @@ Categories are extracted from AI work results. Common categories:
 | **Dependency** | Changes to imports, packages, configs | "Added new npm package" |
 | **Architecture** | Structural or design pattern changes | "Introduced factory pattern" |
 | **Bug Fix** | Corrections to existing behavior | "Fixed null pointer in edge case" |
+| **Deletion** | Removed code, features, or dependencies | "Removed deprecated `legacyAuth()` function" |
 
 ## Gap Taxonomy
 


### PR DESCRIPTION
## Summary

- Katalepsis Category Taxonomy에 **Deletion** 카테고리 추가 (코드, 기능, 의존성 제거 커버)
- 기존 6개 카테고리가 생성/변경 중심으로 설계되어 삭제 작업을 분류할 수 없던 공백 보완
- plugin.json 버전 `1.8.3` → `1.8.4`

## Test plan

- [ ] `/verify` 정적 검사 통과 확인
- [x] `/grasp` 실행 시 AI 삭제 작업에 대해 Deletion 카테고리가 Phase 0에서 추출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
