### PR TITLE
feat(aitesis): Phase 1 ctx_web 조건부 WebSearch 추가

### DIFF
--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -63,7 +63,7 @@ narrowing(Q, A) = |remaining(after)| < |remaining(before)| ∨ context(remaining
 early_exit = user_declares_sufficient
 
 ── TOOL GROUNDING ──
-Phase 1 Ctx  (collect)  → Read, Grep (context collection)
+Phase 1 Ctx  (collect)  → Read, Grep (context collection); WebSearch (conditional: environmental dependency)
 Phase 2 Q    (extern)   → AskUserQuestion (mandatory; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3      (state)    → Internal state update
 Phase 0 Scan (infer)    → Internal analysis (no external tool)
@@ -221,7 +221,14 @@ Collect contextual evidence to enrich uncertainty descriptions and improve quest
 
 **Purpose shift**: Context collection aims to ask better questions, not to eliminate them. Evidence enriches the uncertainty description presented in Phase 2, enabling the user to provide more targeted answers.
 
-**Scope restriction**: Read-only investigation only. No API calls, test execution, or file modifications.
+**Web context** (conditional): When uncertainty carries an environmental dependency signal
+(external API versions, library maintenance status, breaking changes),
+extend context collection to web search.
+Web evidence is tagged with `source: "web:{url}"` for traceability.
+Activation condition: `environmental(Uᵢ) ∧ ¬resolved(Uᵢ, codebase)`.
+
+**Scope restriction**: Read-only investigation only. No test execution or file modifications.
+Web search is permitted when activation condition is met.
 
 ### Phase 2: Uncertainty Surfacing
 


### PR DESCRIPTION
## Summary

- Aitesis Phase 1 컨텍스트 수집에 WebSearch 조건부 추가 (v3.1.3 → v3.2.0)
- 환경 의존성 신호(외부 API 버전, 라이브러리 유지보수 상태, 브레이킹 체인지)가 있는 불확실성에 대해 웹 검색으로 컨텍스트 수집 확장
- 기존 `Evidence = { source: String, content: String }` 타입이 `source: "web:{url}"`을 자연스럽게 수용하므로 TYPES 변경 불필요

### 변경 사항

| 위치 | 변경 |
|------|------|
| TOOL GROUNDING | Phase 1 Ctx에 `WebSearch (conditional: environmental dependency)` 추가 |
| Phase 1 prose | Web context 활성화 조건 (`environmental(Uᵢ) ∧ ¬resolved(Uᵢ, codebase)`) + Evidence 태깅 규칙 |
| Scope restriction | "No API calls" 제거 → WebSearch 허용 문구로 조정 |
| plugin.json | `3.1.3` → `3.2.0` (minor: 새 기능) |

### Co-change checklist

- [x] CLAUDE.md — 불필요 (deficit→resolution 변경 없음)
- [x] 다른 SKILL.md distinction table — 불필요 (프로토콜 정체성 변경 없음)
- [x] graph.json — 불필요 (edge 변경 없음)
- [x] static-checks — all pass

## Context

Grounded Detection Phase 1의 일부. Aitesis 불확실성 중 환경 의존성(external API versions, library maintenance status, breaking changes)은 코드베이스만으로 해소되지 않으므로, Phase 1에서 조건부 웹 검색을 허용.

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` — 0 failures
- [x] `/inquire` 실행 시 환경 의존성 불확실성에서 WebSearch 활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
