### PR TITLE
fix(katalepsis): PR #66 리뷰 반영 — FLOW, MODE STATE, prose 보완

### DIFF
--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -13,7 +13,7 @@ Achieve certain comprehension of AI work through structured verification, enabli
 
 ```
 ── FLOW ──
-R → C → Sₑ → Tᵣ → P → Δ → Q → A → Tᵤ → P' → (loop until katalepsis)
+R → C → Sₑ → Tᵣ → P → Δ → Q → A → Q(coverage) → Tᵤ → P' → (loop until katalepsis)
 
 ── TYPES ──
 R  = AI's result (the work output)
@@ -66,6 +66,7 @@ Categorize  → Internal analysis (Read for context if needed)
   tasks: Map<TaskId, Task>,
   current: TaskId,
   phantasia: Understanding,
+  probed: Map<TaskId, Set<GapType>>,
   active: Bool
 }
 ```
@@ -272,7 +273,7 @@ For each task (category):
 
    When step 3c evaluates as Correct for the current gap type:
 
-   1. Compare probed gap types vs. potentially relevant unprobed gap types for this category
+   1. Compare probed vs. unprobed gap types relevant to this category
    2. If unprobed aspects exist, **call AskUserQuestion**:
 
    ```
@@ -284,8 +285,8 @@ For each task (category):
        description: "[Why this gap type is relevant to this category]"
    ```
 
-   3. "Sufficient" → proceed to step 4
-   4. Additional gap type selected → return to step 3 with selected gap type as Δ
+   3. User selects "Sufficient" → proceed to step 4
+   4. User selects gap type → return to step 3 with selected gap type as Δ
 
    Skip if all relevant gap types already probed during the verification loop.
 


### PR DESCRIPTION
## Summary

PR #66 (aspect coverage check) 코드 리뷰에서 발견된 4건 반영:

- **FLOW 수식**: `Q(coverage)` 분기점 추가 — aspect summary가 프로토콜 경로에서 누락되어 있었음
- **MODE STATE**: `probed: Map<TaskId, Set<GapType>>` 필드 추가 — step 3d의 "probed vs unprobed" 비교가 대화 맥락 의존이었음
- **Prose 간결화**: `"potentially relevant unprobed gap types"` → `"probed vs. unprobed gap types relevant to this category"`
- **행위자 명확화**: step 3d 내부 3, 4번에 `"User selects"` 접두사 추가 — LOOP 섹션과 표현 일치

## Test plan

- [x] `/verify` 정적 검사 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
