### PR TITLE
refactor(prothesis,epitrope): ESC → Withdraw 패턴 분리

### DIFF
--- a/epitrope/.claude-plugin/plugin.json
+++ b/epitrope/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epitrope",
   "description": "Context-adaptive delegation calibration through scenario-based interview — /calibrate (ἐπιτροπή: a turning over to)",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epitrope/skills/calibrate/SKILL.md
+++ b/epitrope/skills/calibrate/SKILL.md
@@ -76,7 +76,9 @@ TeamStructure ∈ {Solo, Augmented(TeamRef, Set(AgentRole)), Restructured(TeamRe
          -- guard: Phase 1 restructure redirects |retain|=0 → terminate (full removal = no team to calibrate)
 AgentRole = { name: String, type: String, focus: String }
 ExplorationScope = { depth: N, breadth: N, drift_action: report | halt }
-CalibratedDelegation = DC where (∀ d ∈ applicable: calibrated(d)) ∨ user_esc
+CalibratedDelegation = DC where (∀ d ∈ applicable: calibrated(d)) ∨ user_withdraw ∨ user_esc
+user_withdraw = user selects Withdraw at Phase 4  -- graceful exit (partial DC applies)
+user_esc      = Esc key at any phase              -- tool-level termination (no cleanup)
 
 ── SCENARIO TEMPLATES ──
 FileModification:  "When files need to be modified for this task?" → {Autonomous, ReportThenAct, AskBefore}
@@ -119,13 +121,13 @@ After Phase 0 (mode selection):
 
 After Phase 3: check uncalibrated domains.
 If domains remain: return to Phase 2 (next domain or refinement).
-If all calibrated or user ESC: proceed to Phase 4.
+If all calibrated or user Esc key: proceed to Phase 4.
 
 After Phase 4 (contract review):
   approve        → terminate with active DC (approval = authority replacement: DC replaces prior operating contract)
   adjust(who)    → return to Phase 1 (TeamAugment/TeamRestructure only; unavailable in Solo)
   adjust(domain) → return to Phase 2
-  ESC            → terminate; partial DC applies to calibrated domains
+  Withdraw       → terminate; partial DC applies to calibrated domains
 
 ── RECALIBRATION ──
 recalibrate(DC, T') = new_domain_activated(T') ∨ stakes_escalated(T') ∨ team_topology_changed(T')
@@ -145,7 +147,7 @@ Phase 1 restructure (extern) → AskUserQuestion (team restructure: retain/remov
 Phase 1     (detect)    → Read, Grep (task analysis for decomposition)
 Phase 2 Q   (extern)    → AskUserQuestion (mandatory; Esc key → loop termination at LOOP level, not a Response)
 Phase 3     (state)     → Internal DelegationContract update
-Phase 4 Q   (extern)    → AskUserQuestion (contract review + approval)
+Phase 4 Q   (extern)    → AskUserQuestion (contract review + approval; includes Withdraw option for graceful exit with partial DC)
 inherit     (state)     → Read (team config: ~/.claude/teams/{name}/config.json)  -- TeamAugment
 
 ── MODE STATE ──
@@ -212,7 +214,7 @@ When Epitrope is active:
 </system-reminder>
 
 - Epitrope completes before multi-domain execution proceeds
-- Loaded instructions resume after DelegationContract is approved or ESC
+- Loaded instructions resume after DelegationContract is approved or Withdraw
 
 **Protocol precedence**: Default ordering places Epitrope after Telos and before Aitesis (Hermeneia → Telos → Epitrope → Aitesis → Prothesis → Analogia → Syneidesis → Prosoche → Epharmoge; defined goals before delegation calibration, calibrated delegation before context verification). The user can override this default by explicitly requesting a different protocol first. Katalepsis is structurally last — it requires completed AI work (`R`), so it is not subject to ordering choices.
 
@@ -238,7 +240,8 @@ When Epitrope is active:
 | Trigger | Effect |
 |---------|--------|
 | DelegationContract approved | Apply contract to subsequent execution |
-| User Esc key | Partial DC applies to calibrated domains; uncalibrated domains use defaults (shown in Phase 4) |
+| User selects Withdraw | Partial DC applies to calibrated domains; uncalibrated domains use defaults (shown in Phase 4) |
+| User Esc key | Ungraceful exit; no partial DC |
 | User cancels | Discard partial contract, return to normal |
 
 See references/operational-guide.md for domain taxonomy and priority ordering.
@@ -339,7 +342,7 @@ After user response, update the DelegationContract:
 2. Record `(Dᵢ, Sₖ, R)` in history
 3. Check remaining uncalibrated domains
 4. If domains remain: return to Phase 2 (next domain by priority)
-5. If all calibrated or user ESC: proceed to Phase 4
+5. If all calibrated or user Esc key: proceed to Phase 4
 
 ### Phase 4: Contract Review
 
@@ -372,6 +375,7 @@ Here's the delegation contract for this task:
 Options:
 1. **Approve** — apply this contract
 2. **Adjust** — I'd like to change something
+3. **Withdraw** — exit with partial contract (calibrated domains apply, uncalibrated use defaults)
 ```
 
 **Contract format** (Team modes — WHO + WHAT + HOW MUCH):
@@ -394,6 +398,7 @@ Approval replaces the team's prior operating contract with this DelegationContra
 Options:
 1. **Approve** — apply this contract (authority replacement)
 2. **Adjust** — I'd like to change something
+3. **Withdraw** — exit with partial contract (calibrated domains apply, uncalibrated use defaults)
 ```
 
 If user selects "Adjust": present sub-options — "Adjust team structure" (→ Phase 1, TeamAugment/TeamRestructure only) or "Adjust domain calibration" (→ Phase 2). Solo mode only offers "Adjust domain calibration".
@@ -409,8 +414,8 @@ If user selects "Adjust": present sub-options — "Adjust team structure" (→ P
 5. **Session-scoped**: DelegationContract applies for current session only; does not persist across sessions
 6. **Domain priority**: Calibrate External first (highest impact), then FileModification, Strategy, Exploration
 7. **Minimal interruption**: Skip calibration for single-domain clear-scope tasks; use Light intensity when possible
-8. **Esc key respected**: User can exit at any point; partial contract applies to calibrated domains. Uncalibrated defaults: Exploration → autonomous (read-only, inherently safe), others → ask-before. Defaults explicitly shown in Phase 4 contract review
-9. **Convergence persistence**: Mode active until DelegationContract approved or user Esc key
+8. **Withdraw and Esc key**: Withdraw exits gracefully (partial contract applies to calibrated domains). Esc key is ungraceful termination (no partial DC). Uncalibrated defaults: Exploration → autonomous (read-only, inherently safe), others → ask-before. Defaults explicitly shown in Phase 4 contract review
+9. **Convergence persistence**: Mode active until DelegationContract approved or user Withdraw or user Esc key
 10. **Cross-protocol awareness**: Calibrated DC informs but does not replace Aitesis context verification or Syneidesis gap surfacing
 11. **Authority replacement**: DC approval replaces the team's prior operating contract; execution-layer distribution is outside protocol scope
 12. **Solo backward compatibility**: Solo mode preserves near-identical behavior to v1.1.1 — Phase 0 adds one new user-facing step (mode selection, proposing Solo when no team is active); subsequent phases proceed identically to v1.1.1

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -60,11 +60,12 @@ R''    = Set(Result) post-cross-dialogue              -- R' ∪ dialogue respons
 D?     = Conditional dialogue: Δ ≠ ∅ → peer negotiation → structured report → conditional hub-spoke → user review; Δ = ∅ → skip dialogue (synthesis + user review still proceed)
 Syn    = Synthesis: R'' → (∩, D, A)
 L      = Lens { convergence: ∩, divergence: D, assessment: A }
-FramedInquiry = L where (|Pₛ| ≥ 1 ∧ user_wrap_up) ∨ user_esc  -- Mode 2 terminal; Mode 1 terminates at LensEstablished (deficit remains open)
+FramedInquiry = L where (|Pₛ| ≥ 1 ∧ user_wrap_up) ∨ user_withdraw ∨ user_esc  -- Mode 2 terminal; Mode 1 terminates at LensEstablished (deficit remains open)
 user_wrap_up  = (J = wrap_up) at Phase 4   -- user selects wrap_up routing option
-user_esc      = J = ESC at any phase        -- user selects ESC (Escape)
-J      = Routing ∈ {calibrate, extend, add_input, wrap_up, ESC}  -- Phase 4 routing decision (post-merge)
-J_mb   = MissionBriefRouting ∈ {confirm, modify(field), ESC}  -- Phase 0 routing decision
+user_withdraw = J = Withdraw at Phase 4    -- user selects graceful exit (team cleanup)
+user_esc      = Esc key at any phase       -- tool-level termination (no cleanup)
+J      = Routing ∈ {calibrate, extend, add_input, wrap_up, Withdraw}  -- Phase 4 routing decision (post-merge)
+J_mb   = MissionBriefRouting ∈ {confirm, modify(field)}  -- Phase 0 routing decision
 PF     = preserve_findings: (T, L) → Q[AskUserQuestion](select categories)          -- returns selected; TaskCreate is post-TeamDelete step
 
 ── U-BINDING ──
@@ -94,7 +95,7 @@ After Phase 0 (Mission Brief + Mode Selection):
     m = inquire   → Phase 1 → Phase 2 → LensEstablished → Phase 3 → Phase 4
   J_mb = confirm       → proceed to Phase 1 with (MBᵥ, m)
   J_mb = modify(field) → re-present Q1(MB') → await → MBᵥ (m retained from initial selection)
-  J_mb = ESC           → terminate (no team exists)
+  -- Esc key → terminate (no team exists)
 
 After LensEstablished (mode branching):
   J = recommend → Mode 1 terminus. recommend_compose(Pₛ) and terminate:
@@ -116,14 +117,14 @@ After Phase 4 (routing):
   J = add_input  → user context → revise Syn(R'' + input) → L' → re-present Q(L', routing)
   J = wrap_up    → PF[AskUserQuestion](select) → Ω(T, shutdown) → TeamDelete → TaskCreate(selected) → terminate with L
                    → recommend_protocols(L)
-  J = ESC        → Ω(T, shutdown) → TeamDelete → terminate with current L
-                   (ESC = fast exit, preserve_findings skipped)
+  J = Withdraw   → Ω(T, shutdown) → TeamDelete → terminate with current L
+                   (Withdraw = graceful exit, preserve_findings skipped)
 
 recommend_protocols(L):
   L.divergence ≠ ∅ → suggest Syneidesis (gap audit) or Epitrope (calibrate delegation — provide task scope T when calling /calibrate)
   L.assessment reveals indeterminate goals → suggest Telos
 
-Continue until convergence: user satisfied OR user ESC.
+Continue until convergence: user satisfied OR user Withdraw OR user Esc key.
 
 ── BOUNDARY ──
 Q(MB, M) (confirm+select) = extern: Mission Brief confirmation + mode selection boundary
@@ -139,7 +140,7 @@ T (parallel)             → TeamCreate tool (creates team with shared task list
 ∥I (parallel)            → TaskCreate/TaskUpdate (shared task list for inquiry coordination)
 Phase 4 Δ (detect)       → Internal operation (trigger check: contradictions, horizon intersections, uncorroborated high-stakes)
 Phase 4 D? (conditional) → SendMessage tool (type: "message", coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke → independent synthesis; skip if Δ = ∅)
-Phase 4 Q (extern)       → AskUserQuestion (synthesis + routing: present Lens L with calibrate/extend/add_input/wrap_up options; Esc key → loop termination at LOOP level)
+Phase 4 Q (extern)       → AskUserQuestion (synthesis + routing: present Lens L with calibrate/extend/add_input/wrap_up/Withdraw options; Esc key → loop termination at LOOP level)
 PF Q (extern)            → AskUserQuestion (multiSelect: preservation scope; in LOOP wrap_up path only)
 wrap_up TaskCreate (state) → TaskCreate (session-scoped: PF-selected findings, created after TeamDelete clears team context)
 Ω (extern)               → SendMessage tool (type: "shutdown_request", graceful teammate termination)
@@ -416,6 +417,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    2. **Extend** — add new perspective, deepen existing analysis, or review execution results
    3. **Add input** — provide additional context for synthesis revision
    4. **Wrap up** — finalize with current Lens
+   5. **Withdraw** — exit with current Lens (team cleanup, no findings preservation)
    ```
 
    **"Calibrate" availability**: Present when L contains actionable findings (divergence with clear fix directions, or assessment with implementation implications). When L is purely confirmatory or exploratory, omit this option.
@@ -449,7 +451,7 @@ After cross-dialogue (R'' = R' + any dialogue responses), or directly from R' if
 - **Calibrate**: Team retained — Epitrope detects the active team and presents TeamAugment, TeamRestructure, Solo options. After DC approval, routing re-presents so user can /batch then "Extend" to feed execution results back to the review team.
 - **Wrap up**: PF presents L categories (convergence, divergence, assessment highlights) via multiSelect AskUserQuestion; selected items migrate to session TaskCreate after TeamDelete.
 
-All other routing options (Extend, Add input, ESC) and convergence/recommendation behavior Per LOOP.
+All other routing options (Extend, Add input, Withdraw) and convergence/recommendation behavior Per LOOP.
 
 Consult `references/conceptual-foundations.md` for trigger/skip heuristics, Parametric Nature, and Specialization.
 


### PR DESCRIPTION
## 요약

Side effect가 있는 프로토콜 종료(TeamDelete, partial DC)를 Esc key 메커니즘에서 분리하여 명시적 answer type(`Withdraw`)으로 노출.

## 배경

- Esc key를 누르면 agent에게 cleanup 기회 없이 즉시 suspend됨
- Prothesis의 `Ω(T, shutdown) → TeamDelete`와 Epitrope의 `partial DC applies`는 Esc key로는 실행 불가
- Prosoche는 이미 `Deactivate` answer type으로 이 문제를 해결함

## 변경 사항

### Prothesis (v5.6.3 → v5.6.4)
- `J = Routing`에서 `ESC` → `Withdraw` 교체
- `user_withdraw` 술어 추가 (graceful exit with team cleanup)
- `user_esc`를 Esc key 메커니즘으로 재정의 (tool-level, no cleanup)
- `J_mb`에서 `ESC` 제거 (Phase 0에는 team 없어 side effect 불필요)
- Phase 4 AskUserQuestion 옵션에 Withdraw 추가
- TOOL GROUNDING Phase 4에 Withdraw 반영

### Epitrope (v2.3.3 → v2.3.4)
- LOOP Phase 4에서 `ESC` → `Withdraw` 교체
- `user_withdraw`, `user_esc` 술어 정의 추가
- Phase 4 계약 리뷰에 Withdraw 옵션 추가 (Solo + Team 포맷)
- Mode Deactivation 테이블: Withdraw (partial DC) / Esc key (no cleanup) 분리
- Rules #8, #9 업데이트

## 설계 원리

**Three-tier termination model**:
1. **Answer type** (Tier 1): `Withdraw` — 명시적 사용자 선택, agent cleanup 실행 가능
2. **Tool mechanism** (Tier 2): Esc key — 즉시 suspend, cleanup 없음
3. **Convergence** (Tier 0): `user_withdraw ∨ user_esc` — 양쪽 모두 convergence 달성

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 0 failures, 3 warnings (기존 notation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)