### PR TITLE
feat(verify): onboard co-change 검증 static check 추가

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -1301,6 +1301,132 @@ function checkCrossRefScan() {
 }
 
 // ============================================================
+// Check 11: Onboard Sync (Protocol coverage in onboard materials)
+// ============================================================
+function checkOnboardSync() {
+  const onboardSkillPath = path.join(projectRoot, 'epistemic-cooperative/skills/onboard/SKILL.md');
+  if (!fs.existsSync(onboardSkillPath)) {
+    results.warn.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/skills/onboard/SKILL.md',
+      message: 'Onboard SKILL.md not found, skipping onboard sync check'
+    });
+    return;
+  }
+
+  const onboardContent = fs.readFileSync(onboardSkillPath, 'utf8');
+  let subCheckFailed = false;
+
+  // Build protocol metadata from PROTOCOL_FILES
+  // e.g., 'prothesis/skills/frame/SKILL.md' → { name: 'Prothesis', command: 'frame' }
+  const protocols = PROTOCOL_FILES.map(relPath => {
+    const parts = relPath.split('/');
+    return {
+      name: parts[0].charAt(0).toUpperCase() + parts[0].slice(1),
+      command: parts[2]
+    };
+  });
+
+  // Sub-check 1: Data Sources table — every protocol must have a row
+  for (const { name, command } of protocols) {
+    const pattern = `${name} \`/${command}\``;
+    if (!onboardContent.includes(pattern)) {
+      results.fail.push({
+        check: 'onboard-sync',
+        file: 'epistemic-cooperative/skills/onboard/SKILL.md',
+        message: `Data Sources table missing protocol row: ${pattern}`
+      });
+      subCheckFailed = true;
+    }
+  }
+
+  // Sub-check 2: Protocol count reference matches actual count
+  const expectedCount = protocols.length;
+  if (!onboardContent.includes(`the ${expectedCount} protocols`)) {
+    results.warn.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/skills/onboard/SKILL.md',
+      message: `Protocol count may be stale — expected "the ${expectedCount} protocols"`
+    });
+  }
+
+  // Sub-check 3: Phase 0 category groupings cover all slash commands
+  // (assumes Pre-execution/Analysis/Execution on consecutive lines)
+  const categoryLines = onboardContent.match(/Pre-execution[^\n]*\n[^\n]*Analysis[^\n]*\n[^\n]*Execution[^\n]*/);
+  if (categoryLines) {
+    const categoryText = categoryLines[0];
+    for (const { command } of protocols) {
+      if (!categoryText.includes(`/${command}`)) {
+        results.warn.push({
+          check: 'onboard-sync',
+          file: 'epistemic-cooperative/skills/onboard/SKILL.md',
+          message: `Phase 0 category groupings missing "/${command}"`
+        });
+      }
+    }
+  } else {
+    results.warn.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/skills/onboard/SKILL.md',
+      message: 'Phase 0 category groupings pattern not found — structure may have changed'
+    });
+  }
+
+  // Sub-check 4: scenarios.md — every protocol must have a scenario block
+  const scenariosPath = path.join(projectRoot, 'epistemic-cooperative/skills/onboard/references/scenarios.md');
+  if (fs.existsSync(scenariosPath)) {
+    const scenariosContent = fs.readFileSync(scenariosPath, 'utf8');
+    for (const { name, command } of protocols) {
+      const heading = `## ${name} \`/${command}\``;
+      if (!scenariosContent.includes(heading)) {
+        results.fail.push({
+          check: 'onboard-sync',
+          file: 'epistemic-cooperative/skills/onboard/references/scenarios.md',
+          message: `Missing scenario block: ${heading}`
+        });
+        subCheckFailed = true;
+      }
+    }
+  } else {
+    results.warn.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/skills/onboard/references/scenarios.md',
+      message: 'scenarios.md not found'
+    });
+  }
+
+  // Sub-check 5: workflow.md — all slash commands present
+  const workflowPath = path.join(projectRoot, 'epistemic-cooperative/skills/onboard/references/workflow.md');
+  if (fs.existsSync(workflowPath)) {
+    const workflowContent = fs.readFileSync(workflowPath, 'utf8');
+    for (const { command } of protocols) {
+      if (!workflowContent.includes(`/${command}`)) {
+        results.fail.push({
+          check: 'onboard-sync',
+          file: 'epistemic-cooperative/skills/onboard/references/workflow.md',
+          message: `Missing "/${command}" in workflow diagram`
+        });
+        subCheckFailed = true;
+      }
+    }
+  } else {
+    results.warn.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/skills/onboard/references/workflow.md',
+      message: 'workflow.md not found'
+    });
+  }
+
+  if (!subCheckFailed) {
+    results.pass.push({
+      check: 'onboard-sync',
+      file: 'epistemic-cooperative/',
+      message: `Onboard sync — Data Sources, scenarios, and workflow verified for ${expectedCount} protocols`
+    });
+  }
+}
+
+// ============================================================
 // Run All Checks
 // ============================================================
 try {
@@ -1314,6 +1440,7 @@ try {
   checkGraphIntegrity();
   checkSpecVsImpl();
   checkCrossRefScan();
+  checkOnboardSync();
 
   // Output results as JSON
   console.log(JSON.stringify(results, null, 2));

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,6 +269,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 8. **graph-integrity**: graph.json node/edge validation — edge-type allowlist, edge-reference check, node-directory existence, orphaned node detection (SKILL.md presence), isolated node detection (no edges), precondition DAG acyclicity (Kahn's algorithm)
 9. **spec-vs-impl**: TYPES definitions cross-referenced against PHASE TRANSITIONS and prose — detects rename drift, dead types, and resolution type mismatches
 10. **cross-ref-scan**: Protocol name and deficit → resolution pair consistency across CLAUDE.md and all SKILL.md files, distinction table completeness, graph.json edge type allowlist verification
+11. **onboard-sync**: Onboard SKILL.md Data Sources table, protocol count, Phase 0 category groupings, `references/scenarios.md` scenario blocks, `references/workflow.md` slash commands — all cross-checked against `PROTOCOL_FILES`
 
 ## Delegation Constraint
 
@@ -310,6 +311,6 @@ node .claude/skills/verify/scripts/static-checks.js .
 | Delegation change | SKILL.md (isolation section), CLAUDE.md (delegation constraint) |
 | Any protocol change | `plugin.json` version bump, then `/verify` |
 | New plugin added | `marketplace.json` (plugins array), plugin directory with `plugin.json` |
-| New protocol added | All of the above, plus: CLAUDE.md (overview, architecture, plugins, precedence, workflow, delegation), `static-checks.js` (3 arrays: `aliasToSkill`, `checkRequiredSections`, `checkToolGrounding`), ALL existing SKILL.md (precedence descriptions + distinction tables), README.md + README_ko.md |
+| New protocol added | All of the above, plus: CLAUDE.md (overview, architecture, plugins, precedence, workflow, delegation), `static-checks.js` (`PROTOCOL_FILES`, `PRECEDENCE_FILES`, `CANONICAL_PRECEDENCE`, `CANONICAL_WORKFLOW`, `CANONICAL_PROTOCOLS` in `checkCrossRefScan`), ALL existing SKILL.md (precedence descriptions + distinction tables), onboard (`SKILL.md` Data Sources + `references/scenarios.md` + `references/workflow.md`), README.md + README_ko.md |
 | Precedence change | CLAUDE.md (precedence section + workflow diagram), ALL SKILL.md precedence descriptions |
 | Initiator taxonomy change | CLAUDE.md (initiator taxonomy), ALL SKILL.md (distinction tables + Rule #1), READMEs, `review-checklists.md` |


### PR DESCRIPTION
## Summary

- `static-checks.js`에 Check #11 `onboard-sync` 추가 — onboard SKILL.md, scenarios.md, workflow.md의 프로토콜 커버리지를 `PROTOCOL_FILES` 기반으로 검증
- CLAUDE.md co-change 테이블의 stale `aliasToSkill` 참조를 실제 상수명으로 수정, onboard 파일을 "New protocol added" 행에 추가
- Check #11 문서화 (static checks 목록)

## Checklist

- [x] `checkOnboardSync()` 5개 sub-check 구현 (Data Sources, protocol count, Phase 0 categories, scenarios.md, workflow.md)
- [x] CLAUDE.md co-change 테이블 `PRECEDENCE_FILES` 누락 수정 + `CANONICAL_PROTOCOLS` scope 명시
- [x] `/simplify` 리뷰 반영: sub-check 3 regex 실패 시 silent skip 방지 (else 분기)
- [x] `/review` Episteme 리뷰 반영: pass 메시지 정확성, 코멘트 fragility 문서화

## Test Plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` → 36 pass, 0 fail, 5 warn (기존 warn만)
- [x] 새 프로토콜 추가 시 onboard 미갱신 → fail 3개 발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


