### PR TITLE
fix: resolve protocol drift 2026-03-02

### DIFF
--- a/.claude/skills/verify/graph.json
+++ b/.claude/skills/verify/graph.json
@@ -18,6 +18,8 @@
     { "source": "prothesis", "target": "epitrope", "type": "transition", "satisfies": "J=calibrate: 관점→위임 직접 모드 전환 (팀 유지)" },
     { "source": "aitesis", "target": "prosoche", "type": "advisory", "satisfies": "검증된 컨텍스트가 실행 시 위험 평가 초점을 좁힘" },
     { "source": "epitrope", "target": "prosoche", "type": "advisory", "satisfies": "위임 범위가 실행 시 감시 수준을 결정" },
-    { "source": "prosoche", "target": "epharmoge", "type": "advisory", "satisfies": "실행 시 주의가 사후 적용성 검증 컨텍스트를 제공" }
+    { "source": "prosoche", "target": "epharmoge", "type": "advisory", "satisfies": "실행 시 주의가 사후 적용성 검증 컨텍스트를 제공" },
+    { "source": "prothesis", "target": "aitesis", "type": "advisory", "satisfies": "관점 시뮬레이션이 컨텍스트 검증 추천을 제공" },
+    { "source": "hermeneia", "target": "aitesis", "type": "advisory", "satisfies": "배경 갭이 실행 컨텍스트 영역이면 Aitesis 전환 제안" }
   ]
 }

--- a/hermeneia/README.md
+++ b/hermeneia/README.md
@@ -27,6 +27,7 @@ Users often recognize their expression is ambiguous (`IntentMisarticulated`) but
 | Aitesis | AI-guided | `ContextInsufficient → InformedExecution` |
 | Epitrope | AI-guided | `DelegationAmbiguous → CalibratedDelegation` |
 | Epharmoge | AI-guided | `ApplicationDecontextualized → ContextualizedExecution` |
+| Prosoche | User-initiated | `ExecutionBlind → SituatedExecution` |
 | Katalepsis | User-initiated | `ResultUngrasped → VerifiedUnderstanding` |
 
 ## Protocol Flow
@@ -45,7 +46,7 @@ Phase 3: Integration   → Proceed with clarified expression
 | Expression | "Did you mean X or Y?" |
 | Precision | "How specifically: [options]?" |
 | Coherence | "You mentioned X but also Y..." |
-| Context | "What's the context for this?" |
+| Background | "What's the context for this?" |
 
 ## When to Use
 

--- a/hermeneia/README_ko.md
+++ b/hermeneia/README_ko.md
@@ -20,9 +20,15 @@
 
 | 프로토콜 | 주도자 | 타입 시그니처 |
 |----------|--------|---------------|
-| Prothesis | AI 감지 | `FrameworkAbsent → FramedInquiry` |
-| Syneidesis | AI 감지 | `GapUnnoticed → AuditedDecision` |
+| Prothesis | AI-guided | `FrameworkAbsent → FramedInquiry` |
+| Syneidesis | AI-guided | `GapUnnoticed → AuditedDecision` |
 | **Hermeneia** | **Hybrid** | **`IntentMisarticulated → ClarifiedIntent`** |
+| Telos | AI-guided | `GoalIndeterminate → DefinedEndState` |
+| Aitesis | AI-guided | `ContextInsufficient → InformedExecution` |
+| Epitrope | AI-guided | `DelegationAmbiguous → CalibratedDelegation` |
+| Prosoche | User-initiated | `ExecutionBlind → SituatedExecution` |
+| Epharmoge | AI-guided | `ApplicationDecontextualized → ContextualizedExecution` |
+| Katalepsis | User-initiated | `ResultUngrasped → VerifiedUnderstanding` |
 
 ## 프로토콜 흐름
 
@@ -40,7 +46,7 @@ Phase 3: Integration   → 명확화된 표현으로 진행
 | Expression | "X를 의미하셨나요, Y를 의미하셨나요?" |
 | Precision | "구체적으로 어느 정도: [옵션]?" |
 | Coherence | "X를 언급하셨지만 Y도..." |
-| Context | "이것의 맥락이 무엇인가요?" |
+| Background | "이것의 맥락이 무엇인가요?" |
 
 ## 사용 시기
 

--- a/prosoche/README.md
+++ b/prosoche/README.md
@@ -7,7 +7,7 @@ Evaluate execution-time risks during AI operations through continuous risk asses
 ## Type Signature
 
 ```
-(ExecutionBlind, AI-guided, EVALUATE, ExecutionAction) → SituatedExecution
+(ExecutionBlind, User, EVALUATE, ExecutionAction) → SituatedExecution
 ```
 
 ## What It Does

--- a/prosoche/README_ko.md
+++ b/prosoche/README_ko.md
@@ -7,7 +7,7 @@
 ## 타입 시그니처
 
 ```
-(ExecutionBlind, AI-guided, EVALUATE, ExecutionAction) → SituatedExecution
+(ExecutionBlind, User, EVALUATE, ExecutionAction) → SituatedExecution
 ```
 
 ## 기능

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -180,7 +180,7 @@ When Prothesis is active:
 - Prothesis completes before other workflows begin
 - User Memory rules resume after perspective is established
 
-**Protocol precedence**: Default ordering places Prothesis after Aitesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Syneidesis → Prosoche → Epharmoge; established perspective contextualizes gap detection). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed result (`R`), so it is not subject to ordering choices.
+**Protocol precedence**: Default ordering places Prothesis after Aitesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Syneidesis → Prosoche → Epharmoge; established perspective contextualizes gap detection). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed AI work (`R`), so it is not subject to ordering choices.
 
 ### Per-Message Application
 

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -113,7 +113,7 @@ When Syneidesis is active:
 - All decision points become candidates for interactive confirmation
 - User Memory rules resume after mode deactivation
 
-**Protocol precedence**: Default ordering places Syneidesis after Prothesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Syneidesis → Prosoche → Epharmoge; gap detection applies within the established, context-verified perspective). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed result (`R`), so it is not subject to ordering choices.
+**Protocol precedence**: Default ordering places Syneidesis after Prothesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Syneidesis → Prosoche → Epharmoge; gap detection applies within the established, context-verified perspective). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed AI work (`R`), so it is not subject to ordering choices.
 
 ### Mode Deactivation
 


### PR DESCRIPTION
## 요약

4개 병렬 에이전트 기반 drift audit 수행 후 발견된 12건의 불일치를 수정합니다.

### 수정 내역

**Priority 1 — 사실 오류 (4건)**
- Prosoche README: type signature `AI-guided` → `User` (SKILL.md canonical source와 일치)
- Hermeneia README: gap type `Context` → `Background` (SKILL.md rename 미반영)

**Priority 2 — Taxonomy 불일치 (4건)**
- Hermeneia README_ko: `AI 감지` → `AI-guided` (Strategy D(A) taxonomy 반영)
- Hermeneia README_ko: distinction table 3행 → 9행 (전체 프로토콜 포함)
- Hermeneia README: Prosoche 행 누락 → 추가 (8행 → 9행)

**Priority 3 — 워딩 drift (2건)**
- Prothesis/Syneidesis SKILL.md: `completed result` → `completed AI work` (7/9 프로토콜 다수 패턴과 일치)

**Priority 4 — Graph 보강 (2건)**
- `prothesis → aitesis` (advisory): SKILL.md recommend_protocols에 기술된 관계 반영
- `hermeneia → aitesis` (advisory): Background gap → Aitesis territory 전환 경로 반영

### 검증

- 각 수정 그룹별 `static-checks.js` 실행 → 0 fail 확인
- graph.json: 9 nodes, 16 edges (14 → 16), DAG acyclicity 유지

## 테스트 계획

- [x] Static checks 전체 통과 확인
- [x] graph.json integrity 검증 (16 edges, 0 cycle)
- [x] Prosoche SKILL.md:8 `User` 와 README `User` 일치 확인
- [x] Hermeneia SKILL.md:21 `Background` 와 README `Background` 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

