### PR TITLE
fix(verify): spec-vs-impl formal block cross-reference 인식

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -858,14 +858,20 @@ function checkSpecVsImpl() {
       const inPhase = new RegExp(escaped).test(phaseSection);
       // Check if type appears in prose
       const inProse = new RegExp(escaped).test(proseContent);
+      // Check if type is cross-referenced elsewhere in formal block
+      // (FLOW, LOOP, MODE STATE, other TYPES definitions, etc.)
+      // Remove the type's own definition line(s) to avoid self-match
+      const defLinePattern = new RegExp(`^${escaped}\\s+[=∈].*$`, 'gm');
+      const formalWithoutOwnDef = formalBlock.replace(defLinePattern, '');
+      const inFormalCrossRef = new RegExp(escaped).test(formalWithoutOwnDef);
 
-      // A type defined in TYPES but absent from both PHASE TRANSITIONS and prose
-      // suggests potential rename drift or dead type
-      if (!inPhase && !inProse) {
+      // A type defined in TYPES but absent from PHASE TRANSITIONS, prose,
+      // AND all other formal block sections suggests rename drift or dead type
+      if (!inPhase && !inProse && !inFormalCrossRef) {
         results.warn.push({
           check: 'spec-vs-impl',
           file: relPath,
-          message: `Type "${typeName}" defined in TYPES but not referenced in PHASE TRANSITIONS or prose — possible rename drift or dead type`
+          message: `Type "${typeName}" defined in TYPES but not referenced in PHASE TRANSITIONS, prose, or formal block cross-references — possible rename drift or dead type`
         });
       }
     }


### PR DESCRIPTION
## 요약

`spec-vs-impl` 검사에서 TYPES 내 상호참조(타입 간 참조)를 인식하도록 로직 확장.

### 변경 내용
- 타입 사용 여부 판단 범위: `PHASE TRANSITIONS + prose` → **formal block 전체 cross-reference** 추가
- 타입의 자체 정의 라인(`TypeName = ...`)만 제외하고 formal block 전체에서 검색
- FLOW, LOOP, MODE STATE, 다른 TYPES 정의에서의 참조를 인식

### 해소된 false positives (8개 → 0개)
- **Epitrope** (7): `DecomposedDomains`, `TeamRef`, `AgentRef`, `Complexity`, `Condition`, `AgentRole`, `ExplorationScope` — 다른 타입 정의나 MODE STATE에서 참조되는 구조적 타입
- **Prosoche** (1): `ClassifiedActions` — FLOW에서 참조

## 테스트 계획
- [x] `node .claude/skills/verify/scripts/static-checks.js .` — 0 failures, 3 warnings (notation only)
- [x] spec-vs-impl warnings: 8 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)