### PR TITLE
refactor(epitrope,prothesis,reflexion): SKILL.md 품질 개선

### DIFF
--- a/epitrope/.claude-plugin/plugin.json
+++ b/epitrope/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epitrope",
   "description": "Context-adaptive delegation calibration through scenario-based interview — /calibrate (ἐπιτροπή: a turning over to)",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epitrope/skills/calibrate/SKILL.md
+++ b/epitrope/skills/calibrate/SKILL.md
@@ -224,26 +224,7 @@ When Epitrope is active:
 | User ESC | Return to default autonomy assumptions |
 | User cancels | Discard partial contract, return to normal |
 
-## Domain Taxonomy
-
-| Domain | Scope | Example Actions |
-|--------|-------|-----------------|
-| **FileModification** | Creating, editing, deleting files | Write new modules, refactor existing code, delete unused files |
-| ↳ *ephemeral* | Temp files, build artifacts, generated code | — (follows FileModification autonomy level) |
-| ↳ *durable* | Source code, config, memory, CLAUDE.md, rules | May require different autonomy than ephemeral |
-| **Exploration** | Reading files, searching codebase, web research | Grep for patterns, read adjacent files, fetch documentation |
-| **Strategy** | Choosing implementation approach | Select architecture pattern, decide refactoring scope, pick library |
-| **External** | Actions visible outside local environment | git push, PR creation, Slack messages, issue comments |
-
-### Domain Priority
-
-When calibrating, interview in this order (highest impact first):
-1. **External** (highest): Hardest to reverse, visible to others
-2. **FileModification**: Changes to codebase, tracked by git
-3. **Strategy**: Approach decisions, affect scope of work
-4. **Exploration** (lowest): Read-only, inherently safe
-
-Only domains applicable to the current task are calibrated. Skip irrelevant domains.
+See references/operational-guide.md for domain taxonomy, priority ordering, intensity levels, and UX safeguards.
 
 ## Protocol
 
@@ -295,30 +276,7 @@ Then decompose task into applicable ActionDomains.
 
 **Call the AskUserQuestion tool** to present the next uncalibrated domain as a concrete scenario. Team modes include team-specific scenarios (TeamCoordination, ScopeCreep) alongside standard domain scenarios.
 
-**Scenario format** (Akinator-style binary/ternary choice):
-
-```
-For this task, I'd like to calibrate how I should handle [domain]:
-
-[Concrete scenario description relevant to the actual task]
-
-Options:
-1. **[Autonomy level A]** — [what this means in practice]
-2. **[Autonomy level B]** — [what this means in practice]
-3. **[Autonomy level C]** — [if applicable]
-```
-
-**Design principles**:
-- **Concrete scenarios**: Use task-specific situations, not abstract policy questions
-- **Binary/ternary**: Maximum 3 options per question (excluding "Other")
-- **Refinement available**: After initial answer, may ask one follow-up for precision
-- **Domain cap**: Maximum 4 domains per calibration session
-
-**Refinement questions** (optional, one per domain):
-- FileModification: "What about persistent files (config, memory, rules) vs. regular code changes?"
-- Exploration: "How far should I look beyond the immediate task scope?"
-- Strategy: "If I find a better approach mid-execution, should I...?"
-- External: "Should I draft PR descriptions for your review or create directly?"
+See references/output-formats.md for scenario and contract templates.
 
 ### Phase 3: Contract Integration
 
@@ -334,82 +292,7 @@ After user response, update the DelegationContract:
 
 **Call the AskUserQuestion tool** to present the assembled DelegationContract for approval.
 
-**Contract format** (Solo mode — WHAT + HOW MUCH):
-
-```
-Here's the delegation contract for this task:
-
-**Autonomous** (I'll proceed without asking):
-- [list of calibrated autonomous actions]
-
-**Report then act** (I'll tell you what I'm doing, then proceed):
-- [list of report-then-act actions]
-
-**Ask before** (I'll ask for permission first):
-- [list of ask-before actions]
-
-**Halt conditions** (I'll stop and escalate):
-- [list of halt conditions]
-
-**Skipped** (not applicable to this task):
-- [list of domains from Λ.skipped, if any]
-
-**Defaults** (uncalibrated domains default):
-- Exploration: autonomous (read-only, inherently safe)
-- Others: ask-before
-
-Options:
-1. **Approve** — apply this contract
-2. **Adjust** — I'd like to change something
-```
-
-**Contract format** (Team modes — WHO + WHAT + HOW MUCH):
-
-```
-Here's the delegation contract for this task:
-
-**Team Structure** (WHO):
-- [role assignments]
-
-**Autonomous** (proceed without asking):
-- [list of calibrated autonomous actions]
-
-**Report then act** / **Ask before** / **Halt conditions**:
-- [as in Solo format]
-
-**Authority transition**:
-Approval replaces the team's prior operating contract with this DelegationContract.
-
-Options:
-1. **Approve** — apply this contract (authority replacement)
-2. **Adjust** — I'd like to change something
-```
-
-If user selects "Adjust": present sub-options — "Adjust team structure" (→ Phase 1, TeamAugment/TeamRestructure only) or "Adjust domain calibration" (→ Phase 2). Solo mode only offers "Adjust domain calibration".
-
-**Authority replacement**: Approval is not advisory — it replaces the team's prior operating contract (e.g., MissionBrief from Prothesis) with the DelegationContract. Execution-layer distribution (SendMessage, Task spawning) is handled by built-in commands after protocol termination.
-
-## Intensity
-
-| Level | When | Format |
-|-------|------|--------|
-| Light | 1-2 domains, familiar task type | Single question covering key domain |
-| Medium | 3+ domains, moderate ambiguity | Sequential domain interviews (1 question each) |
-| Heavy | New project, history of friction, 4 domains | Full interview with refinement questions |
-
-## UX Safeguards
-
-| Rule | Structure | Threshold |
-|------|-----------|-----------|
-| Session immunity | Approved DC → skip recalibration for session | `¬recalibrate(DC, T')`: recalibrate only on `new_domain_activated ∨ stakes_escalated(→High)` |
-| Domain cap | `\|domains\| ≤ 4` | Confirmed (taxonomy is exhaustive) |
-| Question cap | `\|questions\| ≤ 12` (Solo: 9, Team: 12) | Wildcard triggers on response variance within same domain |
-| Cross-protocol fatigue | `prior_protocol_count(session) ≥ 2` → reduce intensity one level | Confirmed |
-| Prothesis mode-switch | `ctx.team ≠ ∅ ∧ ctx.lens ≠ ∅` → skip domains with unanimous Lens convergence | Confirmed |
-| WHO cap | `\|roles\| ≤ 6` for any team structure | Confirmed |
-| Full restructure guard | `TeamRestructure + \|retain\| = 0` → terminate (no team to calibrate) | Confirmed |
-| No-change guard | `TeamRestructure + \|retain\| = \|team\| ∧ \|new\| = 0` → redirect to TeamAugment | Confirmed |
-| Blanket escape | "Just do it" → immediate ESC, default autonomy | Confirmed |
+See references/output-formats.md for scenario and contract templates.
 
 ## Rules
 
@@ -426,37 +309,4 @@ If user selects "Adjust": present sub-options — "Adjust team structure" (→ P
 11. **Authority replacement**: DC approval replaces the team's prior operating contract; execution-layer distribution is outside protocol scope
 12. **Solo backward compatibility**: Solo mode preserves near-identical behavior to v1.1.1 — Phase 0 adds one new user-facing step (mode selection, proposing Solo when no team is active); subsequent phases proceed identically to v1.1.1
 
-## Cross-Protocol Interface
-
-### Prothesis → Epitrope Transition
-
-When Prothesis Phase 4 routing selects `J=calibrate`:
-
-1. Coordinator calls `Skill("calibrate")` — Epitrope SKILL.md loads into conversation context
-2. Epitrope Phase 0 detects `team_active` → presents TeamAugment, TeamRestructure, Solo options
-3. Handoff via session context: `T = TaskScope` derived from conversation (original request U, verified MissionBrief MBᵥ, and Lens L are all available in session context; no explicit transfer type needed)
-
-**Context availability** (present in session without explicit transfer):
-- **Team**: `~/.claude/teams/{name}/config.json` (Read) — {name} from conversation context (mode-switch: coordinator retains team name) or Glob discovery (standalone: `~/.claude/teams/*/config.json`)
-- **Lens L**: Conversation context (presented to user in Prothesis Phase 4)
-- **Findings**: Team task list (TaskList/TaskGet access)
-- **Mission brief**: Conversation context (confirmed in Prothesis Phase 0)
-
-**DC authority transition**: At approval, the team's operating contract transitions from MissionBrief to DelegationContract. This is an epistemic handoff — the protocol produces the DC artifact; execution-layer application (SendMessage, Task spawning) is handled by built-in commands after protocol termination.
-
-**Findings management**:
-
-| Layer | Artifact | Created | Persistence |
-|-------|----------|---------|-------------|
-| Individual findings | Task items | Prothesis Phase 3 TaskCreate | Team task list (until TeamDelete) |
-| Per-perspective results | R (raw results) | Phase 3 SendMessage collection | Conversation context |
-| Convergence/divergence | L (Lens) | Phase 4 Syn | Conversation context |
-
-When `J=calibrate`, TeamDelete is NOT called — task list persists for Epitrope reuse.
-
-### Downstream Protocols
-
-Approved DelegationContract becomes input to subsequent protocols:
-
-- **Syneidesis**: Epitrope (planning layer: "am I allowed to?") and Syneidesis (execution layer: "is this decision sound?") operate on different temporal layers — they complement rather than suppress each other. `DC.how_much[d] = AskBefore` domains surface delegation-scope changes as gaps; autonomous domains do not suppress Syneidesis (execution gaps remain independent of delegation calibration)
-- **Aitesis**: Delegation coverage (Epitrope) and context sufficiency (Aitesis) remain orthogonal axes. Interface deferred to Issue #57 (proactive Aitesis redesign)
+See references/cross-protocol.md for Prothesis transition and downstream protocol interfaces.

--- a/epitrope/skills/calibrate/references/cross-protocol.md
+++ b/epitrope/skills/calibrate/references/cross-protocol.md
@@ -1,0 +1,34 @@
+# Cross-Protocol Interface
+
+### Prothesis → Epitrope Transition
+
+When Prothesis Phase 4 routing selects `J=calibrate`:
+
+1. Coordinator calls `Skill("calibrate")` — Epitrope SKILL.md loads into conversation context
+2. Epitrope Phase 0 detects `team_active` → presents TeamAugment, TeamRestructure, Solo options
+3. Handoff via session context: `T = TaskScope` derived from conversation (original request U, verified MissionBrief MBᵥ, and Lens L are all available in session context; no explicit transfer type needed)
+
+**Context availability** (present in session without explicit transfer):
+- **Team**: `~/.claude/teams/{name}/config.json` (Read) — {name} from conversation context (mode-switch: coordinator retains team name) or Glob discovery (standalone: `~/.claude/teams/*/config.json`)
+- **Lens L**: Conversation context (presented to user in Prothesis Phase 4)
+- **Findings**: Team task list (TaskList/TaskGet access)
+- **Mission brief**: Conversation context (confirmed in Prothesis Phase 0)
+
+**DC authority transition**: At approval, the team's operating contract transitions from MissionBrief to DelegationContract. This is an epistemic handoff — the protocol produces the DC artifact; execution-layer application (SendMessage, Task spawning) is handled by built-in commands after protocol termination.
+
+**Findings management**:
+
+| Layer | Artifact | Created | Persistence |
+|-------|----------|---------|-------------|
+| Individual findings | Task items | Prothesis Phase 3 TaskCreate | Team task list (until TeamDelete) |
+| Per-perspective results | R (raw results) | Phase 3 SendMessage collection | Conversation context |
+| Convergence/divergence | L (Lens) | Phase 4 Syn | Conversation context |
+
+When `J=calibrate`, TeamDelete is NOT called — task list persists for Epitrope reuse.
+
+### Downstream Protocols
+
+Approved DelegationContract becomes input to subsequent protocols:
+
+- **Syneidesis**: Epitrope (planning layer: "am I allowed to?") and Syneidesis (execution layer: "is this decision sound?") operate on different temporal layers — they complement rather than suppress each other. `DC.how_much[d] = AskBefore` domains surface delegation-scope changes as gaps; autonomous domains do not suppress Syneidesis (execution gaps remain independent of delegation calibration)
+- **Aitesis**: Delegation coverage (Epitrope) and context sufficiency (Aitesis) remain orthogonal axes. Interface deferred to Issue #57 (proactive Aitesis redesign)

--- a/epitrope/skills/calibrate/references/operational-guide.md
+++ b/epitrope/skills/calibrate/references/operational-guide.md
@@ -1,0 +1,44 @@
+# Operational Guide
+
+## Domain Taxonomy
+
+| Domain | Scope | Example Actions |
+|--------|-------|-----------------|
+| **FileModification** | Creating, editing, deleting files | Write new modules, refactor existing code, delete unused files |
+| ↳ *ephemeral* | Temp files, build artifacts, generated code | — (follows FileModification autonomy level) |
+| ↳ *durable* | Source code, config, memory, CLAUDE.md, rules | May require different autonomy than ephemeral |
+| **Exploration** | Reading files, searching codebase, web research | Grep for patterns, read adjacent files, fetch documentation |
+| **Strategy** | Choosing implementation approach | Select architecture pattern, decide refactoring scope, pick library |
+| **External** | Actions visible outside local environment | git push, PR creation, Slack messages, issue comments |
+
+### Domain Priority
+
+When calibrating, interview in this order (highest impact first):
+1. **External** (highest): Hardest to reverse, visible to others
+2. **FileModification**: Changes to codebase, tracked by git
+3. **Strategy**: Approach decisions, affect scope of work
+4. **Exploration** (lowest): Read-only, inherently safe
+
+Only domains applicable to the current task are calibrated. Skip irrelevant domains.
+
+## Intensity
+
+| Level | When | Format |
+|-------|------|--------|
+| Light | 1-2 domains, familiar task type | Single question covering key domain |
+| Medium | 3+ domains, moderate ambiguity | Sequential domain interviews (1 question each) |
+| Heavy | New project, history of friction, 4 domains | Full interview with refinement questions |
+
+## UX Safeguards
+
+| Rule | Structure | Threshold |
+|------|-----------|-----------|
+| Session immunity | Approved DC → skip recalibration for session | `¬recalibrate(DC, T')`: recalibrate only on `new_domain_activated ∨ stakes_escalated(→High)` |
+| Domain cap | `\|domains\| ≤ 4` | Confirmed (taxonomy is exhaustive) |
+| Question cap | `\|questions\| ≤ 12` (Solo: 9, Team: 12) | Wildcard triggers on response variance within same domain |
+| Cross-protocol fatigue | `prior_protocol_count(session) ≥ 2` → reduce intensity one level | Confirmed |
+| Prothesis mode-switch | `ctx.team ≠ ∅ ∧ ctx.lens ≠ ∅` → skip domains with unanimous Lens convergence | Confirmed |
+| WHO cap | `\|roles\| ≤ 6` for any team structure | Confirmed |
+| Full restructure guard | `TeamRestructure + \|retain\| = 0` → terminate (no team to calibrate) | Confirmed |
+| No-change guard | `TeamRestructure + \|retain\| = \|team\| ∧ \|new\| = 0` → redirect to TeamAugment | Confirmed |
+| Blanket escape | "Just do it" → immediate ESC, default autonomy | Confirmed |

--- a/epitrope/skills/calibrate/references/output-formats.md
+++ b/epitrope/skills/calibrate/references/output-formats.md
@@ -1,0 +1,85 @@
+# Output Formats
+
+## Phase 2: Scenario Format
+
+**Scenario format** (Akinator-style binary/ternary choice):
+
+```
+For this task, I'd like to calibrate how I should handle [domain]:
+
+[Concrete scenario description relevant to the actual task]
+
+Options:
+1. **[Autonomy level A]** — [what this means in practice]
+2. **[Autonomy level B]** — [what this means in practice]
+3. **[Autonomy level C]** — [if applicable]
+```
+
+**Design principles**:
+- **Concrete scenarios**: Use task-specific situations, not abstract policy questions
+- **Binary/ternary**: Maximum 3 options per question (excluding "Other")
+- **Refinement available**: After initial answer, may ask one follow-up for precision
+- **Domain cap**: Maximum 4 domains per calibration session
+
+**Refinement questions** (optional, one per domain):
+- FileModification: "What about persistent files (config, memory, rules) vs. regular code changes?"
+- Exploration: "How far should I look beyond the immediate task scope?"
+- Strategy: "If I find a better approach mid-execution, should I...?"
+- External: "Should I draft PR descriptions for your review or create directly?"
+
+## Phase 4: Contract Format
+
+**Contract format** (Solo mode — WHAT + HOW MUCH):
+
+```
+Here's the delegation contract for this task:
+
+**Autonomous** (I'll proceed without asking):
+- [list of calibrated autonomous actions]
+
+**Report then act** (I'll tell you what I'm doing, then proceed):
+- [list of report-then-act actions]
+
+**Ask before** (I'll ask for permission first):
+- [list of ask-before actions]
+
+**Halt conditions** (I'll stop and escalate):
+- [list of halt conditions]
+
+**Skipped** (not applicable to this task):
+- [list of domains from Λ.skipped, if any]
+
+**Defaults** (uncalibrated domains default):
+- Exploration: autonomous (read-only, inherently safe)
+- Others: ask-before
+
+Options:
+1. **Approve** — apply this contract
+2. **Adjust** — I'd like to change something
+```
+
+**Contract format** (Team modes — WHO + WHAT + HOW MUCH):
+
+```
+Here's the delegation contract for this task:
+
+**Team Structure** (WHO):
+- [role assignments]
+
+**Autonomous** (proceed without asking):
+- [list of calibrated autonomous actions]
+
+**Report then act** / **Ask before** / **Halt conditions**:
+- [as in Solo format]
+
+**Authority transition**:
+Approval replaces the team's prior operating contract with this DelegationContract.
+
+Options:
+1. **Approve** — apply this contract (authority replacement)
+2. **Adjust** — I'd like to change something
+```
+
+If user selects "Adjust": present sub-options — "Adjust team structure" (→ Phase 1, TeamAugment/TeamRestructure only) or "Adjust domain calibration" (→ Phase 2). Solo mode only offers "Adjust domain calibration".
+
+**Authority replacement**: Approval is not advisory — it replaces the team's prior operating contract (e.g., MissionBrief from Prothesis) with the DelegationContract. Execution-layer distribution (SendMessage, Task spawning) is handled by built-in commands after protocol termination.

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -187,30 +187,7 @@ When Prothesis is active:
 
 **Protocol precedence**: Default ordering places Prothesis after Aitesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Syneidesis → Prosoche → Epharmoge; established perspective contextualizes gap detection). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed AI work (`R`), so it is not subject to ordering choices.
 
-### Per-Message Application
-
-Every user message triggers perspective evaluation:
-
-| Message Type | Action |
-|--------------|--------|
-| New inquiry | Prothesis |
-| Follow-up within established lens | Continue with selected perspective |
-| Uncertain | Default to Prothesis |
-
-**Decision rule**: When uncertain whether perspective is established, default to Prothesis.
-
-```
-False positive (unnecessary question) < False negative (missed perspective)
-```
-
-### Mode Deactivation
-
-| Trigger | Effect |
-|---------|--------|
-| Synthesis complete | Lens established; follow-ups continue within lens |
-| User starts unrelated topic | Re-evaluate for new Prothesis |
-
-Consult `references/conceptual-foundations.md` for Plan Mode Integration and Distinction from Socratic Method.
+Consult `references/conceptual-foundations.md` for per-message application rules, mode deactivation triggers, Plan Mode Integration, and Distinction from Socratic Method.
 
 ## Protocol
 
@@ -390,18 +367,7 @@ Collect inquiry results into R'. Team remains active — shutdown/retain decisio
 
 #### Isolated Context Requirement
 
-**Mode 2 (inquire) only.** Mode 1 (recommend) terminates before Phase 3 — see Rule 3.
-
-Each perspective MUST be analyzed in **isolated teammate context** to prevent:
-- Cross-perspective contamination from shared conversation history
-- Confirmation bias from main agent's prior reasoning
-- Anchoring on initial assumptions formed during context gathering
-
-**Structural necessity**: Only teammates in an agent team provide fresh context—main agent retains full conversation history. Therefore, perspective analysis MUST be delegated to separate teammates. This is not a stylistic preference; it is architecturally required for epistemically valid multi-perspective analysis. **Phase-dependent isolation**: In Phase 3 (inquiry), perspectives operate in strict isolation — no cross-dialogue occurs. In Phase 4 (cross-dialogue), peers negotiate directly on coordinator-identified tension topics (≤3 exchanges per pair), then submit structured reports. If divergence remains, the coordinator queries each divergent peer once (hub-spoke) before synthesizing independently (see Phase 4 for coordinator role details).
-
-**Isolation trade-off on extend loops**: When `J=extend` deepens an existing perspective via SendMessage, the coordinator's re-inquiry instruction inherently carries synthesis context (what to deepen, why). This introduces controlled cross-pollination — the teammate gains partial awareness of other perspectives' findings. This is acceptable because: (1) the user explicitly requested extension, sanctioning the trade-off; (2) the coordinator controls what information crosses the boundary; (3) fresh initial analysis was already completed in full isolation.
-
-**Isolation trade-off on cross-dialogue phase**: Phase 4 allows peer-to-peer communication. This is acceptable because: (1) Phase 3 already secured independent analysis — isolation has served its epistemic purpose; (2) direct peer exchange produces richer negotiation than coordinator relay, which introduces State-Cognition Gap (information loss at each transfer layer); (3) the coordinator retains structural control — topic signaling, structured report collection, conditional hub-spoke — without acting as message intermediary during peer exchange. Hub-spoke is a controlled reversion to coordinator-mediated interaction, justified by the need for independent synthesis when peers cannot resolve divergence themselves.
+Each perspective MUST be analyzed in isolated teammate context. See `references/isolation-rationale.md` for the full rationale (cross-perspective contamination prevention, structural necessity, and isolation trade-offs).
 
 ### Phase 4: Cross-Dialogue & Synthesis
 
@@ -466,8 +432,6 @@ After cross-dialogue (R'' = R' + any dialogue responses), or directly from R' if
 [Synthesized answer with attribution to contributing perspectives]
 ```
 
-**v5.3.0 scope note**: Prothesis is pure theoria (analysis only). Prior to v4.0.0, a separate routing phase included classification (Fₐ/Fᵤ/Fᵈ) and execution (plan → praxis → verify). These have been extracted to Epitrope. Since v5.3.0, synthesis review and routing are combined in Phase 4 — Lens L confirmation and next-action selection happen in a single AskUserQuestion. Users seeking end-to-end execution should select "Calibrate" to transition to Epitrope, which establishes a DelegationContract covering WHO/WHAT/HOW MUCH for the implementation team. The Lens L persists in conversation context for Epitrope to reference.
-
 **Loop behavior** (team lifecycle aware):
 - **Calibrate**: Call Skill("calibrate") to activate Epitrope. Team retained — Epitrope detects the active team and presents TeamAugment, TeamRestructure, Solo options. Coordinator transitions to delegation calibration. Epitrope produces DC; after DC approval, routing re-presents so user can /batch then "Extend" to feed execution results back to the review team.
 - **Extend**: Follow-up AskUserQuestion — "Add new perspective" → Phase 2 (spawn new teammate into T), "Deepen existing" → Phase 3 (SendMessage re-inquiry to target teammate), or "Review execution results" → Phase 3 (SendMessage /batch output to team). Team retained in all cases.
@@ -483,28 +447,7 @@ After cross-dialogue (R'' = R' + any dialogue responses), or directly from R' if
 
 Recommendations are informational — user decides whether to call follow-up protocols.
 
-## Conditions
-
-### Trigger Prothesis
-
-Prothesis applies to **open-world** cognition where the problem space is not fully enumerated:
-
-- Purpose present, approach unspecified
-- Multiple valid epistemic frameworks exist
-- User's domain awareness likely incomplete
-- **Structure test**: "What might I be missing?" is a meaningful question
-
-### Skip Prothesis
-
-Prothesis does **not** apply to **closed-world** cognition:
-
-- Single deterministic execution path exists
-- Perspective already specified
-- Known target with binary outcome
-
-**Heuristic**: If a deterministic procedure can answer the inquiry, skip Prothesis.
-
-Consult `references/conceptual-foundations.md` for Parametric Nature and Specialization.
+Consult `references/conceptual-foundations.md` for trigger/skip heuristics, Parametric Nature, and Specialization.
 
 ## Rules
 

--- a/prothesis/skills/frame/references/conceptual-foundations.md
+++ b/prothesis/skills/frame/references/conceptual-foundations.md
@@ -63,3 +63,47 @@ Prothesis(mandatory_baseline, optional_extension):
 ```
 
 **Principle**: Mandatory baseline cannot be reduced by user selection; only extended.
+
+## Per-Message Application
+
+Every user message triggers perspective evaluation:
+
+| Message Type | Action |
+|--------------|--------|
+| New inquiry | Prothesis |
+| Follow-up within established lens | Continue with selected perspective |
+| Uncertain | Default to Prothesis |
+
+**Decision rule**: When uncertain whether perspective is established, default to Prothesis.
+
+```
+False positive (unnecessary question) < False negative (missed perspective)
+```
+
+## Mode Deactivation
+
+| Trigger | Effect |
+|---------|--------|
+| Synthesis complete | Lens established; follow-ups continue within lens |
+| User starts unrelated topic | Re-evaluate for new Prothesis |
+
+## Conditions
+
+### Trigger Prothesis
+
+Prothesis applies to **open-world** cognition where the problem space is not fully enumerated:
+
+- Purpose present, approach unspecified
+- Multiple valid epistemic frameworks exist
+- User's domain awareness likely incomplete
+- **Structure test**: "What might I be missing?" is a meaningful question
+
+### Skip Prothesis
+
+Prothesis does **not** apply to **closed-world** cognition:
+
+- Single deterministic execution path exists
+- Perspective already specified
+- Known target with binary outcome
+
+**Heuristic**: If a deterministic procedure can answer the inquiry, skip Prothesis.

--- a/prothesis/skills/frame/references/isolation-rationale.md
+++ b/prothesis/skills/frame/references/isolation-rationale.md
@@ -1,0 +1,14 @@
+# Isolation Rationale
+
+**Mode 2 (inquire) only.** Mode 1 (recommend) terminates before Phase 3 — see Rule 3.
+
+Each perspective MUST be analyzed in **isolated teammate context** to prevent:
+- Cross-perspective contamination from shared conversation history
+- Confirmation bias from main agent's prior reasoning
+- Anchoring on initial assumptions formed during context gathering
+
+**Structural necessity**: Only teammates in an agent team provide fresh context—main agent retains full conversation history. Therefore, perspective analysis MUST be delegated to separate teammates. This is not a stylistic preference; it is architecturally required for epistemically valid multi-perspective analysis. **Phase-dependent isolation**: In Phase 3 (inquiry), perspectives operate in strict isolation — no cross-dialogue occurs. In Phase 4 (cross-dialogue), peers negotiate directly on coordinator-identified tension topics (≤3 exchanges per pair), then submit structured reports. If divergence remains, the coordinator queries each divergent peer once (hub-spoke) before synthesizing independently (see Phase 4 for coordinator role details).
+
+**Isolation trade-off on extend loops**: When `J=extend` deepens an existing perspective via SendMessage, the coordinator's re-inquiry instruction inherently carries synthesis context (what to deepen, why). This introduces controlled cross-pollination — the teammate gains partial awareness of other perspectives' findings. This is acceptable because: (1) the user explicitly requested extension, sanctioning the trade-off; (2) the coordinator controls what information crosses the boundary; (3) fresh initial analysis was already completed in full isolation.
+
+**Isolation trade-off on cross-dialogue phase**: Phase 4 allows peer-to-peer communication. This is acceptable because: (1) Phase 3 already secured independent analysis — isolation has served its epistemic purpose; (2) direct peer exchange produces richer negotiation than coordinator relay, which introduces State-Cognition Gap (information loss at each transfer layer); (3) the coordinator retains structural control — topic signaling, structured report collection, conditional hub-spoke — without acting as message intermediary during peer exchange. Hub-spoke is a controlled reversion to coordinator-mediated interaction, justified by the need for independent synthesis when peers cannot resolve divergence themselves.

--- a/reflexion/.claude-plugin/plugin.json
+++ b/reflexion/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "reflexion",
   "description": "Cross-session learning via Reflexion pattern",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/reflexion/skills/reflexion/SKILL.md
+++ b/reflexion/skills/reflexion/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: reflexion
-description: >-
-  This skill should be used when the user asks to "reflect on session",
-  "extract insights", "analyze this conversation", "save learnings to memory",
-  "run /reflect", "what did we learn?", "capture this for future sessions",
-  "session wrap-up", or wants to persist session knowledge to User/Project memory.
-  Conversational memory reconstruction through guided dialogue.
+description: "Cross-session learning through guided dialogue. Extracts session insights and integrates into persistent memory when session knowledge should be preserved. Alias: Reflexion."
 ---
 
 # Reflexion v3


### PR DESCRIPTION
## 요약

- **epitrope**: calibrate SKILL.md에서 3개 supplementary 섹션을 `references/`로 분리 (463→312L, -33%)
- **prothesis**: frame SKILL.md에서 4개 구간을 `references/`로 이동 + 중복 삭제 (522→465L, -11%)
- **reflexion**: SKILL.md description을 lean pattern으로 축소 (8 trigger phrase → 1-line)

### 상세 변경

**Unit 1 — epitrope/calibrate** (`v2.1.4 → v2.1.5`)
- `references/output-formats.md`: Phase 2 scenario format + Phase 4 contract format 분리
- `references/cross-protocol.md`: Prothesis → Epitrope transition + downstream protocols 분리
- `references/operational-guide.md`: Domain taxonomy, priority, intensity, UX safeguards 분리
- distinction table은 SKILL.md에 유지 (cross-ref-scan 호환)

**Unit 2 — prothesis/frame** (`v5.3.0 → v5.3.1`)
- `references/isolation-rationale.md`: Isolated Context Requirement 근거 분리 (신규)
- v5.3.0 scope note 삭제 (conceptual-foundations.md "Theoria → Praxis"에 중복)
- Per-Message Application + Mode Deactivation → conceptual-foundations.md 이동
- Conditions (Trigger/Skip) → conceptual-foundations.md 이동

**Unit 3 — reflexion** (`v3.2.2 → v3.2.3`)
- description: 8개 trigger phrase 제거, Alias 추가, ~25 words lean pattern

## 테스트 계획

- [x] `node .claude/skills/verify/scripts/static-checks.js .` 전체 pass (0 fail)
- [ ] `structure`: `## Mode Activation` 헤더 존재 확인 (Unit 2)
- [ ] `cross-ref-scan`: distinction table 일관성 확인 (Unit 1, 2)
- [ ] `version-staleness`: plugin.json 버전 bump 확인
- [ ] `xref`: 새 references/ 파일 경로 참조 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)