### PR TITLE
refactor(epistemic-cooperative): /onboard 퀘스트 학습 재설계

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ Detect application-context mismatch after execution when correct output may not 
 ### Epistemic Cooperative (Report + Onboard + Dashboard)
 Utility skill group for session analytics.
 - **Report** `/report`: Generate epistemic usage analysis report with evidence-backed protocol recommendations and HTML artifact. Analytical output — pattern evidence, anti-pattern diagnostics, session snippets.
-- **Onboard** `/onboard`: Quest-based protocol learning through scenario experience, trial execution, and Socratic quiz. Flow: Entry → Scan → Extract → Map → Scenario → Trial → Quiz → Guide. Phases 1-2 share infrastructure with `/report`; Phase 3 uses simplified mapping; Phases 4-7 deliver experiential learning (体験=/onboard, 分析=/report).
+- **Onboard** `/onboard`: Quest-based protocol learning through scenario experience, trial execution, and Socratic quiz. Flow: Entry → Scan → Extract → Map → Scenario → Trial → Quiz → Guide. Phase 0 selects learning path; Phases 1-2 share infrastructure with `/report`; Phases 3-7 deliver experiential learning.
 - **Dashboard** `/dashboard`: Full-session coverage dashboard with friction mapping, growth timeline, achievements, and quality score. Flow: Collect → Aggregate → Analyze → Present. Phase 2 uses `coverage-scanner` subagent for batch aggregation.
 
 ### Reflexion

--- a/epistemic-cooperative/skills/onboard/SKILL.md
+++ b/epistemic-cooperative/skills/onboard/SKILL.md
@@ -136,11 +136,11 @@ Expected outcome: [e.g., N corrections reduced to 0-2]
 
 **Clarity rule**: Scenarios must present **clear-cut** protocol fits where the mapping is unambiguous. If a session pattern could plausibly map to multiple protocols (e.g., "exploration" could be `/goal` or `/frame`), do NOT use it as a scenario — reserve it for Phase 6 quiz material instead. The scenario phase builds confidence through recognition; the quiz phase builds discrimination through ambiguity.
 
-**Anti-patterns**:
-- Do not reference session IDs or list pattern counts without context. If the user has to wonder "what session was that?", engagement drops. Scenarios must be **self-contained**: session summary first, then pattern, then intervention.
-- Do not present scenarios where the user might reasonably challenge "isn't /Y a better fit?" — that debate belongs in the quiz. If the scenario invites protocol choice debate, it is too ambiguous for Phase 4.
+**Anti-pattern**: Scenarios must be self-contained (session summary + pattern + intervention) with unambiguous protocol fit. Ambiguous patterns belong in Phase 6 quiz.
 
 **Session summary source**: `summary` field or `firstPrompt` text from `sessions-index.json`. If neither is available, infer session character from primary tool/file patterns extracted in Phase 2.
+
+Call AskUserQuestion to present each scenario.
 
 **AskUserQuestion #3** (per scenario):
 - Text: Present the scenario (with session context) and intervention point
@@ -153,23 +153,15 @@ Expected outcome: [e.g., N corrections reduced to 0-2]
 
 Guide the user through a real, abbreviated protocol experience.
 
+Call AskUserQuestion to present the trial prompt.
+
 **AskUserQuestion #4**:
 - Text: Present a mini practice prompt tailored to the protocol
 - Options:
   - "Start trial"
   - "Skip trial"
 
-**Mini practice prompts** (scoped for 2-3 exchanges):
-- `/clarify`: "Let's practice: tell me 'Fix the auth flow' and I'll show how /clarify decomposes it"
-- `/goal`: "Let's practice: say 'Improve the dashboard' and I'll show how /goal co-constructs success criteria"
-- `/gap`: "Let's practice: say 'I'm ready to merge this PR' and I'll show how /gap surfaces blind spots"
-- `/frame`: "Let's practice: say 'Should we use microservices?' and I'll show how /frame recommends analytical lenses"
-- `/inquire`: "Let's practice: say 'Deploy the staging environment' and I'll show how /inquire catches missing context"
-- `/calibrate`: "Let's practice: say 'Handle this refactoring however you think is best' and I'll show how /calibrate sets delegation boundaries"
-- `/ground`: "Let's practice: say 'Apply the strangler fig pattern to our codebase' and I'll show how /ground validates the mapping"
-- `/attend`: "Let's practice: say 'Run the migration script' and I'll show how /attend classifies execution risks"
-- `/contextualize`: "Let's practice: say 'I just deployed the new component' and I'll show how /contextualize checks environment fit"
-- `/grasp`: "Let's practice: I'll describe a complex refactoring, and /grasp will verify your understanding"
+**Mini practice prompts** (scoped for 2-3 exchanges): Use the **Trial prompt** field from `references/scenarios.md` for the target protocol.
 
 **Execution**: When user starts trial, prompt them to invoke the actual protocol (e.g., type `/clarify`). The protocol runs in the same session with the mini prompt as context. After 2-3 exchanges or protocol completion, present: "Trial complete. Type 'continue onboarding' to resume."
 
@@ -186,17 +178,6 @@ Protocol Insight: /X (Greek name)
 [Workflow position — where this protocol sits and why]
 [Game feel — the experiential pattern you just went through]
 ```
-
-Example for `/contextualize`:
-```
-Protocol Insight: /contextualize (ἐφαρμογή — application, fitting)
-
-Core: Applicability over Correctness — correct code that doesn't fit your context is not useful code.
-Position: Post-execution — after work is done, check if it fits where it's going.
-Game feel: "Done! ...wait, does this actually fit here?" → mismatch detection → evidence → adapt or dismiss.
-```
-
-This bridges the gap between "I used it" and "I understand why it's designed this way." The insight arrives at the moment of peak receptivity — immediately after hands-on experience.
 
 ### Phase 6: Quiz (Socratic Verification)
 
@@ -223,6 +204,8 @@ Call AskUserQuestion:
   - "I'll type my answer"
   - "Skip this question"
 
+Design questions are open-ended — no scored "correct" answer. Evaluate based on whether the response demonstrates protocol awareness.
+
 **Feedback** (immediate, after each question):
 - **Correct**: Reinforce with the core principle + why the distinction matters. "Correct — `/gap` surfaces blind spots at *decision points* (what you haven't considered), while `/attend` classifies *execution risks* (what could go wrong when you act). Both happen before action, but they audit different things: decision quality vs. execution safety."
 - **Incorrect**: Explain the distinction through the design axis that separates them. "The key difference is *timing and direction*: `/inquire` catches missing context *before* execution (User→AI: 'what do you need to know?'), while `/contextualize` checks context fit *after* execution (AI→User: 'does this actually fit here?'). Same axis — context fitness — but opposite timing."
@@ -240,19 +223,7 @@ Summarize the learning experience, connect it to the broader epistemic workflow,
 
 2. **Epistemic Map** (connect the dots):
 
-   Present a simplified workflow showing where the experienced protocols sit:
-
-   ```
-   [Intent] → [Goal] → [Delegation] → [Context] → [Perspective] → [Mapping] → [Decision] → [Execution] → [Application] → [Comprehension]
-      ↑          ↑          ↑              ↑            ↑              ↑            ↑             ↑              ↑               ↑
-   /clarify    /goal    /calibrate     /inquire      /frame        /ground        /gap        /attend     /contextualize     /grasp
-   ```
-
-   Highlight the protocols the user experienced with emphasis (e.g., bold or `★`), and briefly explain the flow:
-   - "You tried `/clarify` (Intent) — this is the starting point. Before goals, context, or perspectives matter, intent must be clear."
-   - "You quizzed on `/gap` (Decision) and `/attend` (Execution) — these are neighbors that sound similar but audit different things."
-
-   This gives the user a mental map: "I'm not learning random tools — each protocol has a specific place in a coherent workflow."
+   Present the Epistemic Workflow diagram from `references/workflow.md`. Highlight protocols the user experienced with emphasis (e.g., bold or `★`).
 
 3. **Report CTA**: "Run `/report` for a comprehensive analysis with evidence-backed recommendations and an HTML profile."
 
@@ -262,15 +233,11 @@ Summarize the learning experience, connect it to the broader epistemic workflow,
    - Not installed → `claude plugin install epistemic-protocols/{plugin-name}`
    - If 2+ not installed → also mention `bash scripts/install.sh`
 
-5. **Next protocol suggestion**: Based on quiz results and MAP data, suggest the next protocol to explore — preferring adjacent protocols in the workflow. "You experienced `/clarify` (Intent). The natural next step is `/goal` (Goal) — defining what success looks like. Run `/onboard` again and choose it when ready."
+5. **Next protocol suggestion**: Based on quiz results and MAP data, suggest the next protocol to explore — preferring adjacent protocols in the workflow.
 
 6. **Advanced Usage** (bonus tips after main guide):
 
-   Present 3-5 tips sourced from `references/advanced-usage.md`. Select tips relevant to the protocols the user experienced during this session.
-
-   Refer to `references/advanced-usage.md` for the full curated pattern tables: protocol chaining, multi-protocol sessions, invocation techniques, AskUserQuestion engagement, non-sequential invocation, and composition with built-in commands.
-
-   **Selection rule**: Prioritize tips related to the protocols from TRIAL and QUIZ. For example, if the user tried `/frame`, highlight the Frame → Calibrate chain. If they quizzed on `/gap` vs `/attend`, show the three-step pre-execution chain (inquire → gap → attend).
+   Present 3-5 tips from `references/advanced-usage.md` (protocol chaining, multi-protocol sessions, invocation techniques, etc.), prioritizing tips related to protocols from TRIAL and QUIZ. If the user tried `/frame`, highlight the Frame → Calibrate chain. If they quizzed on `/gap` vs `/attend`, show the three-step pre-execution chain (inquire → gap → attend).
 
 ## Quiz Design
 

--- a/epistemic-cooperative/skills/onboard/references/scenarios.md
+++ b/epistemic-cooperative/skills/onboard/references/scenarios.md
@@ -1,13 +1,15 @@
 # Preset Scenarios
 
 Fallback scenarios for `/onboard` SCENARIO and QUIZ phases when session data is insufficient (Tier 2-3).
-Each protocol has a realistic situation, intervention description, and two quiz questions.
+Each protocol has a realistic situation, intervention description, trial prompt, and two quiz questions.
 
 ## Hermeneia `/clarify`
 
 **Situation**: You tell Claude "Fix the auth flow" but get back a complete rewrite of the login page, including UI changes, session management refactoring, and new error handling — when all you meant was fixing the token refresh bug.
 
 **Intervention**: `/clarify` decomposes the expression "fix the auth flow" into concrete dimensions (scope, target component, success criteria) and surfaces the gap between what you said and what you meant before any code is written.
+
+**Trial prompt**: "Let's practice: tell me 'Fix the auth flow' and I'll show how /clarify decomposes it"
 
 **Quiz Q (situation)**: You asked Claude to "make the dashboard better" and it redesigned the entire layout, added new charts, and refactored the data layer — but you just wanted faster load times.
 - A) Telos `/goal` — B) Hermeneia `/clarify` — C) Syneidesis `/gap` — D) Prothesis `/frame`
@@ -16,13 +18,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You want to request "Refactor the API client" but worry Claude might change the interface contracts. How would you use a protocol to prevent scope overflow?
 - Hint: The issue is your expression doesn't capture your actual boundaries.
 
-**Philosophy**: ἑρμηνεία (interpretation) — Aristotle's treatise on language and meaning. Core principle: **Expression ≠ Intent**. Your words are a lossy compression of your intent; `/clarify` decompresses them before execution begins. Position: first in the epistemic workflow — intent must be clear before goals, context, or perspectives matter. Game feel: "I said X, but I meant Y" → decompose → align → proceed with shared understanding.
+**Philosophy**: ἑρμηνεία (interpretation) — Aristotle's treatise on language and meaning. Core principle: **Expression ≠ Intent**. Your words are a lossy compression of your intent; `/clarify` decompresses them before execution begins. Workflow position: first in the epistemic workflow — intent must be clear before goals, context, or perspectives matter. Game feel: "I said X, but I meant Y" → decompose → align → proceed with shared understanding.
 
 ## Telos `/goal`
 
 **Situation**: You start a session with "I want to improve the search feature" — no success criteria, no metrics, no scope boundary. Claude asks what you mean, you say "just make it better," and three iterations later you've built something nobody needed.
 
 **Intervention**: `/goal` co-constructs a GoalContract by proposing concrete success criteria, scope boundaries, and constraints — transforming "make it better" into "reduce search latency below 200ms for queries under 50 chars, without changing the existing API contract."
+
+**Trial prompt**: "Let's practice: say 'Improve the dashboard' and I'll show how /goal co-constructs success criteria"
 
 **Quiz Q (situation)**: A team member says "Build something for monitoring." No specs, no metrics, no target users defined. You're about to start coding.
 - A) Aitesis `/inquire` — B) Hermeneia `/clarify` — C) Telos `/goal` — D) Epitrope `/calibrate`
@@ -31,13 +35,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You need to "create a notification system" but haven't defined what success looks like. How would you use a protocol to establish clear objectives before implementation?
 - Hint: The problem isn't expression mismatch — it's that the goal itself doesn't exist yet.
 
-**Philosophy**: τέλος (end, purpose) — Aristotle's final cause. Core principle: **Co-construction over Extraction**. The goal doesn't pre-exist in the user's head waiting to be extracted — it's built through dialogue. Position: second in the workflow — once intent is clear, define what success looks like. Game feel: "I know I want something but can't define it" → AI proposes concrete criteria → user shapes → GoalContract emerges.
+**Philosophy**: τέλος (end, purpose) — Aristotle's final cause. Core principle: **Co-construction over Extraction**. The goal doesn't pre-exist in the user's head waiting to be extracted — it's built through dialogue. Workflow position: second in the workflow — once intent is clear, define what success looks like. Game feel: "I know I want something but can't define it" → AI proposes concrete criteria → user shapes → GoalContract emerges.
 
 ## Syneidesis `/gap`
 
 **Situation**: You're about to merge a PR that adds a new API endpoint. The code looks clean, tests pass, but you haven't considered: rate limiting, authentication for the new route, or how it interacts with the existing caching layer.
 
 **Intervention**: `/gap` audits the decision by surfacing procedural gaps (missing review steps), consideration gaps (unexamined dimensions like security), assumption gaps (implicit beliefs about the environment), and alternative gaps (unexplored approaches).
+
+**Trial prompt**: "Let's practice: say 'I'm ready to merge this PR' and I'll show how /gap surfaces blind spots"
 
 **Quiz Q (situation)**: You've finished implementing a database migration script. Tests pass locally. You're about to approve the PR. Something feels off but you can't name it.
 - A) Prosoche `/attend` — B) Syneidesis `/gap` — C) Epharmoge `/contextualize` — D) Aitesis `/inquire`
@@ -46,13 +52,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You're deciding between three architecture options for a new service. You've picked option B. Before committing, how would you check if you're overlooking something?
 - Hint: The issue isn't risk assessment — it's unnoticed blind spots in your decision process.
 
-**Philosophy**: συνείδησις (shared knowing, conscience) — the Stoic inner witness. Core principle: **Surfacing over Deciding**. AI illuminates what you haven't considered; you judge whether it matters. Position: at the decision point — after perspectives are set, before committing. Game feel: "About to commit? Let me check your blind spots" → 4 gap types surface → you address or dismiss → decide with awareness.
+**Philosophy**: συνείδησις (shared knowing, conscience) — the Stoic inner witness. Core principle: **Surfacing over Deciding**. AI illuminates what you haven't considered; you judge whether it matters. Workflow position: at the decision point — after perspectives are set, before committing. Game feel: "About to commit? Let me check your blind spots" → 4 gap types surface → you address or dismiss → decide with awareness.
 
 ## Prothesis `/frame`
 
 **Situation**: You need to evaluate whether to adopt microservices for your monolith. You've been reading blog posts but every perspective seems equally valid — some say split, some say don't, some say it depends.
 
 **Intervention**: `/frame` recommends analytical lenses (e.g., team autonomy, deployment frequency, fault isolation, operational complexity) and can assemble a multi-perspective team to analyze the question from each angle systematically.
+
+**Trial prompt**: "Let's practice: say 'Should we use microservices?' and I'll show how /frame recommends analytical lenses"
 
 **Quiz Q (situation)**: Your team is debating how to handle technical debt. Some want dedicated sprints, others want continuous improvement, others want to rewrite. Everyone has valid points. No one knows which lens to evaluate through.
 - A) Telos `/goal` — B) Prothesis `/frame` — C) Syneidesis `/gap` — D) Epitrope `/calibrate`
@@ -61,13 +69,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You're evaluating three CI/CD tools for your project. Each excels in different dimensions. How would you structure the evaluation to avoid defaulting to the loudest opinion?
 - Hint: The problem isn't missing information or unclear goals — it's not knowing which analytical lens to apply.
 
-**Philosophy**: πρόθεσις (a placing before, setting forth) — the act of laying out options for examination. Core principle: **Recognition over Recall**. You don't need to invent frameworks from scratch — you select from curated lenses. Position: after context is gathered — now choose how to look at the problem. Game feel: "Too many valid angles" → AI recommends lenses → you pick → structured multi-perspective analysis.
+**Philosophy**: πρόθεσις (a placing before, setting forth) — the act of laying out options for examination. Core principle: **Recognition over Recall**. You don't need to invent frameworks from scratch — you select from curated lenses. Workflow position: after context is gathered — now choose how to look at the problem. Game feel: "Too many valid angles" → AI recommends lenses → you pick → structured multi-perspective analysis.
 
 ## Aitesis `/inquire`
 
 **Situation**: You ask Claude to "deploy the staging environment." Claude starts writing Terraform configs, but hasn't asked about: which cloud provider, what region, what instance sizes, whether there's an existing VPC, or what the staging URL convention is.
 
 **Intervention**: `/inquire` detects context insufficiency before execution, prioritizes questions by information gain, and ensures Claude gathers what it needs to know before acting — rather than making assumptions silently.
+
+**Trial prompt**: "Let's practice: say 'Deploy the staging environment' and I'll show how /inquire catches missing context"
 
 **Quiz Q (situation)**: You ask Claude to "set up the CI pipeline for the new repo." Claude immediately starts writing a GitHub Actions workflow without asking about test frameworks, deployment targets, or required checks.
 - A) Hermeneia `/clarify` — B) Aitesis `/inquire` — C) Telos `/goal` — D) Prosoche `/attend`
@@ -76,13 +86,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You're about to ask Claude to migrate your database from Postgres to MySQL. What protocol helps ensure Claude asks the right questions before executing?
 - Hint: Your intent is clear and your goal is defined — but the execution context has unknown dependencies.
 
-**Philosophy**: αἴτησις (a requesting, inquiry) — the act of asking what is needed. Core principle: **Inference over Interrogation**. AI infers what context is missing rather than asking a generic checklist. Position: pre-execution — ensure sufficient context before acting. Game feel: "About to execute? Wait — what don't I know?" → AI surfaces ranked uncertainties → you provide answers → informed execution.
+**Philosophy**: αἴτησις (a requesting, inquiry) — the act of asking what is needed. Core principle: **Inference over Interrogation**. AI infers what context is missing rather than asking a generic checklist. Workflow position: pre-execution — ensure sufficient context before acting. Game feel: "About to execute? Wait — what don't I know?" → AI surfaces ranked uncertainties → you provide answers → informed execution.
 
 ## Epitrope `/calibrate`
 
 **Situation**: You have a team of three Claude agents working on a feature. One is handling frontend, one backend, one tests. But you haven't defined who makes architecture decisions, when to escalate, or what requires your approval versus what they can decide autonomously.
 
 **Intervention**: `/calibrate` produces a Delegation Contract (DC) that specifies WHO decides, WHAT decisions they can make, and HOW MUCH autonomy they have — through scenario-based interview rather than abstract policy setting.
+
+**Trial prompt**: "Let's practice: say 'Handle this refactoring however you think is best' and I'll show how /calibrate sets delegation boundaries"
 
 **Quiz Q (situation)**: You delegate a refactoring task to Claude with "refactor the auth module, use your best judgment." Claude makes sweeping changes — renames interfaces, changes the session model, adds a new dependency — and you wish you'd set boundaries.
 - A) Hermeneia `/clarify` — B) Syneidesis `/gap` — C) Epitrope `/calibrate` — D) Aitesis `/inquire`
@@ -91,13 +103,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You're setting up a multi-agent workflow. How would you define what each agent can decide independently versus what needs your sign-off?
 - Hint: The problem isn't unclear goals or missing context — it's undefined delegation scope.
 
-**Philosophy**: ἐπιτροπή (entrusting, turning over to) — the act of delegating authority. Core principle: **Calibrated Autonomy**. Not "full control" or "full delegation" but a context-specific contract specifying WHO/WHAT/HOW MUCH. Position: after goal is defined — now decide how much to let AI (or agents) do on their own. Game feel: "How much should I trust AI with this?" → scenario-based interview → Delegation Contract → clear boundaries.
+**Philosophy**: ἐπιτροπή (entrusting, turning over to) — the act of delegating authority. Core principle: **Calibrated Autonomy**. Not "full control" or "full delegation" but a context-specific contract specifying WHO/WHAT/HOW MUCH. Workflow position: after goal is defined — now decide how much to let AI (or agents) do on their own. Game feel: "How much should I trust AI with this?" → scenario-based interview → Delegation Contract → clear boundaries.
 
 ## Analogia `/ground`
 
 **Situation**: Claude recommends the "strangler fig pattern" for your monolith migration. The pattern makes sense in theory, but you're unsure how it maps to your specific codebase — which services to extract first, where to draw boundaries, how your shared database fits.
 
 **Intervention**: `/ground` validates the structural mapping between the abstract pattern and your concrete codebase by decomposing the analogy, checking each correspondence, and instantiating with your actual components.
+
+**Trial prompt**: "Let's practice: say 'Apply the strangler fig pattern to our codebase' and I'll show how /ground validates the mapping"
 
 **Quiz Q (situation)**: Claude suggests using the "circuit breaker pattern" for your API. You understand the concept but don't know if your specific service topology and failure modes actually match what the pattern assumes.
 - A) Prothesis `/frame` — B) Katalepsis `/grasp` — C) Analogia `/ground` — D) Aitesis `/inquire`
@@ -106,13 +120,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: Someone says "treat your infrastructure like cattle, not pets." How would you check whether this mental model actually applies to your specific deployment setup?
 - Hint: The advice might be correct in general but structurally mismatched to your context.
 
-**Philosophy**: ἀναλογία (proportion, analogy) — Gentner's Structure Mapping Theory (1983). Core principle: **Structural Correspondence over Abstract Assertion**. An analogy is only as good as its structural match to your domain. Position: after framework is chosen — now validate that abstract advice maps to concrete reality. Game feel: "Sounds right in theory, but does it fit MY code?" → decompose analogy → check each mapping → instantiate with real components.
+**Philosophy**: ἀναλογία (proportion, analogy) — Gentner's Structure Mapping Theory (1983). Core principle: **Structural Correspondence over Abstract Assertion**. An analogy is only as good as its structural match to your domain. Workflow position: after framework is chosen — now validate that abstract advice maps to concrete reality. Game feel: "Sounds right in theory, but does it fit MY code?" → decompose analogy → check each mapping → instantiate with real components.
 
 ## Prosoche `/attend`
 
 **Situation**: You have a plan to restructure the database schema, migrate data, update the ORM, and deploy — all in one go. Each step looks correct individually, but you haven't assessed which steps have cascading risks if they fail.
 
 **Intervention**: `/attend` classifies each task for risk signals (irreversibility, external mutation, security boundaries) and surfaces elevated-risk items for your judgment before execution proceeds.
+
+**Trial prompt**: "Let's practice: say 'Run the migration script' and I'll show how /attend classifies execution risks"
 
 **Quiz Q (situation)**: Claude has generated a 15-step deployment plan. Each step passed review. You're about to run it. You want to know which steps could cause cascading failures.
 - A) Syneidesis `/gap` — B) Prosoche `/attend` — C) Epharmoge `/contextualize` — D) Prothesis `/frame`
@@ -121,13 +137,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: You're about to execute a multi-step infrastructure change. How would you identify which steps carry the highest risk before starting?
 - Hint: The plan itself is sound — the concern is execution-time risk, not decision gaps.
 
-**Philosophy**: προσοχή (attention, vigilance) — the Stoic practice of present-moment awareness during action. Core principle: **Classification over Prevention**. Not trying to prevent all risks — classifying which steps carry elevated risk so you can attend to them. Position: at execution time — plan is approved, now assess which steps need extra care. Game feel: "Plan looks good, let's go" → risk classification → elevated items surface → you decide how to proceed.
+**Philosophy**: προσοχή (attention, vigilance) — the Stoic practice of present-moment awareness during action. Core principle: **Classification over Prevention**. Not trying to prevent all risks — classifying which steps carry elevated risk so you can attend to them. Workflow position: at execution time — plan is approved, now assess which steps need extra care. Game feel: "Plan looks good, let's go" → risk classification → elevated items surface → you decide how to proceed.
 
 ## Epharmoge `/contextualize`
 
 **Situation**: Claude correctly implements a React component with modern hooks and TypeScript. But your project uses React 16 class components, doesn't have TypeScript set up, and the team convention is CSS modules — not the Tailwind Claude used.
 
 **Intervention**: `/contextualize` detects application-context mismatch after execution — where the output is technically correct but doesn't fit the deployment environment, team conventions, or project constraints.
+
+**Trial prompt**: "Let's practice: say 'I just deployed the new component' and I'll show how /contextualize checks environment fit"
 
 **Quiz Q (situation)**: Claude writes a perfect Python script using match statements and walrus operators. Your production environment runs Python 3.8.
 - A) Aitesis `/inquire` — B) Epharmoge `/contextualize` — C) Syneidesis `/gap` — D) Analogia `/ground`
@@ -136,13 +154,15 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: After Claude generates code that works but uses patterns your team doesn't follow, how would you systematically check for environment fit?
 - Hint: The code is correct — the mismatch is between the output and its deployment context.
 
-**Philosophy**: ἐφαρμογή (application, fitting) — Aristotle's practical application. Core principle: **Applicability over Correctness**. Correct code that doesn't fit your context is not useful code. Formal predicate: `correct(R) ∧ ¬warranted(R, X)`. Position: post-execution — after work is done, check if it fits where it's going. Game feel: "Done! ...wait, does this actually fit here?" → mismatch detection → evidence-based surfacing → adapt or dismiss.
+**Philosophy**: ἐφαρμογή (application, fitting) — Aristotle's practical application. Core principle: **Applicability over Correctness**. Correct code that doesn't fit your context is not useful code. Formal predicate: `correct(R) ∧ ¬warranted(R, X)`. Workflow position: post-execution — after work is done, check if it fits where it's going. Game feel: "Done! ...wait, does this actually fit here?" → mismatch detection → evidence-based surfacing → adapt or dismiss.
 
 ## Katalepsis `/grasp`
 
 **Situation**: Claude refactored your authentication module across 12 files — added middleware, changed the session model, updated the database schema, and modified 3 API endpoints. You approved each diff, but you don't actually understand the new flow end-to-end.
 
 **Intervention**: `/grasp` structures comprehension verification through Socratic probes — asking targeted questions about the change, testing edge cases in your understanding, and identifying gaps between "I approved it" and "I understand it."
+
+**Trial prompt**: "Let's practice: I'll describe a complex refactoring, and /grasp will verify your understanding"
 
 **Quiz Q (situation)**: Claude just completed a complex refactoring. All tests pass. You merged it. A teammate asks "how does the new caching layer work?" and you realize you can't explain it.
 - A) Hermeneia `/clarify` — B) Prothesis `/frame` — C) Katalepsis `/grasp` — D) Syneidesis `/gap`
@@ -151,4 +171,4 @@ Each protocol has a realistic situation, intervention description, and two quiz 
 **Quiz Q (design)**: After a large AI-driven change, how would you verify that you actually understand what was done, not just that it works?
 - Hint: The problem isn't that the output is wrong — it's that your comprehension hasn't caught up.
 
-**Philosophy**: κατάληψις (grasping firmly, comprehension) — the Stoic criterion of truth through firm cognitive grasp. Core principle: **Comprehension over Approval**. Approving a diff is not understanding it. Position: structurally last — requires completed AI work; without a result, there is nothing to verify. Game feel: "Tests pass, I approved it... but do I actually understand?" → Socratic probes → test your mental model → verified understanding or identified gaps.
+**Philosophy**: κατάληψις (grasping firmly, comprehension) — the Stoic criterion of truth through firm cognitive grasp. Core principle: **Comprehension over Approval**. Approving a diff is not understanding it. Workflow position: structurally last — requires completed AI work; without a result, there is nothing to verify. Game feel: "Tests pass, I approved it... but do I actually understand?" → Socratic probes → test your mental model → verified understanding or identified gaps.

--- a/epistemic-cooperative/skills/onboard/references/workflow.md
+++ b/epistemic-cooperative/skills/onboard/references/workflow.md
@@ -1,0 +1,7 @@
+# Epistemic Workflow
+
+```
+[Intent] → [Goal] → [Delegation] → [Context] → [Perspective] → [Mapping] → [Decision] → [Execution] → [Application] → [Comprehension]
+   ↑          ↑          ↑              ↑            ↑              ↑            ↑             ↑              ↑               ↑
+/clarify    /goal    /calibrate     /inquire      /frame        /ground        /gap        /attend     /contextualize     /grasp
+```


### PR DESCRIPTION
#125 후속 작업

## Summary

- `/onboard` 퀘스트 기반 체험 학습으로 전면 재설계 — 시나리오 경험 → 시행 실행 → 소크라테스식 퀴즈 흐름
- Phase 0 학습 경로 선택 (Targeted/Standard/Deep Dive) 및 Phase 7 Advanced Usage (hooks.log 기반 고급 팁) 추가
- 교육적 레이어 도입 — 철학적 배경, 워크플로우 위치, 체험 연결을 각 프로토콜 학습에 통합
- 시나리오 품질 기준 강화 (명확한 사례만 시나리오, 모호한 건 퀴즈로 전환)
- 참조 구조 재편: `html-template.md` 제거, `scenarios.md` + `advanced-usage.md` + `workflow.md` 신설
- SKILL.md prose 압축 + 에이전트 description 간소화로 토큰 효율 개선

## Changes

| 영역 | 변경 |
|------|------|
| `skills/onboard/SKILL.md` | Phase 0/7 추가, 교육적 레이어, prose 압축 |
| `references/` | `scenarios.md`, `advanced-usage.md`, `workflow.md` 신설; `html-template.md` 제거 |
| `agents/` | project-scanner, session-analyzer, coverage-scanner description 간소화 |
| `plugin.json` | 버전 업데이트 |
| `CLAUDE.md`, READMEs | /onboard 흐름 설명 동기화 |

## Test Plan

- [x] `/onboard` 실행 → Phase 0 학습 경로 선택지 표시 확인
- [x] Targeted 경로 선택 시 Phase 1-3 skip 확인
- [x] Phase 4 시나리오에 세션 맥락 요약 포함 확인
- [x] Phase 7 Advanced Usage 팁 관련성 확인
- [x] 교육적 레이어 (철학·워크플로우·체험) 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)




