### PR TITLE
feat(katalepsis): Phase 3 aspect coverage check 추가

### DIFF
--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.8.4",
+  "version": "1.9.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## Summary

- Phase 3 comprehension loop에 **step 3d (aspect coverage check)** 추가
- 카테고리 완료 전 probed vs unprobed gap 타입을 AskUserQuestion으로 보여주어 사용자가 추가 탐색 여부를 결정
- 기존 문제: AI가 1개 gap 타입만 probe → 정답이면 바로 completed → 다른 gap 차원 누락 가능
- formal block (PHASE TRANSITIONS, LOOP, TOOL GROUNDING) + prose (step 3d) 동기화
- plugin.json `1.8.4` → `1.9.0` (Phase 3 동작 변경)

## 변경 근거

Category Taxonomy는 체계적 추출 → 사용자 선택 (Selection over Detection)이 적용되지만, Gap Taxonomy는 AI 단일 판단에 의존하여 커버리지 보장 메커니즘이 없었음. Aspect summary는 Detection(AI) + Selection(사용자) 하이브리드로 이 비대칭을 해소.

## Test plan

- [x] `/verify` 정적 검사 통과 확인
- [x] `/grasp` 실행 시 step 3d에서 probed/unprobed gap 표시 및 사용자 선택 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

