### PR TITLE
feat(katalepsis): Phase 3 Other→Emergent 등록 경로 추가

### DIFF
--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.16.3",
+  "version": "1.17.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -333,6 +333,12 @@ For each task (category):
 
    Skip if all detected relevant gap types already probed during the verification loop.
 
+3e. **Emergent aspect handling**: When user selects "Other" and describes a comprehension gap
+   not covered by detected canonical gap types:
+   1. Register user's response as Emergent gap type in `Λ.detected[current]`
+   2. Resume step 3 verification with the Emergent gap type as current aspect
+   3. On subsequent coverage check (3d), the Emergent type appears in probed set
+
 4. **On confirmed comprehension**: Per LOOP — TaskUpdate to `completed`, advance to next pending task.
 
 5. **On gap detected**: Handle per step 3c evaluation table. Do not mark complete until user confirms.


### PR DESCRIPTION
## Summary

- Katalepsis Phase 3에 Other→Emergent gap type 등록 경로 추가 (v1.16.3 → v1.17.0)
- AskUserQuestion 내장 Other 옵션이 이미 Emergent 입력 채널 역할을 하므로 presentation 변경 없음
- TYPES/FLOW/MORPHISM/PHASE TRANSITIONS 변경 없음 — prose만 추가

### 변경 사항

| 위치 | 변경 |
|------|------|
| Phase 3 Step 3e (신규) | Other 입력 시 Emergent gap type으로 `Λ.detected[current]`에 등록 → step 3 verification 재개 → 3d coverage check에 probed set 포함 |
| plugin.json | `1.16.3` → `1.17.0` (minor: Emergent 등록 경로 추가) |

### Co-change checklist

- [x] CLAUDE.md — 불필요 (deficit→resolution 변경 없음)
- [x] 다른 SKILL.md distinction table — 불필요 (프로토콜 정체성 변경 없음)
- [x] graph.json — 불필요 (edge 변경 없음)
- [x] static-checks — all pass

## Context

Grounded Detection Phase 1의 일부. `Emergent(C)` 타입은 GT에 이미 정의되어 있으나, AskUserQuestion의 "Other" 입력이 이를 Emergent로 등록하는 경로가 prose에 명시되지 않아 unreachable type이었음. hooks.log 분석: Phase 3d 148회 중 0.7%만 escape hatch 존재, 14.4% free-text bypass.

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` — 0 failures
- [x] `/grasp` 실행 시 Other 선택 → Emergent gap type 등록 + coverage check 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
