### PR TITLE
feat(onboard): Phase/When to Use 이중 레이블로 프로토콜 구분 강화

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Session analytics: /report for usage analysis, /onboard for quest-based protocol learning, /dashboard for coverage dashboard",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epistemic-cooperative/skills/onboard/SKILL.md
+++ b/epistemic-cooperative/skills/onboard/SKILL.md
@@ -42,18 +42,18 @@ Targeted + std: ENTRY → SCENARIO → TRIAL → QUIZ → GUIDE
 
 Compact mapping for inline use. For full Primary/Secondary/Tertiary tables with detection methods and rationale, refer to `/report` SKILL.md.
 
-| Protocol | Key Patterns |
-|----------|-------------|
-| Telos `/goal` | Vague first prompts ("improve", "optimize", "ideas for"), `wrong_approach` friction |
-| Horismos `/bound` | Boundary probe, domain classification, BoundaryMap |
-| Hermeneia `/clarify` | Same file 3+ edits (same intent), `misunderstood_request` friction |
-| Syneidesis `/gap` | Same file 3+ edits (different concerns), `excessive_changes` friction |
-| Prothesis `/frame` | Exploration ratio 3:1+ (Read+Grep+Glob vs Edit+Write) |
-| Prosoche `/attend` | Bash deploy/push/apply keywords, `wrong_file_edited` friction |
-| Katalepsis `/grasp` | Verification keywords in firstPrompt ("explain", "what did you do") |
-| Aitesis `/inquire` | `context_loss` friction |
-| Analogia `/ground` | Abstract pattern application without domain validation |
-| Epharmoge `/contextualize` | Post-execution environment mismatch |
+| Protocol | Phase | When to Use | Key Patterns |
+|----------|-------|-------------|-------------|
+| Hermeneia `/clarify` | Planning | AI keeps misunderstanding your intent | Same file 3+ edits (same intent), `misunderstood_request` friction |
+| Telos `/goal` | Planning | You have a desire but no clear goal | Vague first prompts ("improve", "optimize", "ideas for"), `wrong_approach` friction |
+| Horismos `/bound` | Planning | Deciding what to delegate to AI | Boundary probe, domain classification, BoundaryMap |
+| Aitesis `/inquire` | Planning | AI is about to execute without enough context | `context_loss` friction |
+| Prothesis `/frame` | Analysis | Unsure which analytical perspective to use | Exploration ratio 3:1+ (Read+Grep+Glob vs Edit+Write) |
+| Analogia `/ground` | Analysis | Checking if abstract advice fits your situation | Abstract pattern application without domain validation |
+| Syneidesis `/gap` | Decision | Right before committing, checking for blind spots | Same file 3+ edits (different concerns), `excessive_changes` friction |
+| Prosoche `/attend` | Execution | Controlling risky actions step by step | Bash deploy/push/apply keywords, `wrong_file_edited` friction |
+| Epharmoge `/contextualize` | Verification | Output is correct but doesn't fit the context | Post-execution environment mismatch |
+| Katalepsis `/grasp` | Understanding | You approved AI work but didn't fully understand it | Verification keywords in firstPrompt ("explain", "what did you do") |
 
 ## Phase Execution
 
@@ -63,7 +63,7 @@ Present the protocol catalog as text output FIRST (always), then ask path select
 
 **Protocol Catalog** (always rendered as text before asking):
 
-Before rendering, check installation status: Glob `~/.claude/plugins/cache/epistemic-protocols/*/` to collect installed plugin directory names. Present the 10 protocols from the Data Sources table as a numbered list with name + one-line description + installation badge (`[installed]` or `[not installed]`).
+Before rendering, check installation status: Glob `~/.claude/plugins/cache/epistemic-protocols/*/` to collect installed plugin directory names. Present the 10 protocols from the Data Sources table as a numbered list grouped by Phase, with name + phase label + "When to Use" description + installation badge (`[installed]` or `[not installed]`).
 
 **AskUserQuestion #1**:
 - Text: "Which path?"
@@ -76,9 +76,9 @@ Before rendering, check installation status: Glob `~/.claude/plugins/cache/epist
 **If Targeted + no protocol specified → AskUserQuestion #2**:
 - Text: "Which protocol? (refer to catalog above, type name or number in Other)"
 - Options:
-  - "Pre-execution — /clarify, /goal, /bound, /inquire"
-  - "Analysis — /frame, /ground, /gap"
-  - "Execution — /attend, /contextualize, /grasp"
+  - "Pre-execution (Planning) — /clarify, /goal, /bound, /inquire"
+  - "Analysis/Decision — /frame, /ground, /gap"
+  - "Execution/Verification/Understanding — /attend, /contextualize, /grasp"
 
 **AskUserQuestion #3** (Targeted only, session source):
 - Text: "Where should examples come from?"
@@ -118,7 +118,7 @@ Apply User Context Profile to match protocols to the user's context.
 
 1. **General path**: Match Profile against the compact mapping table (Data Sources section). Select 2-3 protocols most relevant to the user's work domains and conversation patterns, defaulting to Starter Trio.
 2. **Targeted path**: Filter to target protocol, use Profile for scenario personalization. Note related protocols from the compact mapping table.
-3. **Fallback**: If Profile quality is insufficient (no sessions, sparse metadata) → **Starter Trio**: Hermeneia `/clarify`, Telos `/goal`, Syneidesis `/gap`. Proceed immediately without blocking the onboarding flow.
+3. **Fallback**: If Profile quality is insufficient (no sessions, sparse metadata) → **Starter Trio**: Hermeneia `/clarify` (Planning — expression fix), Telos `/goal` (Planning — goal shaping), Syneidesis `/gap` (Decision — blind spot audit). Proceed immediately without blocking the onboarding flow.
 
 For detailed mapping logic (Primary/Secondary/Tertiary tables, session diagnostics, anti-pattern detection), refer to `/report` SKILL.md.
 
@@ -279,6 +279,7 @@ Summarize the learning experience, connect it to the broader epistemic workflow,
 **Difficulty progression**: Start with high-contrast pairs (e.g., `/goal` vs `/attend`), progress to subtle distinctions (e.g., `/clarify` vs `/goal`, `/gap` vs `/attend`).
 
 **Distractor selection**: Choose protocols that share surface similarity with the correct answer:
+- `/clarify` ↔ `/gap`: both surface "something wrong" but different targets — `/clarify` fixes expression before work begins (Planning: "I said X but meant Y"), `/gap` audits blind spots at a decision point (Decision: "Am I overlooking something?")
 - `/clarify` ↔ `/goal`: both about "unclear starting point" but different deficits (expression vs. existence)
 - `/gap` ↔ `/attend`: both about risk awareness but different timing (`/gap` audits before action, `/attend` gates during execution)
 - `/inquire` ↔ `/contextualize`: both about "context" but different timing (pre vs. post execution)

--- a/epistemic-cooperative/skills/onboard/references/scenarios.md
+++ b/epistemic-cooperative/skills/onboard/references/scenarios.md
@@ -18,7 +18,7 @@ Each protocol has a realistic situation, intervention description, trial prompt,
 **Quiz Q (design)**: You want to request "Refactor the API client" but worry Claude might change the interface contracts. How would you use a protocol to prevent scope overflow?
 - Hint: The issue is your expression doesn't capture your actual boundaries.
 
-**Philosophy**: ἑρμηνεία (interpretation) — Aristotle's treatise on language and meaning. Core principle: **Expression ≠ Intent**. Your words are a lossy compression of your intent; `/clarify` decompresses them before execution begins. Workflow position: first in the epistemic workflow — intent must be clear before goals, context, or perspectives matter. Game feel: "I said X, but I meant Y" → decompose → align → proceed with shared understanding.
+**Philosophy**: ἑρμηνεία (interpretation) — Aristotle's treatise on language and meaning. Core principle: **Expression ≠ Intent**. Your words are a lossy compression of your intent; `/clarify` decompresses them before execution begins. Workflow position: first in the epistemic workflow (Planning phase) — intent must be clear before goals, context, or perspectives matter. Game feel: "I said X, but I meant Y" → decompose → align → proceed with shared understanding.
 
 ## Telos `/goal`
 
@@ -69,7 +69,7 @@ Each protocol has a realistic situation, intervention description, trial prompt,
 **Quiz Q (design)**: You're deciding between three architecture options for a new service. You've picked option B. Before committing, how would you check if you're overlooking something?
 - Hint: The issue isn't risk assessment — it's unnoticed blind spots in your decision process.
 
-**Philosophy**: συνείδησις (shared knowing, conscience) — the Stoic inner witness. Core principle: **Surfacing over Deciding**. AI illuminates what you haven't considered; you judge whether it matters. Workflow position: at the decision point — after perspectives are set, before committing. Game feel: "About to commit? Let me check your blind spots" → 4 gap types surface → you address or dismiss → decide with awareness.
+**Philosophy**: συνείδησις (shared knowing, conscience) — the Stoic inner witness. Core principle: **Surfacing over Deciding**. AI illuminates what you haven't considered; you judge whether it matters. Workflow position: at the decision point (Decision phase) — after perspectives are set, before committing. Game feel: "About to commit? Let me check your blind spots" → 4 gap types surface → you address or dismiss → decide with awareness.
 
 ## Prothesis `/frame`
 

--- a/epistemic-cooperative/skills/onboard/references/workflow.md
+++ b/epistemic-cooperative/skills/onboard/references/workflow.md
@@ -4,4 +4,5 @@
 [Intent] → [Goal] → [Boundary] → [Context] → [Perspective] → [Mapping] → [Decision] → [Execution] → [Application] → [Comprehension]
    ↑          ↑          ↑            ↑             ↑              ↑            ↑             ↑              ↑               ↑
 /clarify    /goal      /bound      /inquire      /frame        /ground        /gap        /attend     /contextualize     /grasp
+    |----------- Planning -----------|              |-- Analysis --|         Decision     Execution     Verification  Understanding
 ```

--- a/prosoche/.claude-plugin/plugin.json
+++ b/prosoche/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prosoche",
   "description": "Evaluate execution-time risks during AI operations — /attend (προσοχή: attention)",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -167,6 +167,15 @@ Phase 3 A            (state)   → Internal state update (no external tool)
 Task completion      (state)   → TaskUpdate (status tracking) [Tool]
 Withdraw shutdown    (extern)  → SendMessage (shutdown_request to team members) [Tool]
 
+── ELIDABLE CHECKPOINTS ──
+Phase -1 confirm (cold start)   → elidable when: user_invoked ∧ specific_args(C.args)
+                                   default: accept materialized task list
+                                   regret: bounded (Phase 0 Classify provides independent risk check)
+Phase -1 conflict (tasks+prior) → always_gated (classificatory: resume vs refresh vs merge)
+Phase -1 TeamCoord (team)       → always_gated (classificatory: team structure selection)
+Phase -1 Augment (roles)        → always_gated (classificatory: role confirmation)
+Phase 2 Q (checkpoint)          → always_gated (constitutive: execution risk judgment)
+
 ── MODE STATE ──
 Λ = { phase: Phase, E: ExecutionAction,
        granularity: Granularity, state: Σ,
@@ -296,6 +305,7 @@ Materialize execution intent into a concrete task list and resolve team structur
    - **Conflict** (`C.tasks ≠ ∅` + `C.prior`): **Call AskUserQuestion** 1x — resume existing tasks, refresh from prior, or merge
    - **Auto-proceed** (`C.prior` exists, no tasks): Create tasks from prior protocol output, skip confirmation — intent already verified by upstream protocols. Longer protocol chains (e.g., Telos → Aitesis → Prosoche) carry more accumulated verification
    - **Confirm** (neither): Create tasks from arguments, **call AskUserQuestion** 1x to verify task list — cold start without prior context
+   **Elidable confirmation**: The `confirm` path AskUserQuestion may be elided when `C.args` provides specific execution intent (e.g., `/attend "push changes and deploy"`). Phase 0 Classify provides an independent downstream risk check per task, and Withdraw is available at every Phase 2 checkpoint. Elision does not apply to conflict, TeamCoord, or Augment paths (classificatory).
 3. **Create tasks** via TaskCreate, establishing the task list that Phase 0 will iterate
 4. If `T[] = ∅` after materialization: deactivate (nothing to classify)
 

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -137,6 +137,14 @@ G (gather)               → Read, Glob, Grep (targeted context acquisition, gui
 Phase 4 Syn (synthesis)  → Internal operation (no external tool)
 characterize (internal)  → Internal operation (perspective count tier classification)
 
+── ELIDABLE CHECKPOINTS ──
+Phase 0 Q (MB+mode)     → elidable when: user_invoked ∧ explicit_arg(U)
+                           default: (Q1=confirm, Q2=ai_recommended_mode)
+                           regret: bounded (Phase 2 S always gated; J_mb=modify on re-invoke)
+Phase 2 S (perspective)  → always_gated (classificatory: lens selection is epistemic choice)
+Phase 4 Q (routing)      → always_gated (constitutive: loop path + team lifecycle)
+PF Q (preserve)          → always_gated (constitutive: knowledge preservation scope)
+
 ── CATEGORICAL NOTE ──
 ∩ = meet (intersection) over comparison morphisms between perspective outputs
 D = join (union of distinct findings) where perspectives diverge
@@ -207,6 +215,8 @@ Consult `references/conceptual-foundations.md` for design rationale (Plan Mode I
 Construct a Mission Brief from the user's request and **call the AskUserQuestion tool** to confirm it.
 
 **Do NOT skip this phase.** The Mission Brief is the primary context vehicle for teammate spawn prompts — it ensures agent-teams best practice ("give teammates enough context") is structurally guaranteed rather than depending on coordinator inference.
+
+**Elidable confirmation**: When the user explicitly invoked `/frame "text"`, the Phase 0 AskUserQuestion (Q) may be elided — the MB is still constructed from U, but proceeds without user confirmation. AI uses `J_mb=confirm` and `m=ai_recommended_mode` as defaults. Phase 2 S (perspective selection) remains always gated, providing a downstream correction opportunity. Elision does not apply to J=extend re-invocations within an active loop.
 
 The coordinator infers the Mission Brief from U (the user's request):
 


### PR DESCRIPTION
## Summary

- Onboard 유저 피드백 반영: Hermeneia(`/clarify`)와 Syneidesis(`/gap`) 간 혼동 해소
- Data Sources 테이블에 **Phase** + **When to Use** 이중 컬럼 추가 (Recognition over Recall)
- Prosoche/Prothesis에 ELIDABLE CHECKPOINTS formal block 추가

## Changes

### Onboard (epistemic-cooperative v1.5.0)

| Surface | 변경 |
|---------|------|
| Data Sources 테이블 | Phase + When to Use 컬럼 추가, precedence 순 재배열 |
| Phase 0 카테고리 | Planning/Analysis·Decision/Execution·Verification·Understanding 레이블 |
| Quiz Design | `/clarify` ↔ `/gap` confusable pair 추가 |
| Starter Trio | 인라인 위상 레이블 (Planning — expression fix 등) |
| workflow.md | 위상 범위 시각화 행 추가 |
| scenarios.md | Hermeneia/Syneidesis Philosophy에 Planning/Decision phase 레이블 |

### Prosoche v1.2.0 / Prothesis v5.8.0

- ELIDABLE CHECKPOINTS formal block: AskUserQuestion 생략 조건 명시
- `elidable when` (조건부 생략) vs `always_gated` (항상 필수) 분류

## Design Decision (via Analogia grounding)

원래 "계획/실행" 한국어 레이블 제안 → Analogia로 검증 → **위상 레이블 + 상황 설명** 이중 구조로 수정:
- 위상 레이블 (Planning/Decision): 빠른 시각적 분류 (scanning)
- When to Use: 구체적 상황 매칭 (Recognition over Recall)

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` — 42/42 pass, 0 fail, 0 warn
- [ ] `/onboard` 실행 — Phase 0 카탈로그에서 Phase별 그루핑 확인
- [ ] `/onboard` Targeted path — Quiz에서 `/clarify` ↔ `/gap` distractor pair 출현 확인
- [x] Starter Trio fallback — 위상 레이블 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

