### PR TITLE
fix(prothesis): Wrap Up TaskCreate 순서 수정

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -47,7 +47,7 @@ user_wrap_up  = (J = wrap_up) at Phase 4   -- user selects wrap_up routing optio
 user_esc      = J = ESC at any phase        -- user selects ESC (Escape)
 J      = Routing ∈ {calibrate, extend, add_input, wrap_up, ESC}  -- Phase 4 routing decision (post-merge)
 J_mb   = MissionBriefRouting ∈ {confirm, modify(field), ESC}  -- Phase 0 routing decision
-PF     = preserve_findings: (T, L) → Q[AskUserQuestion](select categories) → void  -- TaskCreate deferred to post-TeamDelete
+PF     = preserve_findings: (T, L) → Q[AskUserQuestion](select categories)          -- returns selected; TaskCreate is post-TeamDelete step
 
 ── U-BINDING ──
 bind(U) = explicit_arg ∪ colocated_expr ∪ prev_user_turn ∪ ai_identified_request
@@ -122,7 +122,7 @@ Phase 4 Δ (detect)       → Internal operation (trigger check: contradictions,
 Phase 4 D? (conditional) → SendMessage tool (type: "message", coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke → independent synthesis; skip if Δ = ∅)
 Phase 4 Q (extern)       → AskUserQuestion (synthesis + routing: present Lens L with calibrate/extend/add_input/wrap_up options; Escape → terminate)
 PF Q (extern)            → AskUserQuestion (multiSelect: preservation scope; in LOOP wrap_up path only)
-PF (state)               → TaskCreate (session-scoped: selected findings migrated from L after TeamDelete clears team context)
+wrap_up TaskCreate (state) → TaskCreate (session-scoped: PF-selected findings, created after TeamDelete clears team context)
 Ω (extern)               → SendMessage tool (type: "shutdown_request", graceful teammate termination)
 J=calibrate (extern)     → Skill tool (protocol transition: Activate[Skill]("calibrate") → activate Epitrope; in LOOP after Phase 4)
 Λ (state)                → TaskCreate/TaskUpdate (mandatory after Phase 3 spawn, per perspective; TaskUpdate for status tracking)
@@ -436,7 +436,7 @@ After cross-dialogue (R'' = R' + any dialogue responses), or directly from R' if
 - **Calibrate**: Call Skill("calibrate") to activate Epitrope. Team retained — Epitrope detects the active team and presents TeamAugment, TeamRestructure, Solo options. Coordinator transitions to delegation calibration. Epitrope produces DC; after DC approval, routing re-presents so user can /batch then "Extend" to feed execution results back to the review team.
 - **Extend**: Follow-up AskUserQuestion — "Add new perspective" → Phase 2 (spawn new teammate into T), "Deepen existing" → Phase 3 (SendMessage re-inquiry to target teammate), or "Review execution results" → Phase 3 (SendMessage /batch output to team). Team retained in all cases.
 - **Add input**: User provides additional context → revise synthesis with new input → re-present Lens L' with routing options.
-- **Wrap up**: preserve_findings (PF) → shutdown_request → TeamDelete → TaskCreate → terminate with L → recommend_protocols(L). PF presents L categories (convergence, divergence, assessment highlights) via multiSelect AskUserQuestion; after TeamDelete clears team context, selected items are migrated to session-scoped TaskCreate (ensuring tasks survive team cleanup).
+- **Wrap up**: preserve_findings (PF) → shutdown_request → TeamDelete → TaskCreate → terminate with L → recommend_protocols(L). PF presents L categories (convergence, divergence, assessment highlights) via multiSelect AskUserQuestion; selected items migrate to session TaskCreate after TeamDelete.
 - **ESC**: shutdown_request → TeamDelete → terminate with current Lens L (fast exit — preserve_findings skipped)
 
 **Convergence**: Mode terminates when user selects wrap_up or explicitly exits (ESC). Team is deleted only at terminal states.

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -47,7 +47,7 @@ user_wrap_up  = (J = wrap_up) at Phase 4   -- user selects wrap_up routing optio
 user_esc      = J = ESC at any phase        -- user selects ESC (Escape)
 J      = Routing ∈ {calibrate, extend, add_input, wrap_up, ESC}  -- Phase 4 routing decision (post-merge)
 J_mb   = MissionBriefRouting ∈ {confirm, modify(field), ESC}  -- Phase 0 routing decision
-PF     = preserve_findings: (T, L) → Q[AskUserQuestion](select categories) → TaskCreate(selected) → void
+PF     = preserve_findings: (T, L) → Q[AskUserQuestion](select categories) → void  -- TaskCreate deferred to post-TeamDelete
 
 ── U-BINDING ──
 bind(U) = explicit_arg ∪ colocated_expr ∪ prev_user_turn ∪ ai_identified_request
@@ -68,7 +68,7 @@ Phase 2:  (C, MBᵥ) → present[S]({P₁...Pₙ}(C, MBᵥ)) → await → Pₛ 
             m=recommend: Pₛ → recommend_compose(Pₛ) → terminate      -- Mode 1 termination
 Phase 3:  Pₛ → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → R → Ω[SendMessage](T) → R'  -- inquiry + collection [Tool]
 Phase 4:  R' → Δ(R') → D?[SendMessage](T) → R'' → Syn(R'') → L → Q[AskUserQuestion](L, routing) → J  -- cross-dialogue, synthesis, review & routing [Tool]
-          J=wrap_up → PF[AskUserQuestion](select) → TaskCreate → Ω → TeamDelete  [Tool]
+          J=wrap_up → PF[AskUserQuestion](select) → Ω → TeamDelete → TaskCreate(selected)  [Tool]
 
 ── LOOP ──
 After Phase 0 (Mission Brief + Mode Selection):
@@ -95,7 +95,7 @@ After Phase 4 (routing):
   J = extend     → Q[AskUserQuestion](add perspective | deepen existing | review execution results)
                    → Phase 2 (new perspective) or Phase 3 (SendMessage to existing team)
   J = add_input  → user context → revise Syn(R'' + input) → L' → re-present Q(L', routing)
-  J = wrap_up    → PF[AskUserQuestion](select) → TaskCreate(selected) → Ω(T, shutdown) → TeamDelete → terminate with L
+  J = wrap_up    → PF[AskUserQuestion](select) → Ω(T, shutdown) → TeamDelete → TaskCreate(selected) → terminate with L
                    → recommend_protocols(L)
   J = ESC        → Ω(T, shutdown) → TeamDelete → terminate with current L
                    (ESC = fast exit, preserve_findings skipped)
@@ -122,7 +122,7 @@ Phase 4 Δ (detect)       → Internal operation (trigger check: contradictions,
 Phase 4 D? (conditional) → SendMessage tool (type: "message", coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke → independent synthesis; skip if Δ = ∅)
 Phase 4 Q (extern)       → AskUserQuestion (synthesis + routing: present Lens L with calibrate/extend/add_input/wrap_up options; Escape → terminate)
 PF Q (extern)            → AskUserQuestion (multiSelect: preservation scope; in LOOP wrap_up path only)
-PF (state)               → TaskCreate (session-scoped: selected findings migrated from L before TeamDelete)
+PF (state)               → TaskCreate (session-scoped: selected findings migrated from L after TeamDelete clears team context)
 Ω (extern)               → SendMessage tool (type: "shutdown_request", graceful teammate termination)
 J=calibrate (extern)     → Skill tool (protocol transition: Activate[Skill]("calibrate") → activate Epitrope; in LOOP after Phase 4)
 Λ (state)                → TaskCreate/TaskUpdate (mandatory after Phase 3 spawn, per perspective; TaskUpdate for status tracking)
@@ -436,7 +436,7 @@ After cross-dialogue (R'' = R' + any dialogue responses), or directly from R' if
 - **Calibrate**: Call Skill("calibrate") to activate Epitrope. Team retained — Epitrope detects the active team and presents TeamAugment, TeamRestructure, Solo options. Coordinator transitions to delegation calibration. Epitrope produces DC; after DC approval, routing re-presents so user can /batch then "Extend" to feed execution results back to the review team.
 - **Extend**: Follow-up AskUserQuestion — "Add new perspective" → Phase 2 (spawn new teammate into T), "Deepen existing" → Phase 3 (SendMessage re-inquiry to target teammate), or "Review execution results" → Phase 3 (SendMessage /batch output to team). Team retained in all cases.
 - **Add input**: User provides additional context → revise synthesis with new input → re-present Lens L' with routing options.
-- **Wrap up**: preserve_findings (PF) → shutdown_request → TeamDelete → terminate with L → recommend_protocols(L). PF presents L categories (convergence, divergence, assessment highlights) via multiSelect AskUserQuestion; selected items are migrated to session TaskCreate before TeamDelete destroys the team task list.
+- **Wrap up**: preserve_findings (PF) → shutdown_request → TeamDelete → TaskCreate → terminate with L → recommend_protocols(L). PF presents L categories (convergence, divergence, assessment highlights) via multiSelect AskUserQuestion; after TeamDelete clears team context, selected items are migrated to session-scoped TaskCreate (ensuring tasks survive team cleanup).
 - **ESC**: shutdown_request → TeamDelete → terminate with current Lens L (fast exit — preserve_findings skipped)
 
 **Convergence**: Mode terminates when user selects wrap_up or explicitly exits (ESC). Team is deleted only at terminal states.


### PR DESCRIPTION
## Summary

- Wrap Up 경로에서 `TaskCreate`를 `TeamDelete` **이후**로 이동하여 preserve_findings 태스크가 세션 스코프에 영속되도록 수정
- 기존: `PF → TaskCreate → Ω → TeamDelete` (팀 task list에 생성 후 TeamDelete가 삭제)
- 수정: `PF → Ω → TeamDelete → TaskCreate` (팀 컨텍스트 해제 후 세션 task list에 생성)

## Test plan

- [x] Mode 2 Wrap Up 경로에서 preserve_findings 선택 후 태스크가 세션 task list에 존재하는지 확인
- [x] ESC 경로(preserve_findings 생략)는 기존 동작 유지 확인
- [x] Static check 전항 통과 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)



