### PR TITLE
feat(epistemic-cooperative): HTML artifact 브라우저 자동 오픈

### DIFF
--- a/epistemic-cooperative/skills/dashboard/SKILL.md
+++ b/epistemic-cooperative/skills/dashboard/SKILL.md
@@ -31,7 +31,7 @@ COLLECT → AGGREGATE → ANALYZE → PRESENT
 | 1. Collect | Main | Glob | Inventory + path decision |
 | 2. Aggregate | Subagent (coverage-scanner) | Bash, Read, Grep, Glob | Batch data collection |
 | 3. Analyze | Main | — | 7 computations |
-| 4. Present | Main | Write | HTML dashboard + console summary |
+| 4. Present | Main | Write, Bash | HTML dashboard + console summary |
 
 ## Data Sources
 
@@ -165,6 +165,8 @@ Composite score (0-100):
    - Top friction areas
    - Quality score (if available)
    - File path: `~/.claude/.insights/dashboard.html`
+
+3. **Open in browser**: Call Bash `open ~/.claude/.insights/dashboard.html` to launch the dashboard in the default browser
 
 ## HTML Artifact Guidelines
 

--- a/epistemic-cooperative/skills/onboard/SKILL.md
+++ b/epistemic-cooperative/skills/onboard/SKILL.md
@@ -30,7 +30,7 @@ SCAN → EXTRACT → MAP → PRESENT → GUIDE
 | 1. Scan | Subagent (project-scanner) | Bash, Read, Glob | Project discovery + secondary sources |
 | 2. Extract | Subagent (session-analyzer) | Grep, Read | Pattern extraction from JSONL |
 | 3. Map | Main | — | Pattern → Protocol matching |
-| 4. Present | Main | AskUserQuestion, Write | User confirmation + HTML artifact |
+| 4. Present | Main | AskUserQuestion, Write, Bash | User confirmation + HTML artifact |
 | 5. Guide | Main | AskUserQuestion | Protocol trial CTA |
 
 ## Data Sources
@@ -62,7 +62,7 @@ SCAN → EXTRACT → MAP → PRESENT → GUIDE
 | `~/.claude/usage-data/session-meta/{session_id}.json` | Read | tool_counts, git_commits, git_pushes, languages, uses_task_agent, duration_minutes, first_prompt |
 
 **Join key**: session_id from sessions-index.json matches filename in both directories.
-**Availability**: Only exists if user has run `/dashboard`. Read-only consumption — never write to these caches. For full coverage analysis across all sessions, run `/dashboard`.
+**Availability**: Only exists if user has run `/insights` (built-in command). Read-only consumption — never write to these caches. For full coverage analysis across all sessions, run `/dashboard`.
 
 ## Phase Execution
 
@@ -165,7 +165,7 @@ Apply the mapping tables below to match observed patterns to protocols.
 
    Refer to `references/html-template.md` for the HTML skeleton and CSS class reference.
 
-3. Provide artifact file path to user
+3. Open HTML artifact in default browser via Bash: `open ~/.claude/.onboard/epistemic-profile.html`
 
 ### Phase 5: Guide (Trial CTA + Install Helper)
 


### PR DESCRIPTION
## Summary

- onboard, dashboard Phase 4에서 HTML artifact 생성 후 `open` 명령으로 기본 브라우저에서 자동 오픈하도록 변경
- onboard SKILL.md facets 데이터 출처를 `/dashboard` → `/insights` (built-in command)로 수정
- 두 스킬의 workflow table에 `Bash` 도구 추가하여 table-prose 동기화

## Test plan

- [ ] `/onboard` 실행 후 HTML artifact가 브라우저에서 자동으로 열리는지 확인
- [x] `/dashboard` 실행 후 HTML dashboard가 브라우저에서 자동으로 열리는지 확인
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


