### PR TITLE
fix(aitesis): Context Inferencer 모델 전환 마무리

### DIFF
--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -54,7 +54,7 @@ early_exit = user_declares_sufficient
 Phase 1 Ctx  (collect)  → Read, Grep (context collection)
 Phase 2 Q    (extern)   → AskUserQuestion (uncertainty surfacing + progress)
 Phase 3      (state)    → Internal state update
-Phase 0 Scan (detect)   → Internal analysis (no external tool)
+Phase 0 Scan (infer)    → Internal analysis (no external tool)
 
 ── MODE STATE ──
 Λ = { phase: Phase, X: ExecutionPlan, uncertainties: Set(Uncertainty),


### PR DESCRIPTION
## Summary
- Aitesis Context Inferencer 모델 전환의 마무리 작업
- Phase 0 PHASE TRANSITIONS 동사를 `detect` → `infer`로 정렬
- plugin.json 버전 3.0.0 → 3.0.1 패치 범프

## Changes
- `aitesis/skills/inquire/SKILL.md`: Phase 0 Scan 동사 변경 (`detect` → `infer`) — Context Inferencer 모델의 능동적 추론 의미론 반영
- `aitesis/.claude-plugin/plugin.json`: 패치 버전 범프 (3.0.0 → 3.0.1)

## Test plan
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 통과 확인
- [x] PHASE TRANSITIONS 내 동사와 프로토콜 모델명 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

