### PR TITLE
feat(*): Full Taxonomy Confirmation — PAR 패턴 Kind Purification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,162 +71,50 @@ epistemic-protocols/
 - References directory: `skills/*/references/` for detailed documentation (optional per plugin)
 - No external dependencies; Node.js standard library only
 
-**SKILL.md Formal Block Anatomy** (all protocols share this structure within `Definition` code block):
-```
-── FLOW ──              Protocol path formula (multi-line for multi-mode protocols)
-── MORPHISM ──          (if applicable) Essential type transition skeleton: requires/deficit/preserves/invariant
-── TYPES ──             Symbol definitions with type signatures and comments
-── ENTRY TYPES ──       (if applicable) Extended types for entry modes
-── DELEGATION TYPES ──  (if applicable) Extended types for delegation structure
-── *-BINDING ──         (if applicable) Input binding resolution rules (U-BINDING, E-BINDING, G-BINDING)
-── PHASE TRANSITIONS ── Phase-by-phase state transitions; [Tool] suffix marks external operations
-── LOOP ──              Post-phase control flow (J values → next phase or terminal)
-── BOUNDARY ──          (if applicable) Purpose annotations for key operations
-── TOOL GROUNDING ──    Symbol → concrete Claude Code tool mapping
-── ELIDABLE CHECKPOINTS ──  (if applicable) Per-gate dual-axis analysis (Qc/Qs answer space + regret profile)
-── CATEGORICAL NOTE ──  (if applicable) Mathematical notation definitions
-── MODE STATE ──        Runtime state type (Λ) with nested state types
-```
-Static checks (`structure`, `tool-grounding`) validate this anatomy. New phases must appear in PHASE TRANSITIONS with `[Tool]` suffix AND in TOOL GROUNDING with concrete tool mapping. Gate operations use Qc/Qs kind suffix in operation names (e.g., `Qc (extern)`).
-
-**FLOW-MORPHISM relationship**: MORPHISM is the image of FLOW under a forgetful functor that discards computational detail and tool annotations, retaining only the essential type transition skeleton (source object → transformation steps → target object) with structural annotations (requires/deficit/preserves/invariant).
+**SKILL.md Formal Block Anatomy**: FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, LOOP, TOOL GROUNDING, ELIDABLE CHECKPOINTS, MODE STATE (and optional blocks). Details: [docs/design-philosophy.md](docs/design-philosophy.md#skillmd-formal-block-anatomy)
 
 ## Plugins
 
-### Frame (πρόθεσις) — Prothesis
-Resolve absent frameworks by recommending analytical lenses (Mode 1) or assembling a team for multi-perspective inquiry (Mode 2).
-- **Deficit**: FrameworkAbsent → FramedInquiry
-- **Triggers**: Purpose present but approach unspecified; multiple valid frameworks exist
-- **Invocation**: `/frame` or use "frame" in conversation
+| Protocol | Slash | Deficit → Resolution |
+|----------|-------|----------------------|
+| Prothesis | `/frame` | FrameworkAbsent → FramedInquiry |
+| Syneidesis | `/gap` | GapUnnoticed → AuditedDecision |
+| Hermeneia | `/clarify` | IntentMisarticulated → ClarifiedIntent |
+| Katalepsis | `/grasp` | ResultUngrasped → VerifiedUnderstanding |
+| Telos | `/goal` | GoalIndeterminate → DefinedEndState |
+| Horismos | `/bound` | BoundaryUndefined → DefinedBoundary |
+| Aitesis | `/inquire` | ContextInsufficient → InformedExecution |
+| Analogia | `/ground` | MappingUncertain → ValidatedMapping |
+| Prosoche | `/attend` | ExecutionBlind → SituatedExecution |
+| Epharmoge | `/contextualize` | ApplicationDecontextualized → ContextualizedExecution |
 
-### Gap (συνείδησις) — Syneidesis
-Surface unnoticed gaps at decision points as questions.
-- **Deficit**: GapUnnoticed → AuditedDecision
-- **Triggers**: Committed action detected with observable, unaddressed gaps
-- **Invocation**: `/gap` or use "gap" in conversation
-
-### Clarify (ἑρμηνεία) — Hermeneia
-Clarify intent-expression gaps through hybrid-initiated dialogue.
-- **Deficit**: IntentMisarticulated → ClarifiedIntent
-- **Triggers**: "clarify", "what I mean", "did I express this right"; also AI-detected trigger for expression ambiguity (requires user confirmation)
-- **Invocation**: `/clarify` or use "clarify" in conversation
-
-### Grasp (κατάληψις) — Katalepsis
-Achieve certain comprehension of AI work through structured verification.
-- **Deficit**: ResultUngrasped → VerifiedUnderstanding
-- **Triggers**: "explain this", "what did you do?", "help me understand"
-- **Invocation**: `/grasp` or use "grasp" in conversation
-
-### Goal (τέλος) — Telos
-Co-construct defined goals from vague intent through AI-proposed, user-shaped dialogue.
-- **Deficit**: GoalIndeterminate → DefinedEndState
-- **Triggers**: "not sure what I want", "something like", "ideas for", exploratory framing
-- **Invocation**: `/goal` or use "goal" in conversation
-
-### Bound (ὁρισμός) — Horismos
-Define epistemic boundaries per decision through AI-guided detection.
-- **Deficit**: BoundaryUndefined → DefinedBoundary
-- **Triggers**: Task scope with undefined ownership, "should I decide this or you?", boundary-undefined domains detected
-- **Invocation**: `/bound` or use "bound" in conversation
-
-### Inquire (αἴτησις) — Aitesis
-Context sufficiency sensor + factual resolver + epistemic router. Senses multi-dimensional context insufficiency (factual, coherence, relevance), self-resolves factual dimensions via read-only verification and empirical probes, and routes non-factual dimensions to downstream protocols.
-- **Deficit**: ContextInsufficient → InformedExecution
-- **Triggers**: Context insufficiency heuristics (ambiguous execution scope, external dependency, implicit requirements)
-- **Invocation**: `/inquire` or use "inquire" in conversation
-
-### Ground (ἀναλογία) — Analogia
-Validate structural mapping between abstract and concrete domains through AI-guided detection.
-- **Deficit**: MappingUncertain → ValidatedMapping
-- **Triggers**: Abstract framework applied without domain-specific validation; cross-domain analogy; grounding probe ("concrete example", "how does this apply", "show me in my context")
-- **Invocation**: `/ground` or use "ground" in conversation
-
-### Attend (προσοχή) — Prosoche
-Route upstream epistemic deficits, materialize execution intent, classify risk signals, coordinate team delegation, and gate elevated-risk findings for user review.
-- **Deficit**: ExecutionBlind → SituatedExecution
-- **Triggers**: User declares execution intent via `/attend`
-- **Invocation**: `/attend` or use "attend" in conversation
-
-### Contextualize (ἐφαρμογή) — Epharmoge
-Detect application-context mismatch after execution when correct output may not fit context.
-- **Deficit**: ApplicationDecontextualized → ContextualizedExecution
-- **Triggers**: Post-execution applicability heuristics (environment assumption, convention mismatch, scope overflow)
-- **Invocation**: `/contextualize` or use "contextualize" in conversation
-- **Status**: Conditional — requires Aitesis operational experience
-
-### Epistemic Cooperative (Report + Onboard + Dashboard + Preferences + Catalog)
-Utility skill group for session analytics, configuration, and reference.
-- **Catalog** `/catalog`: Protocol handbook — instant reference for when to use each protocol. No args = cluster-grouped overview, cluster/protocol arg = detail card from scenarios.md. No gates — pure text output.
-- **Report** `/report`: Generate Growth Map — orthogonal epistemic analysis (protocol adoption patterns, coverage gaps, anti-patterns) using `/insights` data as targeting input. Output: HTML artifact (`growth-map.html`); falls back to Epistemic Profile when insights unavailable.
-- **Onboard** `/onboard`: Quick recommendation from recent sessions, or quest-based learning through scenario, trial, and quiz. Flow: Quick Proof (Entry → QuickScan → Pick-1 → Evidence → Trial → Insight → Next), Targeted (Entry → QuickScan → Map → Scenario → Trial → Quiz → Guide), Targeted + std (Entry → Scenario → Trial → Quiz → Guide). Phase 0 selects path (quick default); Onboarding Pool (`/goal`, `/gap`, `/frame`) serves both Quick auto-recommend and Targeted fallback; pool exhaustion in Quick path transitions to Targeted.
-- **Dashboard** `/dashboard`: Full-session coverage dashboard with friction mapping, growth timeline, achievements, and quality score. Flow: Collect → Aggregate → Analyze → Present. Phase 2 uses `coverage-scanner` subagent for batch aggregation.
-- **Preferences** `/preferences`: Protocol preference initialization with defaults, stored in `.claude/rules/` with user/project scope selection. Individual modifications via `/memory`. Flow: Detect → Initialize → Write.
-
-### Reflexion
-Extract insights from Claude Code sessions into persistent memory.
-- **Flow**: Session → Context → ∥Extract → Select → Integrate → Verify
-- **Key**: Phase 2 uses parallel agents (`session-summarizer`, `insight-extractor`, `knowledge-finder`)
-- **References**: `skills/reflexion/references/` for detailed workflows
-
-### Write
-Transform session insights into blog posts through multi-perspective analysis.
-- **Flow**: `Frame → Format → Write → Refine → Gap → Finalize`
-- **Key**: Integrates both protocols—Prothesis for perspective selection, Syneidesis for gap validation
-
-### Verify (Project-level)
-Pre-commit protocol verification via static checks and expert review.
-- **Location**: `.claude/skills/verify/`
-- **Invocation**: `/verify` before commits
+**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/dashboard`, `/preferences`), Reflexion (`/reflect`), Write (`/write`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
 
 ## Core Principles
 
 - **Recognition over Recall**: Options to select, not blanks to fill
-- **Detection with user authority**: AI detects and presents with evidence; user retains decision authority (confirm/add/remove)
+- **Detection with user authority**: AI detects and presents with evidence; user retains decision authority (proceed/revise)
 - **Surfacing over Deciding**: AI illuminates, user judges
 - **Convergence Persistence**: Modes active until convergence
 - **Priority Override**: Active protocols supersede default behaviors
 
 ## Design Philosophy
 
-**Unix Philosophy Homomorphism**: Each protocol is a single-purpose epistemic tool. Composition is bottom-up — users invoke protocols for recognized cost situations, not follow a prescribed pipeline. The precedence order below is a logical default for multi-activation, not a mandatory sequence.
+Detailed rationale: [docs/design-philosophy.md](docs/design-philosophy.md)
 
-**Session Text Composition**: Inter-protocol data flows as natural language in the session context — no structured data channels between protocols. Each protocol's output becomes part of the conversation that subsequent protocols naturally read. Cell-based structured transport was considered and rejected: structuring context loses information. If structured transport becomes necessary, functor composition is the escalation path.
-
-**Dual Advisory Layer**: Inter-protocol guidance operates through two distinct mechanisms at different abstraction levels: graph.json `advisory` edges (structural, validated by static checks, topology-aware) and Post-Convergence Suggestions (heuristic, session-context-dependent, deficit-condition-driven). These are complementary, not redundant — graph.json edges encode stable architectural relationships, while Post-Convergence suggestions respond to runtime session state. Suggestion targets may overlap with or diverge from graph.json edges; neither system constrains the other.
-
-**Coexistence over Mirroring**: Protocols coexist with Claude Code built-in commands (`/simplify`, `/batch`) as orthogonal tools occupying different layers:
-
-| Layer | Concern | Tools |
-|-------|---------|-------|
-| Epistemic | "Are we doing the right thing?" | Protocols (`/clarify`, `/goal`, `/inquire`, `/gap`, ...) |
-| Execution | "Are we doing it correctly?" | Built-ins (`/batch`, `/simplify`) |
-| Verification | "Did we understand?" | Protocol (`/grasp`) |
-
-Do not mirror built-in execution capabilities (e.g., worktree isolation, PR creation) into protocol definitions. Do not absorb protocol epistemic concerns into built-in command wrappers. Each system maintains its own responsibility boundary, exchanging results at handoff points only.
-
-**Three-Tier Termination**: Protocol exit follows a graduated taxonomy based on side-effect presence:
-
-| Tier | Mechanism | Cleanup | Scope |
-|------|-----------|---------|-------|
-| `user_esc` | Esc key at gate (tool-level or free-response turn) | None (ungraceful) | All protocols — universal |
-| `user_withdraw` | Explicit gate option | Yes (team shutdown, partial state) | Protocols with side-effect state only |
-| Normal convergence | Completion predicate | Full | Per-protocol |
-
-Principle: side effects require explicit answer types, not tool-level escape. When termination has consequences (team cleanup, partial contract), the exit path must be a selectable option the agent can act on. Protocols without termination side effects need only `user_esc`. Circular protocol interactions (e.g., boundary redefinition loops) are healthy dialogue — `user_esc` guarantees termination at every moment.
-
-**Audience Reach**: CLAUDE.md principles guide contributors (protocol designers). End users receive only SKILL.md content via the plugin system. For a principle to affect runtime protocol behavior, it must be structurally embedded in SKILL.md — documenting it in CLAUDE.md alone is insufficient.
-
-**Adversarial Protocol Design**: Each protocol must anticipate how an AI agent might shortcut or rationalize away from faithful execution, and include structural guards in Rules and Phase prose. Formal specification guarantees definitional consistency; adversarial design guarantees execution fidelity. Common rationalization paths: premature convergence assertion, silent detection dismissal, skipping gate interaction entirely (presenting content without yielding turn for response), collapsing Qs gates to plain acknowledgment. These are orthogonal concerns — a protocol can be formally correct yet routinely circumvented.
-
-**Deficit Empiricism**: Protocol creation must be grounded in observed deficit instances (N≥3) from actual sessions. Theoretical deficit classification alone is insufficient justification — the deficit must have demonstrably caused cost (wasted effort, wrong direction, missed consideration) in practice. This grounds the type system in empirical evidence rather than a priori categorization.
-
-**Convergence Evidence**: Protocol convergence must be demonstrated, not asserted. At convergence, the agent must present a transformation trace mapping each identified deficit instance to its resolution — the MORPHISM instantiated at the concrete level. "All gaps resolved" or "goal defined" as bare assertion without per-item evidence = protocol violation.
-
-**Structural Idempotency**: Same protocol definition must produce the same epistemic outcome regardless of interaction realization (tool call, text+stop, future client). Protocol specifications define gate semantics (what to present, what response constitutes), not tool mechanics. A gate is: present structured content → yield turn → parse response. The realization layer maps this to concrete tools based on client capabilities and user preferences.
-
-**Pattern over Tool**: The Recognition over Recall principle is a content invariant — the protocol function lies in the structured options pattern, not in the specific tool that renders them. Structured numbered text followed by turn yield satisfies the same epistemic function as an AskUserQuestion tool call. The invariant: user receives structured options with differential implications, and their response is parsed into a typed answer.
-
-**Interaction Kind Factorization**: Every user-facing gate operation factors as G = R(p) ∘ A, where A abstracts the gate (Ep → Abs) and R(p) realizes it for preferences p (Abs → Cl). Gate operations are classified: Qc (classificatory — projection from finite coproduct; user selects from N options) and Qs (constitutive — pushout; user response incorporates new content). Qc has bounded regret by default when elided (correctable at next gate); Qs has unbounded regret (missed user content). Specific Qc gates may carry unbounded regret from downstream irreversibility — expressed via always_gated annotation in ELIDABLE CHECKPOINTS.
+- **Unix Philosophy Homomorphism**: Single-purpose epistemic tools; bottom-up composition
+- **Session Text Composition**: Inter-protocol data flows as natural language in session context
+- **Dual Advisory Layer**: graph.json (structural) + Post-Convergence Suggestions (heuristic)
+- **Coexistence over Mirroring**: Protocols occupy epistemic layer; built-ins occupy execution layer
+- **Three-Tier Termination**: user_esc (ungraceful) / user_withdraw (graceful) / normal convergence
+- **Audience Reach**: CLAUDE.md guides contributors; SKILL.md guides runtime
+- **Adversarial Protocol Design**: Anticipate AI shortcut paths; structural guards in Rules
+- **Deficit Empiricism**: Protocol creation requires N≥3 observed deficit instances
+- **Convergence Evidence**: Demonstrated transformation trace, not bare assertion
+- **Structural Idempotency**: Same definition → same outcome regardless of realization
+- **Pattern over Tool**: Recognition over Recall is content invariant, not tool-dependent
+- **Interaction Kind Factorization**: G = R(p) ∘ A; Qc (classificatory, bounded regret) / Qs (constitutive, unbounded regret)
+- **Full Taxonomy Confirmation**: Finite taxonomy Qc gates present ALL types with status + evidence; Post-Convergence traverses ALL conditions
 
 ## Protocol Precedence
 
@@ -263,15 +151,6 @@ Protocols grouped by primary concern, ordered by activation sequence within each
 - Static checks: `node .claude/skills/verify/scripts/static-checks.js .`
 - Packaging: `node scripts/package.js [--dry-run]` — produces `dist/*.zip` + `dist/release-notes.md`
 
-### Packaging Transformations
-
-`scripts/package.js` applies non-trivial transforms when building release ZIPs:
-- Renames `SKILL.md` → `Skill.md` (marketplace case convention)
-- Strips frontmatter fields: `allowed-tools`, `license`, `compatibility`, `metadata`
-- Overrides descriptions exceeding 200 chars (`frame`, `reflexion`)
-- Excludes `agents/`, `commands/`, README files from ZIPs
-- 500-line guideline per SKILL.md (warns if exceeded)
-
 ### graph.json
 
 Protocol dependency graph at `.claude/skills/verify/graph.json`. Validated by static check `graph-integrity`.
@@ -293,21 +172,7 @@ Run `/verify` before commits. Static checks via:
 node .claude/skills/verify/scripts/static-checks.js .
 ```
 
-**Static checks performed**:
-1. **json-schema**: plugin.json required fields (name, version, description, author), semver format, name format (`/^[a-z][a-z0-9-]*$/`)
-2. **notation**: Unicode consistency (→, ∥, ∩, ∪, ⊆, ∈, ≠ over ASCII fallbacks)
-3. **directive-verb**: `call` (not `invoke`/`use`) for tool instructions
-4. **xref**: Referenced file paths exist in expected locations
-5. **structure**: Required sections in protocol SKILL.md (Definition, Mode Activation, Protocol, Rules, PHASE TRANSITIONS, MODE STATE)
-6. **tool-grounding**: TOOL GROUNDING section present, external operations have `[Tool]` notation in PHASE TRANSITIONS
-7. **version-staleness**: plugin content changed without plugin.json version bump (git-aware, warn level; skips during merge/rebase conflicts; ignores README, LICENSE, .gitignore)
-8. **graph-integrity**: graph.json node/edge validation — edge-type allowlist, edge-reference check, node-directory existence, orphaned node detection (SKILL.md presence), isolated node detection (no edges), precondition DAG acyclicity (Kahn's algorithm)
-9. **spec-vs-impl**: TYPES definitions cross-referenced against PHASE TRANSITIONS and prose — detects rename drift, dead types, and resolution type mismatches
-10. **cross-ref-scan**: Protocol name and deficit → resolution pair consistency across CLAUDE.md and all SKILL.md files, distinction table completeness, graph.json edge type allowlist verification
-11. **onboard-sync**: Onboard SKILL.md Data Sources table, protocol count, Phase 0 category groupings, `references/scenarios.md` scenario blocks, `references/workflow.md` slash commands — all cross-checked against `PROTOCOL_FILES`
-12. **precedence-linear-extension**: Verifies CANONICAL_PRECEDENCE total order is a valid linear extension of graph.json precondition partial order
-13. **partition-invariant**: Verifies MODE STATE pairwise disjoint partition invariants — universe set and partition members exist as MODE STATE fields
-14. **catalog-sync**: Catalog SKILL.md protocol coverage — all protocol names and commands present, count verified against `PROTOCOL_FILES`
+14 static checks: json-schema, notation, directive-verb, xref, structure, tool-grounding, version-staleness, graph-integrity, spec-vs-impl, cross-ref-scan, onboard-sync, precedence-linear-extension, partition-invariant, catalog-sync. Details: [docs/verification.md](docs/verification.md)
 
 ## Delegation Constraint
 
@@ -341,19 +206,4 @@ node .claude/skills/verify/scripts/static-checks.js .
 - `call` for tool references, `present` for gate operations (tool-agnostic verb)
 - Skills frontmatter: `name` (required), `description` (required, quote if contains `:`), `allowed-tools` (optional), `license`, `compatibility`, `metadata`
 
-**Co-change pattern** (protocol modifications require synchronized edits):
-
-| Change | Files to update |
-|--------|----------------|
-| New/modified phase | SKILL.md (formal block + prose) |
-| New tool usage | SKILL.md (PHASE TRANSITIONS `[Tool]` + TOOL GROUNDING entry) |
-| New loop option | SKILL.md (LOOP + terminal phase prose + Rules) |
-| Delegation change | SKILL.md (isolation section), CLAUDE.md (delegation constraint) |
-| Any protocol change | `plugin.json` version bump, then `/verify` |
-| New plugin added | `marketplace.json` (plugins array), plugin directory with `plugin.json` |
-| New skill added to existing plugin | `SKILL.md`, `plugin.json` (version + description), `marketplace.json` description, `package.js` (PLUGINS + FIRST_RELEASE_HIGHLIGHTS), CLAUDE.md (architecture, plugin section, delegation, static checks if applicable) |
-| New protocol added | All of the above, plus: CLAUDE.md (overview, architecture, plugins, precedence, workflow, delegation), `static-checks.js` (`PROTOCOL_FILES`, `PRECEDENCE_FILES`, `CANONICAL_PRECEDENCE`, `CANONICAL_CLUSTERS`, `CANONICAL_PROTOCOLS` in `checkCrossRefScan`), ALL existing SKILL.md (precedence descriptions + distinction tables), onboard (`SKILL.md` Data Sources + `references/scenarios.md` + `references/workflow.md`), catalog SKILL.md, README.md + README_ko.md |
-| Precedence change | CLAUDE.md (precedence section + concern cluster table), ALL SKILL.md precedence descriptions |
-| Initiator taxonomy change | CLAUDE.md (initiator taxonomy), ALL SKILL.md (distinction tables + Rule #1), READMEs, `review-checklists.md` |
-| Post-convergence suggestion pattern change | ALL 10 SKILL.md Post-Convergence sections, plugin.json version bumps |
-| Gate interaction pattern change | ALL SKILL.md Rules + PHASE TRANSITIONS + TOOL GROUNDING + phase prose + plugin.json version bumps |
+Co-change patterns tracked in [docs/co-change.md](docs/co-change.md). Key: any protocol change requires plugin.json version bump + `/verify`.

--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -365,7 +365,7 @@ After integration:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the resolved context changed the execution plan. State in one sentence what shifted (e.g., "Resolved API version targets v2, which changes the migration approach") or note that the original plan proceeds unchanged. This is informational text — not a gate interaction.
 
@@ -374,6 +374,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - `/gap` (GapUnnoticed): Decision gaps in resolved context → suggest gap audit before execution
 - `/frame` (FrameworkAbsent): Framework absent for informed execution → suggest framework recommendation
 - `/ground` (MappingUncertain): Mapping uncertain between context and execution → suggest structural mapping validation
+
 **Dimension-specific routing** (non-factual Uₙ detected in classify):
 
 | Dimension | Candidate Protocols | Selection Criterion |
@@ -390,7 +391,7 @@ Phase 2 classify summary shows the best-matched protocol as routing target.
 - Restate execution plan with resolved context as reference
 - Note any accepted uncertainties carried into execution
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -369,11 +369,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the resolved context changed the execution plan. State in one sentence what shifted (e.g., "Resolved API version targets v2, which changes the migration approach") or note that the original plan proceeds unchanged. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Decision gaps in resolved context → suggest `/gap` (gap audit before execution)
-- Framework absent for informed execution → suggest `/frame` (framework recommendation)
-- Mapping uncertain between context and execution → suggest `/ground` (structural mapping validation)
+- `/gap` (GapUnnoticed): Decision gaps in resolved context → suggest gap audit before execution
+- `/frame` (FrameworkAbsent): Framework absent for informed execution → suggest framework recommendation
+- `/ground` (MappingUncertain): Mapping uncertain between context and execution → suggest structural mapping validation
 **Dimension-specific routing** (non-factual Uₙ detected in classify):
 
 | Dimension | Candidate Protocols | Selection Criterion |

--- a/analogia/.claude-plugin/plugin.json
+++ b/analogia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "analogia",
   "description": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -272,7 +272,7 @@ After integration:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the validated mapping changed the application of the abstract framework. State in one sentence what shifted (e.g., "The Strangler Fig mapping confirmed except for the shared-database component, which requires a different migration strategy") or note that the original mapping was confirmed as structurally sound. This is informational text — not a gate interaction.
 
@@ -287,7 +287,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Summarize validated mapping with confirmed/dismissed correspondences
 - Note any structural limits accepted (where analogy breaks down)
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -276,11 +276,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the validated mapping changed the application of the abstract framework. State in one sentence what shifted (e.g., "The Strangler Fig mapping confirmed except for the shared-database component, which requires a different migration strategy") or note that the original mapping was confirmed as structurally sound. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Decision gaps in validated mapping → suggest `/gap` (gap audit on mapping application)
-- Context insufficiency for mapping execution → suggest `/inquire` (context verification)
-- Mapping reveals indeterminate goals → suggest `/goal` (goal co-construction)
+- `/gap` (GapUnnoticed): Decision gaps in validated mapping → suggest gap audit on mapping application
+- `/inquire` (ContextInsufficient): Context insufficiency for mapping execution → suggest context verification
+- `/goal` (GoalIndeterminate): Mapping reveals indeterminate goals → suggest goal co-construction
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/docs/co-change.md
+++ b/docs/co-change.md
@@ -1,0 +1,18 @@
+# Co-Change Patterns
+
+Protocol modifications require synchronized edits across multiple files. Any protocol change requires `plugin.json` version bump + `/verify`.
+
+| Change | Files to update |
+|--------|----------------|
+| New/modified phase | SKILL.md (formal block + prose) |
+| New tool usage | SKILL.md (PHASE TRANSITIONS `[Tool]` + TOOL GROUNDING entry) |
+| New loop option | SKILL.md (LOOP + terminal phase prose + Rules) |
+| Delegation change | SKILL.md (isolation section), CLAUDE.md (delegation constraint) |
+| Any protocol change | `plugin.json` version bump, then `/verify` |
+| New plugin added | `marketplace.json` (plugins array), plugin directory with `plugin.json` |
+| New skill added to existing plugin | `SKILL.md`, `plugin.json` (version + description), `marketplace.json` description, `package.js` (PLUGINS + FIRST_RELEASE_HIGHLIGHTS), CLAUDE.md (architecture, plugin section, delegation, static checks if applicable) |
+| New protocol added | All of the above, plus: CLAUDE.md (overview, architecture, plugins, precedence, workflow, delegation), `static-checks.js` (`PROTOCOL_FILES`, `PRECEDENCE_FILES`, `CANONICAL_PRECEDENCE`, `CANONICAL_CLUSTERS`, `CANONICAL_PROTOCOLS` in `checkCrossRefScan`), ALL existing SKILL.md (precedence descriptions + distinction tables), onboard (`SKILL.md` Data Sources + `references/scenarios.md` + `references/workflow.md`), catalog SKILL.md, README.md + README_ko.md |
+| Precedence change | CLAUDE.md (precedence section + concern cluster table), ALL SKILL.md precedence descriptions |
+| Initiator taxonomy change | CLAUDE.md (initiator taxonomy), ALL SKILL.md (distinction tables + Rule #1), READMEs, `review-checklists.md` |
+| Post-convergence suggestion pattern change | ALL 10 SKILL.md Post-Convergence sections, plugin.json version bumps |
+| Gate interaction pattern change | ALL SKILL.md Rules + PHASE TRANSITIONS + TOOL GROUNDING + phase prose + plugin.json version bumps |

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -4,7 +4,7 @@ Detailed rationale for each design principle governing epistemic protocols.
 
 ## Unix Philosophy Homomorphism
 
-Each protocol is a single-purpose epistemic tool. Composition is bottom-up — users invoke protocols for recognized cost situations, not follow a prescribed pipeline. The precedence order below is a logical default for multi-activation, not a mandatory sequence.
+Each protocol is a single-purpose epistemic tool. Composition is bottom-up — users invoke protocols for recognized cost situations, not follow a prescribed pipeline. The precedence order (see CLAUDE.md Protocol Precedence) is a logical default for multi-activation, not a mandatory sequence.
 
 ## Session Text Composition
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,0 +1,97 @@
+# Design Philosophy
+
+Detailed rationale for each design principle governing epistemic protocols.
+
+## Unix Philosophy Homomorphism
+
+Each protocol is a single-purpose epistemic tool. Composition is bottom-up — users invoke protocols for recognized cost situations, not follow a prescribed pipeline. The precedence order below is a logical default for multi-activation, not a mandatory sequence.
+
+## Session Text Composition
+
+Inter-protocol data flows as natural language in the session context — no structured data channels between protocols. Each protocol's output becomes part of the conversation that subsequent protocols naturally read. Cell-based structured transport was considered and rejected: structuring context loses information. If structured transport becomes necessary, functor composition is the escalation path.
+
+## Dual Advisory Layer
+
+Inter-protocol guidance operates through two distinct mechanisms at different abstraction levels: graph.json `advisory` edges (structural, validated by static checks, topology-aware) and Post-Convergence Suggestions (heuristic, session-context-dependent, deficit-condition-driven). These are complementary, not redundant — graph.json edges encode stable architectural relationships, while Post-Convergence suggestions respond to runtime session state. Suggestion targets may overlap with or diverge from graph.json edges; neither system constrains the other.
+
+## Coexistence over Mirroring
+
+Protocols coexist with Claude Code built-in commands (`/simplify`, `/batch`) as orthogonal tools occupying different layers:
+
+| Layer | Concern | Tools |
+|-------|---------|-------|
+| Epistemic | "Are we doing the right thing?" | Protocols (`/clarify`, `/goal`, `/inquire`, `/gap`, ...) |
+| Execution | "Are we doing it correctly?" | Built-ins (`/batch`, `/simplify`) |
+| Verification | "Did we understand?" | Protocol (`/grasp`) |
+
+Do not mirror built-in execution capabilities (e.g., worktree isolation, PR creation) into protocol definitions. Do not absorb protocol epistemic concerns into built-in command wrappers. Each system maintains its own responsibility boundary, exchanging results at handoff points only.
+
+## Three-Tier Termination
+
+Protocol exit follows a graduated taxonomy based on side-effect presence:
+
+| Tier | Mechanism | Cleanup | Scope |
+|------|-----------|---------|-------|
+| `user_esc` | Esc key at gate (tool-level or free-response turn) | None (ungraceful) | All protocols — universal |
+| `user_withdraw` | Explicit gate option | Yes (team shutdown, partial state) | Protocols with side-effect state only |
+| Normal convergence | Completion predicate | Full | Per-protocol |
+
+Principle: side effects require explicit answer types, not tool-level escape. When termination has consequences (team cleanup, partial contract), the exit path must be a selectable option the agent can act on. Protocols without termination side effects need only `user_esc`. Circular protocol interactions (e.g., boundary redefinition loops) are healthy dialogue — `user_esc` guarantees termination at every moment.
+
+## Audience Reach
+
+CLAUDE.md principles guide contributors (protocol designers). End users receive only SKILL.md content via the plugin system. For a principle to affect runtime protocol behavior, it must be structurally embedded in SKILL.md — documenting it in CLAUDE.md alone is insufficient.
+
+## Adversarial Protocol Design
+
+Each protocol must anticipate how an AI agent might shortcut or rationalize away from faithful execution, and include structural guards in Rules and Phase prose. Formal specification guarantees definitional consistency; adversarial design guarantees execution fidelity. Common rationalization paths: premature convergence assertion, silent detection dismissal, skipping gate interaction entirely (presenting content without yielding turn for response), collapsing Qs gates to plain acknowledgment. These are orthogonal concerns — a protocol can be formally correct yet routinely circumvented.
+
+## Deficit Empiricism
+
+Protocol creation must be grounded in observed deficit instances (N≥3) from actual sessions. Theoretical deficit classification alone is insufficient justification — the deficit must have demonstrably caused cost (wasted effort, wrong direction, missed consideration) in practice. This grounds the type system in empirical evidence rather than a priori categorization.
+
+## Convergence Evidence
+
+Protocol convergence must be demonstrated, not asserted. At convergence, the agent must present a transformation trace mapping each identified deficit instance to its resolution — the MORPHISM instantiated at the concrete level. "All gaps resolved" or "goal defined" as bare assertion without per-item evidence = protocol violation.
+
+## Structural Idempotency
+
+Same protocol definition must produce the same epistemic outcome regardless of interaction realization (tool call, text+stop, future client). Protocol specifications define gate semantics (what to present, what response constitutes), not tool mechanics. A gate is: present structured content → yield turn → parse response. The realization layer maps this to concrete tools based on client capabilities and user preferences.
+
+## Pattern over Tool
+
+The Recognition over Recall principle is a content invariant — the protocol function lies in the structured options pattern, not in the specific tool that renders them. Structured numbered text followed by turn yield satisfies the same epistemic function as an AskUserQuestion tool call. The invariant: user receives structured options with differential implications, and their response is parsed into a typed answer.
+
+## Interaction Kind Factorization
+
+Every user-facing gate operation factors as G = R(p) ∘ A, where A abstracts the gate (Ep → Abs) and R(p) realizes it for preferences p (Abs → Cl). Gate operations are classified: Qc (classificatory — projection from finite coproduct; user selects from N options) and Qs (constitutive — pushout; user response incorporates new content). Qc has bounded regret by default when elided (correctable at next gate); Qs has unbounded regret (missed user content). Specific Qc gates may carry unbounded regret from downstream irreversibility — expressed via always_gated annotation in ELIDABLE CHECKPOINTS.
+
+## Full Taxonomy Confirmation
+
+When a Qc gate operates on a finite, protocol-owned taxonomy with always_gated annotation, present ALL types with detection status, evidence, and falsification conditions — not only the detected subset behind a generic action verb. The complete assessment enables Recognition (evaluate presented options) over Recall (generate missing options from memory). Design smell: "generic verb hiding finite taxonomy state" — when a gate option label (e.g., "Add type") conceals concrete candidates the AI has already analyzed, creating a Qc/Qs kind impurity (the gate appears classificatory but the sub-step requires constitutive user input). Fix: materialize the full taxonomy, converting mixed Qc/Qs to pure Qc. Applies to: finite type sets with always_gated Qc. Does not apply to: open-ended generation, per-item iteration, or runtime-variable sets. Same principle applies to Post-Convergence Suggestions: traverse ALL listed conditions against session context with explicit status, not only those the AI deems applicable.
+
+## SKILL.md Formal Block Anatomy
+
+All protocols share this structure within `Definition` code block:
+
+```
+── FLOW ──              Protocol path formula (multi-line for multi-mode protocols)
+── MORPHISM ──          (if applicable) Essential type transition skeleton: requires/deficit/preserves/invariant
+── TYPES ──             Symbol definitions with type signatures and comments
+── ENTRY TYPES ──       (if applicable) Extended types for entry modes
+── DELEGATION TYPES ──  (if applicable) Extended types for delegation structure
+── *-BINDING ──         (if applicable) Input binding resolution rules (U-BINDING, E-BINDING, G-BINDING)
+── PHASE TRANSITIONS ── Phase-by-phase state transitions; [Tool] suffix marks external operations
+── LOOP ──              Post-phase control flow (J values → next phase or terminal)
+── BOUNDARY ──          (if applicable) Purpose annotations for key operations
+── TOOL GROUNDING ──    Symbol → concrete Claude Code tool mapping
+── ELIDABLE CHECKPOINTS ──  (if applicable) Per-gate dual-axis analysis (Qc/Qs answer space + regret profile)
+── CATEGORICAL NOTE ──  (if applicable) Mathematical notation definitions
+── MODE STATE ──        Runtime state type (Λ) with nested state types
+```
+
+Static checks (`structure`, `tool-grounding`) validate this anatomy. New phases must appear in PHASE TRANSITIONS with `[Tool]` suffix AND in TOOL GROUNDING with concrete tool mapping. Gate operations use Qc/Qs kind suffix in operation names (e.g., `Qc (extern)`).
+
+### FLOW-MORPHISM Relationship
+
+MORPHISM is the image of FLOW under a forgetful functor that discards computational detail and tool annotations, retaining only the essential type transition skeleton (source object → transformation steps → target object) with structural annotations (requires/deficit/preserves/invariant).

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,33 @@
+# Verification & Packaging
+
+## Static Checks
+
+Run `/verify` before commits. Static checks via:
+```bash
+node .claude/skills/verify/scripts/static-checks.js .
+```
+
+**Static checks performed**:
+1. **json-schema**: plugin.json required fields (name, version, description, author), semver format, name format (`/^[a-z][a-z0-9-]*$/`)
+2. **notation**: Unicode consistency (→, ∥, ∩, ∪, ⊆, ∈, ≠ over ASCII fallbacks)
+3. **directive-verb**: `call` (not `invoke`/`use`) for tool instructions
+4. **xref**: Referenced file paths exist in expected locations
+5. **structure**: Required sections in protocol SKILL.md (Definition, Mode Activation, Protocol, Rules, PHASE TRANSITIONS, MODE STATE)
+6. **tool-grounding**: TOOL GROUNDING section present, external operations have `[Tool]` notation in PHASE TRANSITIONS
+7. **version-staleness**: plugin content changed without plugin.json version bump (git-aware, warn level; skips during merge/rebase conflicts; ignores README, LICENSE, .gitignore)
+8. **graph-integrity**: graph.json node/edge validation — edge-type allowlist, edge-reference check, node-directory existence, orphaned node detection (SKILL.md presence), isolated node detection (no edges), precondition DAG acyclicity (Kahn's algorithm)
+9. **spec-vs-impl**: TYPES definitions cross-referenced against PHASE TRANSITIONS and prose — detects rename drift, dead types, and resolution type mismatches
+10. **cross-ref-scan**: Protocol name and deficit → resolution pair consistency across CLAUDE.md and all SKILL.md files, distinction table completeness, graph.json edge type allowlist verification
+11. **onboard-sync**: Onboard SKILL.md Data Sources table, protocol count, Phase 0 category groupings, `references/scenarios.md` scenario blocks, `references/workflow.md` slash commands — all cross-checked against `PROTOCOL_FILES`
+12. **precedence-linear-extension**: Verifies CANONICAL_PRECEDENCE total order is a valid linear extension of graph.json precondition partial order
+13. **partition-invariant**: Verifies MODE STATE pairwise disjoint partition invariants — universe set and partition members exist as MODE STATE fields
+14. **catalog-sync**: Catalog SKILL.md protocol coverage — all protocol names and commands present, count verified against `PROTOCOL_FILES`
+
+## Packaging Transformations
+
+`scripts/package.js` applies non-trivial transforms when building release ZIPs:
+- Renames `SKILL.md` → `Skill.md` (marketplace case convention)
+- Strips frontmatter fields: `allowed-tools`, `license`, `compatibility`, `metadata`
+- Overrides descriptions exceeding 200 chars (`frame`, `reflexion`)
+- Excludes `agents/`, `commands/`, README files from ZIPs
+- 500-line guideline per SKILL.md (warns if exceeded)

--- a/epharmoge/.claude-plugin/plugin.json
+++ b/epharmoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epharmoge",
   "description": "Detect application-context mismatch after execution — /contextualize (ἐφαρμογή: an application)",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -285,7 +285,7 @@ After adaptation — **re-scan**:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the contextualized result changed the follow-up work. State in one sentence what shifted (e.g., "The adapted deployment target requires updating the CI pipeline configuration") or note that the original result was confirmed as contextually appropriate. This is informational text — not a gate interaction.
 
@@ -300,7 +300,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Summarize contextualized result with applied adaptations
 - Note any environment assumptions that remain unverified
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -289,11 +289,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the contextualized result changed the follow-up work. State in one sentence what shifted (e.g., "The adapted deployment target requires updating the CI pipeline configuration") or note that the original result was confirmed as contextually appropriate. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Comprehension check needed on contextualized result → suggest `/grasp` (verified understanding)
-- Decision gaps revealed by context mismatch resolution → suggest `/gap` (gap audit)
-- Contextualized result requires boundary redefinition → suggest `/bound` (boundary definition)
+- `/grasp` (ResultUngrasped): Comprehension check needed on contextualized result → suggest verified understanding
+- `/gap` (GapUnnoticed): Decision gaps revealed by context mismatch resolution → suggest gap audit
+- `/bound` (BoundaryUndefined): Contextualized result requires boundary redefinition → suggest boundary definition
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/hermeneia/.claude-plugin/plugin.json
+++ b/hermeneia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hermeneia",
   "description": "Clarify intent-expression gaps through dialogue — /clarify (ἑρμηνεία: interpretation)",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -308,6 +308,8 @@ Options:
 
 **Revise sub-step**: On "Revise assessment" selection, user specifies which types to toggle (include previously unselected, exclude previously detected) or describes an emergent gap. Multiple revisions in a single response are supported. After modification, re-present the updated assessment for final confirmation. Phase 1b completes when user selects "Proceed with current assessment."
 
+**Emergent response parsing**: If user provides emergent type content alongside "Proceed with current assessment," treat the emergent content as implicit "Revise assessment" — incorporate the emergent type and re-present the updated assessment. If the content is ambiguous (could be a comment on an existing type rather than a new emergent), ask the user to clarify before proceeding.
+
 **Soft guard**: If user excludes all types from assessment, confirm: "Excluding all gaps terminates clarification. Continue?" If confirmed, `|Gₛ| = 0` → skip Phase 2, evaluate convergence (`|remaining| = 0` in LOOP).
 
 User confirmation determines Gₛ and the clarification strategy in Phase 2. If multiple confirmed, address in priority order (Coherence → Background → Expression → Precision).
@@ -366,7 +368,7 @@ Proceeding with this understanding.
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the clarification changed the downstream action. State in one sentence what shifted (e.g., "The clarified scope narrows implementation to the auth module only") or note that the original expression was confirmed as adequate. This is informational text — not a gate interaction.
 
@@ -381,7 +383,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Restate clarified intent as a reference for downstream work
 - Note any residual ambiguity that was accepted rather than resolved
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/hermeneia/skills/clarify/SKILL.md
+++ b/hermeneia/skills/clarify/SKILL.md
@@ -32,7 +32,7 @@ invariant: Articulation over Assumption
 E  = User's expression (the prompt to clarify)
 Eᵥ = Verified expression (user-confirmed binding)
 Gd = AI-detected gap types ⊆ {Expression, Precision, Coherence, Background} ∪ Emergent(Eᵥ)
-Gₛ = User-confirmed gap types (Gd after confirm/add/remove)
+Gₛ = User-confirmed gap types (from full taxonomy assessment after proceed/revise)
 Q  = Clarification question (via gate interaction)
 A  = User's answer
 Î  = Inferred intent (AI's model of user's goal)
@@ -78,7 +78,7 @@ Convergence evidence: At |remaining| = 0, present transformation trace — for e
 Phase 0 Qc   (extern) → present (AI-detected activation confirmation; ai_strong only)
 Phase 1a Qc  (extern) → present (E confirmation)
 Phase 1b detect (detect) → Internal analysis (gap detection from Eᵥ)
-Phase 1b Qc  (extern) → present (detection confirmation: confirm/add/remove)
+Phase 1b Qc  (extern) → present (full taxonomy assessment: proceed/revise)
 Phase 2 Qs   (extern) → present (clarification options; Esc key → loop termination at LOOP level, not an Answer)
 suggest_only → no tool call (passive suggestion; Λ.active = false)
 integrate    → Internal state update (no external tool)
@@ -278,32 +278,37 @@ Options:
 
 ### Phase 1b: Gap Detection and Confirmation
 
-Analyze Eᵥ to detect applicable gap types, then **present** for user confirmation.
+Analyze Eᵥ to detect applicable gap types, then **present** full taxonomy assessment for user confirmation.
 
 Per Gap Taxonomy above. Apply priority order: Coherence → Background → Expression → Precision. Emergent gaps must satisfy morphism `IntentMisarticulated → ClarifiedIntent`; boundary: intent-expression gap (in-scope) vs. goal definition (→ `/goal`) or execution context (→ `/inquire`).
 
-Present detection results with evidence as text output:
-- Detected gap types in your expression:
-  - **[Type]**: [specific evidence from Eᵥ]
-  - **[Type]**: [specific evidence from Eᵥ]
+Present the full taxonomy assessment as text output — every named type shown with detection status, evidence, and falsification condition for undetected types:
 
-Then **present** to confirm:
+- **Coherence** ✓ detected: [specific evidence from Eᵥ]
+- **Background** — not currently detected: [evidence considered]. Would apply if [falsification condition].
+- **Expression** ✓ detected: [specific evidence from Eᵥ]
+- **Precision** — not currently detected: [evidence considered]. Would apply if [falsification condition].
+- **Emergent**: [If AI detects a potential emergent type: present as named hypothesis with evidence and boundary annotation. Otherwise: "Is there an aspect of your expression that doesn't fit the above categories?"]
+
+Emergent gaps include boundary annotation: "This is an intent-expression gap (Hermeneia scope). Not: goal definition (→ `/goal`) or execution context (→ `/inquire`)"
+
+Then **present**:
 
 ```
-How would you like to proceed with these detected gaps?
+How would you like to proceed?
 
 Options:
-1. **Proceed with these** — start clarification with detected gaps
-2. **Add gap type** — I also notice [type] issues
-3. **Remove gap type** — [type] doesn't apply here
+1. **Proceed with current assessment** — start clarification with detected gaps
+2. **Revise assessment** — toggle any items or describe an emergent gap
 ```
 
-- "Add" and "Remove" options include brief rationale showing why the type was/wasn't detected
-- Emergent gaps include boundary annotation: "This is an intent-expression gap (Hermeneia scope). Not: goal definition (→ `/goal`) or execution context (→ `/inquire`)"
+- Detected types: evidence for why the gap was identified
+- Not-currently-detected types: evidence considered + falsification condition ("would apply if [specific condition]")
+- Evidence parity: each type (detected or not) receives comparable analytical depth
 
-**Add/Remove sub-steps**: On "Add" or "Remove" selection, present via gate interaction to specify which type to add/remove with rationale. After modification, re-present the updated detection result for final confirmation. Phase 1b completes when user selects "Proceed with these."
+**Revise sub-step**: On "Revise assessment" selection, user specifies which types to toggle (include previously unselected, exclude previously detected) or describes an emergent gap. Multiple revisions in a single response are supported. After modification, re-present the updated assessment for final confirmation. Phase 1b completes when user selects "Proceed with current assessment."
 
-**Soft guard**: If user removes all detected gaps, confirm: "Removing all gaps terminates clarification. Continue?" If confirmed, `|Gₛ| = 0` → skip Phase 2, evaluate convergence (`|remaining| = 0` in LOOP).
+**Soft guard**: If user excludes all types from assessment, confirm: "Excluding all gaps terminates clarification. Continue?" If confirmed, `|Gₛ| = 0` → skip Phase 2, evaluate convergence (`|remaining| = 0` in LOOP).
 
 User confirmation determines Gₛ and the clarification strategy in Phase 2. If multiple confirmed, address in priority order (Coherence → Background → Expression → Precision).
 
@@ -365,11 +370,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the clarification changed the downstream action. State in one sentence what shifted (e.g., "The clarified scope narrows implementation to the auth module only") or note that the original expression was confirmed as adequate. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Clarified intent reveals indeterminate goals → suggest `/goal` (goal co-construction)
-- Boundary undefined for clarified decisions → suggest `/bound` (epistemic boundary definition)
-- Clarified scope requires context verification → suggest `/inquire` (context insufficiency check)
+- `/goal` (GoalIndeterminate): Clarified intent reveals indeterminate goals → suggest goal co-construction
+- `/bound` (BoundaryUndefined): Boundary undefined for clarified decisions → suggest epistemic boundary definition
+- `/inquire` (ContextInsufficient): Clarified scope requires context verification → suggest pre-execution context check
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 
@@ -408,7 +413,7 @@ When multiple gaps detected:
 
 1. **Hybrid-initiated, user-confirmed**: Activate on user signal, or with user confirmation when AI detects ambiguous expression
 2. **Recognition over Recall**: Present structured options via gate interaction (Qc/Qs) and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation
-3. **Detection with user authority**: AI detects gap types with evidence; user confirms, adds, or removes (no blind multiSelect, no auto-proceed)
+3. **Detection with user authority**: AI presents full taxonomy assessment — every named type with detection status, evidence, and falsification condition; user confirms or revises (no selective presentation, no auto-proceed)
 4. **Maieutic over Informational**: Frame questions to guide discovery, not merely gather data
 5. **Articulation support**: Help user express what they know, don't guess what they mean
 6. **Minimal questioning**: Surface only gaps that affect execution
@@ -421,3 +426,6 @@ When multiple gaps detected:
 13. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via gate interaction. The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 14. **No premature convergence**: Do not declare |remaining| = 0 without presenting convergence evidence trace. "All gaps resolved" as assertion without per-gap evidence = protocol violation
 15. **No silent gap dismissal**: If detect(Eᵥ) finds no gaps (Gd = ∅), present this finding with reasoning to the user for confirmation before concluding — do not silently proceed
+16. **Full taxonomy assessment**: Phase 1b must present ALL named gap types with detection status and evidence. Presenting only detected types with a generic "Add" option = protocol violation (Recognition over Recall applied to gate content)
+17. **Falsification condition**: Each not-currently-detected type must include "would apply if [specific condition]" — exclusion rationale without falsification condition = protocol violation
+18. **Emergent probe**: Emergent slot must include an active probe question or AI-detected hypothesis with evidence. "No emergent gaps detected" as bare statement without probe = protocol violation

--- a/horismos/.claude-plugin/plugin.json
+++ b/horismos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "horismos",
   "description": "Define epistemic boundaries per decision — /bound (ὁρισμός: a bounding)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/horismos/skills/bound/SKILL.md
+++ b/horismos/skills/bound/SKILL.md
@@ -293,11 +293,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the defined boundaries changed the collaboration approach. State in one sentence what shifted (e.g., "Architecture decisions are now user-spec, which changes delegation scope for the refactoring task") or note that existing assumptions were confirmed. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- AI-spec domains with context insufficiency → suggest `/inquire` (context verification before AI execution)
-- Framework absent for bounded domains → suggest `/frame` (framework recommendation)
-- Decision gaps in boundary-defined scope → suggest `/gap` (gap audit)
+- `/inquire` (ContextInsufficient): AI-spec domains with context insufficiency → suggest context verification before AI execution
+- `/frame` (FrameworkAbsent): Framework absent for bounded domains → suggest framework recommendation
+- `/gap` (GapUnnoticed): Decision gaps in boundary-defined scope → suggest gap audit
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/horismos/skills/bound/SKILL.md
+++ b/horismos/skills/bound/SKILL.md
@@ -289,7 +289,7 @@ After integration:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the defined boundaries changed the collaboration approach. State in one sentence what shifted (e.g., "Architecture decisions are now user-spec, which changes delegation scope for the refactoring task") or note that existing assumptions were confirmed. This is informational text — not a gate interaction.
 
@@ -304,7 +304,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Restate BoundaryMap as a reference for downstream protocols
 - Note any needs-calibration domains deferred for later boundary definition
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -420,7 +420,7 @@ Use:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the verified understanding changed the user's approach. State in one sentence what shifted (e.g., "The user's revised understanding of the caching layer changes the optimization strategy") or note that the original understanding was confirmed as accurate. This is informational text — not a gate interaction.
 
@@ -435,7 +435,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Note any ejected proposals (user-identified areas for future investigation)
 - Summarize verified understanding as reference for subsequent decisions
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -424,11 +424,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the verified understanding changed the user's approach. State in one sentence what shifted (e.g., "The user's revised understanding of the caching layer changes the optimization strategy") or note that the original understanding was confirmed as accurate. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Verified understanding reveals decision gaps → suggest `/gap` (gap audit on understood work)
-- Abstract explanations accepted without grounding → suggest `/ground` (structural mapping validation)
-- Verified understanding reveals intent was actually misarticulated → suggest `/clarify` (re-examine expression-intent alignment)
+- `/gap` (GapUnnoticed): Verified understanding reveals decision gaps → suggest gap audit on understood work
+- `/ground` (MappingUncertain): Abstract explanations accepted without grounding → suggest structural mapping validation
+- `/clarify` (IntentMisarticulated): Verified understanding reveals intent was actually misarticulated → suggest re-examine expression-intent alignment
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/prosoche/.claude-plugin/plugin.json
+++ b/prosoche/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prosoche",
   "description": "Route upstream epistemic deficits and evaluate execution-time risks — /attend (προσοχή: attention)",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -514,7 +514,7 @@ After adaptation:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the execution outcomes changed the remaining plan. State in one sentence what shifted (e.g., "The halted deployment task requires resolving the staging environment issue before proceeding") or note that all tasks completed as planned. This is informational text — not a gate interaction.
 
@@ -529,7 +529,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Summarize halted or gated tasks requiring user follow-up
 - Note any risk signals that were accepted during execution
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -518,11 +518,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the execution outcomes changed the remaining plan. State in one sentence what shifted (e.g., "The halted deployment task requires resolving the staging environment issue before proceeding") or note that all tasks completed as planned. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Post-execution applicability concerns → suggest `/contextualize` (application-context mismatch detection)
-- Scope boundaries shifted during execution → suggest `/bound` (boundary redefinition)
-- Comprehension check needed on execution results → suggest `/grasp` (verified understanding)
+- `/contextualize` (ApplicationDecontextualized): Post-execution applicability concerns → suggest application-context mismatch detection
+- `/bound` (BoundaryUndefined): Scope boundaries shifted during execution → suggest boundary redefinition
+- `/grasp` (ResultUngrasped): Comprehension check needed on execution results → suggest verified understanding
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -453,14 +453,16 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    question: "How would you like to proceed?"
    options:
      - label: "Extend"
-       description: "Add new perspective, deepen existing analysis, or review execution results"
+       description: "[specific proposal grounded in L: which perspective to add or deepen, with rationale from Lens findings]"
      - label: "Add input"
-       description: "Provide additional context for synthesis revision"
+       description: "[specific context gap identified from L that would change synthesis]"
      - label: "Wrap up"
-       description: "Finalize with current Lens"
+       description: "[what the current Lens enables as concrete next steps]"
      - label: "Withdraw"
        description: "Exit with current Lens (team cleanup, no findings preservation)"
    ```
+
+**Routing concreteness**: Each routing option must be grounded in the specific Lens output. Generic descriptions without session-specific rationale fail the Full Taxonomy Confirmation principle — the AI has analyzed the Lens but presents generic action labels instead of concrete proposals. Exception: "Withdraw" retains its fixed description (no session-specific content needed for exit).
 
 **If no triggers**: Proceed to synthesis (step 6) with brief justification (e.g., "No contradictions, horizon intersections, or uncorroborated high-stakes findings detected"), then user review (step 7).
 
@@ -501,17 +503,14 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the selected perspectives changed the analytical approach. State in one sentence what shifted (e.g., "The security perspective revealed attack surface concerns that narrow the implementation options") or note that the original approach was confirmed from all selected viewpoints. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Mode 2: L.divergence reveals unaddressed tensions → suggest `/gap` (gap audit on divergent findings)
-- Mode 2: L.assessment reveals indeterminate goals → suggest `/goal` (goal co-construction from Lens insights)
-- Mode 2: L.assessment contains abstract framework without domain-specific validation → suggest `/ground` (structural mapping validation)
-- Mode 2: L.assessment contains actionable execution items with risk dimensions → suggest `/attend` (execution-time risk evaluation before acting on Lens findings)
-- Mode 2: L.divergence reveals undefined epistemic boundaries → suggest `/bound` (epistemic boundary definition before proceeding)
-- Mode 1: selected perspectives reveal unexplored domain tensions → suggest `/gap` (gap audit on perspective coverage)
-- Mode 1: inquiry intent suggests indeterminate goals → suggest `/goal` (goal co-construction before deeper analysis)
-- Mode 1: selected perspectives use abstract frameworks in user's specific domain → suggest `/ground` (structural mapping validation)
-- Context insufficiency surfaced during session → suggest `/inquire` (pre-execution context verification)
+- `/gap` (GapUnnoticed): Mode 2: L.divergence reveals unaddressed tensions; Mode 1: selected perspectives reveal unexplored domain tensions → suggest gap audit
+- `/goal` (GoalIndeterminate): Mode 2: L.assessment reveals indeterminate goals; Mode 1: inquiry intent suggests indeterminate goals → suggest goal co-construction
+- `/ground` (MappingUncertain): Mode 2: L.assessment contains abstract framework without domain-specific validation; Mode 1: selected perspectives use abstract frameworks in user's specific domain → suggest structural mapping validation
+- `/attend` (ExecutionBlind): Mode 2: L.assessment contains actionable execution items with risk dimensions → suggest execution-time risk evaluation before acting on Lens findings
+- `/bound` (BoundaryUndefined): Mode 2: L.divergence reveals undefined epistemic boundaries → suggest epistemic boundary definition before proceeding
+- `/inquire` (ContextInsufficient): Context insufficiency surfaced during session → suggest pre-execution context verification
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 
@@ -533,3 +532,4 @@ After convergence, scan session context for continuing epistemic needs and prese
 8. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via gate interaction. The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 9. **No premature convergence**: Do not declare wrap_up (Mode 2) or recommend terminus (Mode 1) without presenting convergence evidence trace. "User satisfied" as assertion without per-perspective contribution evidence = protocol violation
 10. **No silent framework dismissal**: If Phase 2 generation yields no candidate frameworks, present this finding with reasoning to user for confirmation before concluding — do not silently terminate
+11. **Concrete routing**: Phase 4 routing options must include session-specific rationale derived from L. Generic labels without Lens-grounded content = protocol violation (Full Taxonomy Confirmation principle applied to routing)

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -462,7 +462,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
        description: "Exit with current Lens (team cleanup, no findings preservation)"
    ```
 
-**Routing concreteness**: Each routing option must be grounded in the specific Lens output. Generic descriptions without session-specific rationale fail the Full Taxonomy Confirmation principle — the AI has analyzed the Lens but presents generic action labels instead of concrete proposals. Exception: "Withdraw" retains its fixed description (no session-specific content needed for exit).
+**Routing concreteness**: Each routing option must be grounded in the specific Lens output. Generic descriptions without session-specific rationale fail the concreteness requirement (analogical application of Full Taxonomy Confirmation) — the AI has analyzed the Lens but presents generic action labels instead of concrete proposals. Exception: "Withdraw" retains its fixed description (no session-specific content needed for exit).
 
 **If no triggers**: Proceed to synthesis (step 6) with brief justification (e.g., "No contradictions, horizon intersections, or uncorroborated high-stakes findings detected"), then user review (step 7).
 
@@ -499,11 +499,13 @@ Consult `references/conceptual-foundations.md` for trigger/skip heuristics, Para
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the selected perspectives changed the analytical approach. State in one sentence what shifted (e.g., "The security perspective revealed attack surface concerns that narrow the implementation options") or note that the original approach was confirmed from all selected viewpoints. This is informational text — not a gate interaction.
 
 **Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
+
+Evaluate all conditions regardless of current mode. For inactive-mode conditions, mark as 'not applicable (mode not active)' rather than skipping.
 
 - `/gap` (GapUnnoticed): Mode 2: L.divergence reveals unaddressed tensions; Mode 1: selected perspectives reveal unexplored domain tensions → suggest gap audit
 - `/goal` (GoalIndeterminate): Mode 2: L.assessment reveals indeterminate goals; Mode 1: inquiry intent suggests indeterminate goals → suggest goal co-construction
@@ -518,7 +520,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Mode 2: summarize key findings from L (convergence, divergence, assessment highlights)
 - Mode 2: if findings are execution-ready, note that `/attend` can orchestrate implementation with risk classification
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Rules
 
@@ -532,4 +534,4 @@ After convergence, scan session context for continuing epistemic needs and prese
 8. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via gate interaction. The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 9. **No premature convergence**: Do not declare wrap_up (Mode 2) or recommend terminus (Mode 1) without presenting convergence evidence trace. "User satisfied" as assertion without per-perspective contribution evidence = protocol violation
 10. **No silent framework dismissal**: If Phase 2 generation yields no candidate frameworks, present this finding with reasoning to user for confirmation before concluding — do not silently terminate
-11. **Concrete routing**: Phase 4 routing options must include session-specific rationale derived from L. Generic labels without Lens-grounded content = protocol violation (Full Taxonomy Confirmation principle applied to routing)
+11. **Concrete routing**: Phase 4 routing options must include session-specific rationale derived from L. Generic labels without Lens-grounded content = protocol violation (analogical application of Full Taxonomy Confirmation — session-grounded concreteness over generic labels)

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -275,11 +275,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the gap audit changed the decision. State in one sentence what shifted (e.g., "The backup verification gap led to adding a pre-migration snapshot step") or note that the original plan was confirmed after review. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Context insufficiency behind surfaced gaps → suggest `/inquire` (pre-execution context verification)
-- Boundary undefined for gap-related decisions → suggest `/bound` (epistemic boundary definition)
-- Abstract framework applied without validation → suggest `/ground` (structural mapping validation)
+- `/inquire` (ContextInsufficient): Context insufficiency behind surfaced gaps → suggest pre-execution context verification
+- `/bound` (BoundaryUndefined): Boundary undefined for gap-related decisions → suggest epistemic boundary definition
+- `/ground` (MappingUncertain): Abstract framework applied without validation → suggest structural mapping validation
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -271,7 +271,7 @@ Note: Esc key → unconditional loop termination (LOOP level). Silence (no respo
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the gap audit changed the decision. State in one sentence what shifted (e.g., "The backup verification gap led to adding a pre-migration snapshot step") or note that the original plan was confirmed after review. This is informational text — not a gate interaction.
 
@@ -286,7 +286,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Summarize deferred items (gaps accepted but not yet addressed)
 - Highlight high-stakes gaps that warrant re-review before execution
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/telos/.claude-plugin/plugin.json
+++ b/telos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "telos",
   "description": "Co-construct defined goals from vague intent — /goal (τέλος: end, purpose)",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/telos/skills/goal/SKILL.md
+++ b/telos/skills/goal/SKILL.md
@@ -33,7 +33,7 @@ G   = User's vague goal (the goal to define)
 Gᵥ  = Verified vague goal (user-confirmed)
 Dd  = AI-detected dimensions ⊆ {Outcome, Metric, Boundary, Priority} ∪ Emergent(G)
 Dₛ  = Selected dimension ∈ {Outcome, Metric, Boundary, Priority}
-Dₐ  = Applicable dimensions (user-confirmed subset of Dd, Dₐ ⊇ {Outcome})
+Dₐ  = Applicable dimensions (user-confirmed from full taxonomy assessment, Dₐ ⊇ {Outcome})
 P   = Proposal (AI-generated concrete candidate)
 A   = User's response ∈ {Accept, Modify(aspect, direction), Reject, Extend(aspect)}
 C   = GoalContract { outcome: ?, metric: ?, boundary: ?, priority: ? }
@@ -240,7 +240,7 @@ Analyze Gᵥ to detect indeterminate dimensions, then **present** for user confi
 
 Per Gap Taxonomy above. Apply priority order: Outcome → Boundary → Priority → Metric. Emergent dimensions must satisfy morphism `GoalIndeterminate → DefinedEndState`; boundary: goal definition (in-scope) vs. expression gap (→ `/clarify`) or execution context (→ `/inquire`).
 
-**Outcome constraint**: Outcome is always included in Dₐ regardless of detection — it is a protocol constraint (`|Dₐ| ≥ 1`). If not detected, include with `[protocol constraint]` annotation. **Outcome cannot be removed** via the "Remove" option.
+**Outcome constraint**: Outcome is always included in Dₐ regardless of detection — it is a protocol constraint (`|Dₐ| ≥ 1`). If not detected, include with `[protocol constraint]` annotation. **Outcome cannot be excluded** via "Revise assessment" toggle.
 
 Present the full taxonomy assessment as text output — every named dimension shown with detection status, evidence, and falsification condition for undetected dimensions:
 
@@ -267,6 +267,8 @@ Options:
 - Evidence parity: each dimension (detected or not) receives comparable analytical depth
 
 **Revise sub-step**: On "Revise assessment" selection, user specifies which dimensions to toggle (include previously unselected, exclude previously detected) or describes an emergent dimension. Multiple revisions in a single response are supported. Outcome exclusion is rejected with explanation (protocol constraint: `Dₐ ⊇ {Outcome}`). After modification, re-present the updated assessment for final confirmation. Phase 1 completes when user selects "Proceed with current assessment."
+
+**Emergent response parsing**: If user provides emergent dimension content alongside "Proceed with current assessment," treat the emergent content as implicit "Revise assessment" — incorporate the emergent dimension and re-present the updated assessment. If the content is ambiguous (could be a comment on an existing dimension rather than a new emergent), ask the user to clarify before proceeding.
 
 **Soft guard**: If user excludes all dimensions except Outcome (by protocol constraint), confirm: "Only Outcome will be defined. Continue with minimal GoalContract?" If confirmed, `Dₐ = {Outcome}` → proceed to Phase 2. If declined, re-present assessment for reconsideration.
 
@@ -355,7 +357,7 @@ Options:
 
 ### Post-Convergence Suggestions
 
-After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction). Display only when at least one suggestion is actionable.
+After convergence, scan session context for continuing epistemic needs and present suggestions as natural-language text (no gate interaction).
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the defined goals changed the implementation scope. State in one sentence what shifted (e.g., "The GoalContract's latency requirement eliminates the batch processing approach") or note that the original scope was confirmed by the defined goals. This is informational text — not a gate interaction.
 
@@ -370,7 +372,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 - Restate GoalContract as a reference for downstream work
 - Note any deferred goal dimensions accepted for later refinement
 
-**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) no observable deficit conditions exist in session context, or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
+**Display rule**: Omit this section entirely when (a) user explicitly moved to next task, (b) all conditions evaluate to not applicable (after full traversal — the traversal itself cannot be skipped), or (c) the user has already invoked another protocol in the current or immediately preceding message. Suggestions are informational text, not gate interactions.
 
 ## Intensity
 

--- a/telos/skills/goal/SKILL.md
+++ b/telos/skills/goal/SKILL.md
@@ -78,7 +78,7 @@ early_exit = user_declares_sufficient (any progress level)
 -- Realization: present → TextPresent+Stop (default) | AskUserQuestion (Epistemic Protocol Preferences)
 Phase 0 Qc (extern)  → present (goal confirmation + activation approval)
 Phase 1 detect (detect) → Internal analysis (dimension detection from Gᵥ)
-Phase 1 Qc (extern)  → present (detection confirmation + progress display)
+Phase 1 Qc (extern)  → present (full taxonomy assessment + progress display)
 Phase 2 P  (detect)  → Read, Grep (context for proposal generation; fallback: template)
 Phase 2 Qs (extern)  → present (mandatory; Esc key → loop termination at LOOP level, not a Response)
 Phase 3    (state)   → Internal GoalContract update (no external tool)
@@ -105,7 +105,7 @@ Phase 4 Qc (approve)       → always_gated (Qc: contract approval — final bin
 ## Epistemic Distinction from Requirements Engineering
 
 Telos is not simplified requirements gathering. Three differentiators:
-1. **Detection with user authority**: AI detects indeterminate dimensions with evidence; user confirms, adds, or removes (not elicited by checklist)
+1. **Detection with user authority**: AI presents full taxonomy assessment with evidence and falsification conditions; user confirms or revises (not elicited by checklist)
 2. **Morphism firing**: Activates only when `GoalIndeterminate` precondition is recognized — not a mandatory pipeline stage
 3. **Falsifiable proposals**: AI proposes specific candidates that can be directly accepted or rejected, surfacing value conflicts and trade-offs (epistemic function) rather than collecting specifications (engineering function)
 
@@ -195,7 +195,7 @@ Approved GoalContract becomes input to subsequent protocols.
 
 **Emergent dimension detection**: Named dimensions are working hypotheses, not exhaustive categories. Detect Emergent dimensions when:
 - The goal's indeterminacy spans multiple named dimensions (e.g., outcome and boundary are entangled and cannot be defined independently)
-- User adds a dimension via "Add dimension" that doesn't map to the four named types
+- User includes a dimension via "Revise assessment" that doesn't map to the four named types
 - The goal involves domain-specific concerns that resist decomposition into Outcome/Metric/Boundary/Priority (e.g., stakeholder alignment, phasing/sequencing, risk tolerance)
 
 Emergent dimensions must satisfy morphism `GoalIndeterminate → DefinedEndState` and map to a GoalContract field.
@@ -242,28 +242,33 @@ Per Gap Taxonomy above. Apply priority order: Outcome → Boundary → Priority 
 
 **Outcome constraint**: Outcome is always included in Dₐ regardless of detection — it is a protocol constraint (`|Dₐ| ≥ 1`). If not detected, include with `[protocol constraint]` annotation. **Outcome cannot be removed** via the "Remove" option.
 
-Present detection results with evidence as text output:
-- Detected dimensions needing definition:
-  - **Outcome** [protocol constraint]: [evidence or "required by protocol"]
-  - **[Type]**: [specific evidence from Gᵥ]
+Present the full taxonomy assessment as text output — every named dimension shown with detection status, evidence, and falsification condition for undetected dimensions:
 
-Then **present** to confirm:
+- **Outcome** ✓ detected [protocol constraint]: [specific evidence from Gᵥ, or "required by protocol — always included"]
+- **Boundary** ✓ detected: [specific evidence from Gᵥ]
+- **Priority** — not currently detected: [evidence considered]. Would apply if [falsification condition].
+- **Metric** — not currently detected: [evidence considered]. Would apply if [falsification condition].
+- **Emergent**: [If AI detects a potential emergent dimension: present as named hypothesis with evidence and boundary annotation. Otherwise: "Is there an aspect of your goal that doesn't fit the above categories?"]
+
+Emergent dimensions include boundary annotation: "This is a goal definition gap (Telos scope). Not: expression gap (→ `/clarify`) or execution context (→ `/inquire`)"
+
+Then **present**:
 
 ```
-How would you like to proceed with these detected dimensions?
+How would you like to proceed?
 
 Options:
-1. **Proceed with these** — start co-construction with detected dimensions
-2. **Add dimension** — I also see [type] gaps
-3. **Remove dimension** — [type] doesn't apply (Outcome cannot be removed)
+1. **Proceed with current assessment** — start co-construction with detected dimensions
+2. **Revise assessment** — toggle any dimensions or describe an emergent dimension (Outcome cannot be excluded)
 ```
 
-- "Add" and "Remove" options include brief rationale showing why the dimension was/wasn't detected
-- Emergent dimensions include boundary annotation: "This is a goal definition gap (Telos scope). Not: expression gap (→ `/clarify`) or execution context (→ `/inquire`)"
+- Detected dimensions: evidence for why the dimension needs definition
+- Not-currently-detected dimensions: evidence considered + falsification condition ("would apply if [specific condition]")
+- Evidence parity: each dimension (detected or not) receives comparable analytical depth
 
-**Add/Remove sub-steps**: On "Add" or "Remove" selection, present via gate interaction to specify which dimension to add/remove with rationale. After modification, re-present the updated detection result for final confirmation. Phase 1 completes when user selects "Proceed with these." Outcome removal is rejected with explanation (protocol constraint: `Dₐ ⊇ {Outcome}`).
+**Revise sub-step**: On "Revise assessment" selection, user specifies which dimensions to toggle (include previously unselected, exclude previously detected) or describes an emergent dimension. Multiple revisions in a single response are supported. Outcome exclusion is rejected with explanation (protocol constraint: `Dₐ ⊇ {Outcome}`). After modification, re-present the updated assessment for final confirmation. Phase 1 completes when user selects "Proceed with current assessment."
 
-**Soft guard**: If user removes all detected dimensions (leaving only Outcome by protocol constraint), confirm: "Only Outcome will be defined. Continue with minimal GoalContract?" If confirmed, `Dₐ = {Outcome}` → proceed to Phase 2. If declined, re-present detection for reconsideration.
+**Soft guard**: If user excludes all dimensions except Outcome (by protocol constraint), confirm: "Only Outcome will be defined. Continue with minimal GoalContract?" If confirmed, `Dₐ = {Outcome}` → proceed to Phase 2. If declined, re-present assessment for reconsideration.
 
 On loop re-entry: show progress (`[defined]` / `[undefined]`) and re-detect only undefined dimensions. Include "Sufficient — approve current GoalContract" option for early exit.
 
@@ -345,8 +350,7 @@ How would you like to proceed with this GoalContract?
 
 Options:
 1. **Approve** — proceed with this GoalContract
-2. **Revise [dimension]** — return to refine a specific field
-3. **Add dimension** — define an additional field
+2. **Revise [dimension]** — return to refine a specific field or include a previously unselected dimension
 ```
 
 ### Post-Convergence Suggestions
@@ -355,11 +359,11 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 **Transformation check**: Before suggesting next protocols, briefly assess whether the defined goals changed the implementation scope. State in one sentence what shifted (e.g., "The GoalContract's latency requirement eliminates the batch processing approach") or note that the original scope was confirmed by the defined goals. This is informational text — not a gate interaction.
 
-**Protocol suggestions**: Based on session context, suggest protocols whose deficit conditions are observable:
+**Protocol suggestions**: Traverse each condition below against current session context. Present status (applicable/not applicable) with brief evidence for each. Omitting a condition without evaluation = protocol violation.
 
-- Boundary undefined for goal-related decisions → suggest `/bound` (epistemic boundary definition)
-- Context insufficiency for goal execution → suggest `/inquire` (pre-execution context verification)
-- Goal construction reveals expression doesn't match intent → suggest `/clarify` (intent-expression gap verification)
+- `/bound` (BoundaryUndefined): Boundary undefined for goal-related decisions → suggest epistemic boundary definition
+- `/inquire` (ContextInsufficient): Context insufficiency for goal execution → suggest pre-execution context verification
+- `/clarify` (IntentMisarticulated): Goal construction reveals expression doesn't match intent → suggest intent-expression gap verification
 
 **Next steps**: Based on the converged output, suggest concrete follow-up actions:
 
@@ -380,7 +384,7 @@ After convergence, scan session context for continuing epistemic needs and prese
 
 1. **AI-guided, user-confirmed**: AI recognizes goal indeterminacy; activation requires user approval via gate interaction (Phase 0)
 2. **Recognition over Recall**: Present structured options via gate interaction (Qc/Qs) and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation. Modify options use structured sub-choices, not free text
-3. **Detection with user authority**: AI detects indeterminate dimensions with evidence; user confirms, adds, or removes (no blind multiSelect, no auto-proceed). Outcome always included (protocol constraint)
+3. **Detection with user authority**: AI presents full taxonomy assessment — every named dimension with detection status, evidence, and falsification condition; user confirms or revises (no selective presentation, no auto-proceed). Outcome always included (protocol constraint)
 4. **Construction over Extraction**: AI proposes falsifiable candidates, not abstract questions
 5. **Concrete proposals**: Every proposal must be specific enough to accept or reject
 6. **User authority**: User shapes, accepts, or rejects; AI does not override
@@ -393,3 +397,6 @@ After convergence, scan session context for continuing epistemic needs and prese
 13. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via gate interaction. The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 14. **No premature sufficiency**: Do not skip Phase 4 (GoalContract review). Even when all Dₐ appear defined, present the assembled GoalContract with transformation trace for explicit user approval
 15. **No silent dimension skip**: If detect(Gᵥ) finds fewer than expected undefined dimensions, present the detection evidence. Do not silently declare dimensions as "already defined" without showing why
+16. **Full taxonomy assessment**: Phase 1 must present ALL named dimension types with detection status and evidence. Presenting only detected dimensions with a generic "Add" option = protocol violation (Recognition over Recall applied to gate content)
+17. **Falsification condition**: Each not-currently-detected dimension must include "would apply if [specific condition]" — exclusion rationale without falsification condition = protocol violation
+18. **Emergent probe**: Emergent slot must include an active probe question or AI-detected hypothesis with evidence. "No emergent dimensions detected" as bare statement without probe = protocol violation


### PR DESCRIPTION
## Summary

- **Full Taxonomy Confirmation 원칙 도입**: Proceed/Add/Remove (PAR) gate 패턴의 Qc/Qs kind impurity 해소. "Add" 옵션이 표면 Qc이나 실질 Qs(사용자 Recall 요구)인 문제를 full taxonomy presentation으로 순수 Qc로 변환
- **Hermeneia Phase 1b + Telos Phase 1**: 전체 taxonomy assessment 패턴 — 모든 named type을 detected/not-currently-detected 상태 + evidence + falsification condition과 함께 제시
- **Prothesis Phase 4 routing**: session-grounded concrete proposals (generic labels → Lens-derived rationale)
- **10개 프로토콜 Post-Convergence**: traversal requirement 추가 — 모든 조건을 명시적으로 순회하고 status 제시
- **CLAUDE.md progressive disclosure**: 3,724 → 1,537 words, 상세 내용 docs/ 분리 (design-philosophy.md, verification.md, co-change.md)

### 설계 근거

5개 perspective 분석 (Interaction Kind Formalism, Cognitive Load Science, Adversarial Resilience, AI Philosophy, Codex gpt-5.4)이 수렴:
1. Kind Purification — mixed Qc/Qs → pure Qc
2. Evaluation < Generation — 4 types 규모에서 인지 부하 순감소
3. Performative contradiction 해소 — Recognition over Recall 원칙의 자기 일관성 회복
4. "excluded"는 과한 단어 → "not currently detected" 사용
5. Design smell: "generic verb hiding finite taxonomy state" → CLAUDE.md에 공식화

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` — fail 0, warn 3 (기존)
- [ ] Hermeneia `/clarify` 실행 — Phase 1b에서 full taxonomy assessment 형식 확인
- [ ] Telos `/goal` 실행 — Phase 1에서 full taxonomy assessment 형식 확인
- [ ] Prothesis `/frame` Mode 2 실행 — Phase 4 routing에서 concrete proposals 확인
- [ ] 임의 프로토콜 Post-Convergence — traversal requirement 준수 확인
- [ ] Hermeneia/Telos emergent response parsing — probe 답변 + "Proceed" 동시 입력 시 implicit Revise 처리 확인
- [ ] Post-Convergence Display rule — "after full traversal" 조건으로 R3(b) escape hatch 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

