### PR TITLE
feat(prothesis): A2 Visibility principle Phase 4 체계적 적용

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.13.12",
+  "version": "5.14.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.14.1",
+  "version": "5.15.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -389,11 +389,7 @@ with another perspective for direct exchange (≤3 messages per pair).
 The coordinator will provide the exact peer agent name — use it as-is for
 the SendMessage `to` field. Do not infer or abbreviate agent names.
 Exchange directly — present your position, engage with the other's reasoning.
-After exchange, submit a structured report to the coordinator:
-- Final position: your concluded stance
-- Agreement points: what you agreed on
-- Remaining divergence: unresolved disagreements (empty if fully agreed)
-- Rationale: why you hold this position
+The coordinator will provide the structured report format at dialogue time.
 If divergence remains, the coordinator may ask one follow-up question —
 respond with specific evidence or impact analysis.
 Do not initiate cross-dialogue unprompted.
@@ -441,7 +437,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
 
 **If triggers detected**: Coordinator initiates peer negotiation with structured reporting:
 
-1. **Topic signal**: Coordinator identifies the tension topic and sends it to each involved peer via SendMessage, including (a) the exact peer agent name, (b) a trigger-appropriate external label, and (c) the structured report format. The coordinator MUST use the peer's exact `name` from `Λ.team.members` for the SendMessage `to` field — do not paraphrase or abbreviate agent names.
+1. **Topic signal**: Coordinator identifies the tension topic and sends it to each involved peer via SendMessage, including (a) the exact peer agent name, (b) a trigger-appropriate external label, and (c) the structured report format (5-field: Final position, Agreement points, Agreement strength [strong/moderate/weak per AgreementStrength definition], Remaining divergence, Rationale). Report format is introduced at dialogue time, not at spawn — Phase 3 isolation preservation. The coordinator MUST use the peer's exact `name` from `Λ.team.members` for the SendMessage `to` field — do not paraphrase or abbreviate agent names.
 
    **External labels** (internal Δₛ trigger types are coordinator-only; peers receive neutral task framing):
    - Contradiction: "You reached materially different conclusions on [topic Z]. Exchange reasons and report agreement/divergence."
@@ -469,7 +465,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    ```
 
    This is informational text — not a gate interaction. Skip this step if Δₛ = ∅ (no triggers detected).
-6. **Synthesis**: Coordinator independently integrates all results — peer exchange outcomes, structured reports, and hub-spoke responses (if any) — into a unified assessment. The coordinator exercises independent judgment as Synthesizer: information collection from peers, but the integration decision is the coordinator's own.
+6. **Synthesis**: Coordinator independently integrates all results — peer exchange outcomes, structured reports, and hub-spoke responses (if any) — into a unified assessment. The coordinator exercises synthesis constitution as Synthesizer: horizons fusion from peer inputs, not new analysis. Information collection from peers; the integration (Horizontverschmelzung) is the coordinator's own.
 7. **User review**: Output the full synthesis as text (O(L)), then **present** routing options via gate interaction. The user reads the complete synthesis with scrollback, then selects next action.
 
    **Step 1** — Text output O(L) (full synthesis, per Synthesis template below):
@@ -505,7 +501,7 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 
 ### Convergence (Shared Horizon)
 [Where perspectives agree—indicates robust finding]
-[Per convergence point: agreement strength (strong/moderate/weak) with basis from Dᵣ]
+[Per convergence point: agreement strength (strong/moderate/weak) with basis from Dᵣ; when Dᵣ = ∅, label as "independent convergence" — strength not assessable without cross-dialogue]
 
 ### Divergence (Horizon Conflicts)
 [Where they disagree—different values, evidence standards, or scope]
@@ -517,8 +513,8 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 [Distinguish findings from isolated inquiry (R') vs. cross-dialogue refinement (Dᵣ)]
 
 ### Synthesis Basis
-[Per assessment claim: source perspective(s), evidence type (R' finding / Dᵣ agreement / Dᵣ divergence / coordinator judgment), and whether claim combines multiple sources]
-[Claims based on coordinator independent judgment explicitly marked as such]
+[Per assessment claim: source perspective(s), evidence type (R' finding / Dᵣ agreement / Dᵣ divergence / synthesis constitution; omit Dᵣ types when Dᵣ = ∅), and whether claim combines multiple sources]
+[Claims based on synthesis constitution (coordinator's horizons fusion beyond direct perspective output) explicitly marked as such]
 ```
 
 Note: Perspective Summaries are surfaced earlier via P(R') preview (Phase 3 Collection). The synthesis template focuses on integration — convergence, divergence resolution, and assessment — rather than repeating individual perspective findings.
@@ -545,7 +541,7 @@ Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidenc
 1. **Mission Brief confirmation**: Always present Mission Brief for confirmation via gate interaction before context gathering (Phase 0 → Phase 1 gate). Pre-filled text (`/frame "text"`) still requires confirmation.
 2. **Recognition over Recall**: Present structured options via gate interaction and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation
 3. **Epistemic Integrity**: Each perspective analyzes in isolated teammate context within an agent team; main agent direct analysis = protocol violation (violates isolation requirement). Mode 1 (recommend) is exempt — no team or isolation (Pₛ selection only). Phase topology per Rule 7
-4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis. Synthesis Basis section enables verification of this constraint — coordinator-judgment claims are explicitly marked
+4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis. Synthesis constitution (horizons fusion) is integration, not analysis — explicitly marked in Synthesis Basis for verification
 5. **Verbatim Transmission**: Pass original question unchanged to each perspective
 6. **Sufficiency check**: After synthesis, output full Lens L as text O(L), then present routing options via gate interaction to confirm or extend analysis
 7. **Phase-dependent topology**: Analysis (Phase 3) enforces strict isolation; cross-dialogue (Phase 4) uses peer-to-peer negotiation (≤3 exchanges/pair) → structured report → conditional hub-spoke (Synthesizer) → user review via gate interaction

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -60,10 +60,11 @@ R      = Set(Result)                                  -- raw inquiry outputs
 R'     = Set(Result) post-collection                  -- after Phase 3 collection
 P      = Preview: R' → UserVisible(R')               -- per-perspective summary output before synthesis (text, not gate interaction)
 Δ      = Trigger detection: R' → Δₛ                  -- produces named trigger set
-Δₛ     = Set(Trigger)                                 -- detected triggers: contradictions, horizon intersections, uncorroborated high-stakes
+Δₛ     = Set(Trigger)                                 -- detected triggers per Trigger Detection Criteria; cite evidence per trigger
 D?     = Conditional dialogue: Δₛ ≠ ∅ → peer negotiation → structured report → conditional hub-spoke → Dᵣ; Δₛ = ∅ → skip dialogue (Dᵣ = ∅)
 Dᵣ     = Set(DialogueReport)                          -- peer negotiation outputs
-DialogueReport = { perspective, final_position, agreement, divergence, rationale }  -- divergence gates hub-spoke conditional
+DialogueReport = { perspective, final_position, agreement, agreement_strength, divergence, rationale }  -- divergence gates hub-spoke conditional; agreement_strength gates synthesis confidence attribution
+AgreementStrength ∈ {strong, moderate, weak}  -- strong: shared evidence + shared conclusion; moderate: shared conclusion, different evidence paths; weak: partial overlap, significant residual divergence
 Syn    = Synthesis: (R', Dᵣ) → (∩, D, A)             -- dual-input: provenance-preserving (Dᵣ = ∅ when Δₛ = ∅)
 L      = Lens { convergence: ∩, divergence: D, assessment: A }
 O      = Output: L → UserVisible(L)                   -- full synthesis presentation as text output before routing question
@@ -136,7 +137,7 @@ T (parallel)             → TeamCreate tool (creates team with shared task list
 ∥Spawn (parallel)        → Task tool (team_name, name: spawn perspective teammates — each receives MBᵥ + perspective only; no Phase 1 context G passed)
 ∥I (parallel)            → TaskCreate/TaskUpdate (shared task list for inquiry coordination)
 Phase 3 P (relay)        → TextPresent+Proceed (per-perspective epistemic contribution + key finding summaries)
-Phase 4 Δ (detect)       → Internal operation (trigger check: contradictions, horizon intersections, uncorroborated high-stakes)
+Phase 4 Δ (detect)       → Internal operation (trigger check per Trigger Detection Criteria; cite evidence per detected trigger)
 Phase 4 D? (conditional) → SendMessage tool (type: "message", coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke; skip if Δₛ = ∅)
 Phase 4 O (relay)        → TextPresent+Proceed (full synthesis — convergence, divergence, integrated assessment)
 Phase 4 Qc (gate)        → present (routing only: extend/add_input/wrap_up/withdraw options; Esc key → loop termination at LOOP level)
@@ -145,7 +146,7 @@ wrap_up TaskCreate (state) → TaskCreate (session-scoped: PF-selected findings,
 Ω (extern)               → SendMessage tool (type: "shutdown_request", graceful teammate termination)
 Λ (state)                → TaskCreate/TaskUpdate (mandatory after Phase 3 spawn, per perspective; TaskUpdate for status tracking)
 G (gather)               → Read, Glob, Grep (meta-scope context acquisition: guided by MBᵥ to identify relevant perspectives — not passed to teammates; teammates independently collect object-scope evidence through their own lens)
-Phase 4 Syn (synthesis)  → Internal operation (no external tool)
+Phase 4 Syn (synthesis)  → Internal operation (no external tool; basis_cited in O(L) Synthesis Basis section)
 characterize (internal)  → Internal operation (perspective count tier classification)
 converge (relay)          → TextPresent+Proceed (convergence evidence trace; proceed with framed inquiry)
 
@@ -279,7 +280,7 @@ The recommendation matches mode to analytical demand — Recommend when the inqu
 
 Gather context sufficient to formulate distinct perspectives, **guided by MBᵥ**.
 
-MBᵥ.inquiry_intent and MBᵥ.scope_constraint direct which files, systems, and domains to investigate. Do not proceed to Phase 2 until context is established.
+MBᵥ.inquiry_intent and MBᵥ.scope_constraint direct which files, systems, and domains to investigate. Gathering intensity scales with MBᵥ complexity: narrow-scope inquiries with clear domain boundaries warrant targeted collection; broad or cross-domain inquiries warrant deeper investigation. Do not proceed to Phase 2 until context is established.
 
 ### Phase 2: Prothesis (Perspective Placement)
 
@@ -332,7 +333,7 @@ Per LOOP Pₛ count tiers for escalation recommendation.
 
 ### Phase 3: Inquiry (Through Selected Lens)
 
-**Plan mode**: When active, `TeamCreate` is unavailable — `Plan` subagents (per perspective) and `Explore` subagent (context) remain available. See `references/conceptual-foundations.md` for Phase 3 degradation behavior (`ExitPlanMode` presents Plan subagent analyses as plan output; actual Lens L requires a fresh `/frame` session from Phase 0 in normal mode).
+**Plan mode**: When active, `TeamCreate` is unavailable — `Plan` subagents (per perspective) and `Explore` subagent (context) remain available. Phase 3 collects R' from Plan subagent outputs. Phase 4 partially executes: Δ(R') trigger detection and Syn(R', ∅) synthesis (both internal operations) produce a partial Lens L without cross-dialogue refinement. D? (peer negotiation) is skipped — requires persistent agent identity via SendMessage. See `references/conceptual-foundations.md` for quality trade-off.
 
 **Agent-Perspective Mapping** (before team spawn)
 
@@ -344,7 +345,7 @@ For each selected perspective in Pₛ, check whether available agents match the 
 
 Agent matching is heuristic: compare perspective focus description against agent `description` and `when to use` fields. Matching does not affect perspective selection (theoria) — it only determines execution assignment (praxis). "Placement over Prescription" invariant: /frame places perspectives; agent mapping realizes execution.
 
-**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. For Tier 2 (|Pₛ| ≥ 4), consider the trade-off explicitly.
+**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. For Tier 2 (|Pₛ| ≥ 4): scope-partition each perspective's investigation to MBᵥ-relevant subdomain — full-codebase sweep per perspective is unnecessary when scope_constraint narrows the evidence space. The coordinator's spawn prompt Orientation field directs each perspective's initial investigation target.
 
 **Team Setup**
 
@@ -436,7 +437,7 @@ After collecting all perspective results (R'), the coordinator reviews for cross
 
 **Cross-Dialogue (Peer Negotiation)**
 
-The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`) before proceeding to synthesis.
+The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ` and Trigger Detection Criteria) before proceeding to synthesis. For each detected trigger, cite the specific evidence: which perspectives, which claims, and the heuristic criterion met.
 
 **If triggers detected**: Coordinator initiates peer negotiation with structured reporting:
 
@@ -447,9 +448,10 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    - Uncorroborated high-stakes: "A consequential claim on [topic Z] needs independent validation. Assess support, uncertainty, and failure impact."
    - Horizon intersection: "Topic [topic Z] warrants additional scrutiny. State your current position, key uncertainty, and one question for the peer."
 2. **Peer exchange**: Peers communicate directly (≤3 exchanges per pair; e.g., A→B, B→A, A→B). Each peer presents their position, responds to the other's reasoning, and works toward common ground. Peers may stop early if agreement is reached. The coordinator does not relay or frame — peers engage with each other's actual arguments.
-3. **Structured report**: Each peer submits a 4-field report to the coordinator:
+3. **Structured report**: Each peer submits a 5-field report to the coordinator:
    - **Final position**: Peer's concluded stance after exchange
    - **Agreement points**: What the peers agreed on
+   - **Agreement strength**: strong (shared evidence + shared conclusion), moderate (shared conclusion, different evidence paths), or weak (partial overlap, significant residual divergence)
    - **Remaining divergence**: Specific unresolved disagreements (empty if fully agreed)
    - **Rationale**: Why this position is held
 4. **Conditional hub-spoke**: If any peer's `remaining_divergence` is non-empty, coordinator initiates hub-spoke reconciliation — one targeted question per divergent peer (e.g., "Peer B argues [X]. Explain the concrete impact of your position on [specific aspect]."). Each peer responds once. Coordinator does not re-engage after receiving responses — synthesis is independent. If `remaining_divergence` is empty for all peers, skip to step 5.
@@ -461,6 +463,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    ### Tension: [Topic Z]
    **Peers**: [Perspective A] vs [Perspective B]
    **Resolution**: [Agreed / Partial agreement / Persistent divergence]
+   **Agreement Strength**: [strong / moderate / weak — with one-line basis]
    - Agreement: [key agreement points]
    - Divergence: [remaining unresolved points, if any]
    ```
@@ -502,6 +505,7 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 
 ### Convergence (Shared Horizon)
 [Where perspectives agree—indicates robust finding]
+[Per convergence point: agreement strength (strong/moderate/weak) with basis from Dᵣ]
 
 ### Divergence (Horizon Conflicts)
 [Where they disagree—different values, evidence standards, or scope]
@@ -511,23 +515,37 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 ### Integrated Assessment
 [Synthesized answer with attribution to contributing perspectives]
 [Distinguish findings from isolated inquiry (R') vs. cross-dialogue refinement (Dᵣ)]
+
+### Synthesis Basis
+[Per assessment claim: source perspective(s), evidence type (R' finding / Dᵣ agreement / Dᵣ divergence / coordinator judgment), and whether claim combines multiple sources]
+[Claims based on coordinator independent judgment explicitly marked as such]
 ```
 
 Note: Perspective Summaries are surfaced earlier via P(R') preview (Phase 3 Collection). The synthesis template focuses on integration — convergence, divergence resolution, and assessment — rather than repeating individual perspective findings.
 
 **Loop behavior**: Per LOOP. Key operational details:
-- **Wrap up**: PF presents L categories (convergence, divergence, assessment highlights) via multiSelect gate interaction; selected items migrate to session TaskCreate after TeamDelete.
+- **Wrap up**: PF presents L categories (convergence, divergence, assessment highlights) via multiSelect gate interaction; selected items migrate to session TaskCreate after TeamDelete. When presenting convergence evidence, annotate each perspective's contribution with which Lens section(s) (∩, D, A) the perspective influenced and whether unique findings survived synthesis. This annotation serves as Reflexion extraction input for cross-session perspective enrichment.
 
 All other routing options (Extend, Add input, withdraw) and convergence behavior Per LOOP.
 
 Consult `references/conceptual-foundations.md` for trigger/skip heuristics, Parametric Nature, and Specialization.
+
+## Trigger Detection Criteria
+
+Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidence per detected trigger in Cross-Dialogue Outcomes.
+
+| Trigger | Heuristic | Evidence Required |
+|---------|-----------|-------------------|
+| **Contradiction** | R'[pᵢ].assessment ≠ R'[pⱼ].assessment on shared referent | Which perspectives, which claims, on what topic |
+| **Horizon Intersection** | R'[pᵢ].horizon_limits ∩ R'[pⱼ].epistemic_contribution ≠ ∅ | Which horizon limit overlaps which contribution |
+| **Uncorroborated High-Stakes** | ∃ claim ∈ R'[p] : stakes(claim) = high ∧ ¬∃ q≠p confirming claim | The claim, the perspective, why high-stakes |
 
 ## Rules
 
 1. **Mission Brief confirmation**: Always present Mission Brief for confirmation via gate interaction before context gathering (Phase 0 → Phase 1 gate). Pre-filled text (`/frame "text"`) still requires confirmation.
 2. **Recognition over Recall**: Present structured options via gate interaction and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation
 3. **Epistemic Integrity**: Each perspective analyzes in isolated teammate context within an agent team; main agent direct analysis = protocol violation (violates isolation requirement). Mode 1 (recommend) is exempt — no team or isolation (Pₛ selection only). Phase topology per Rule 7
-4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis
+4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis. Synthesis Basis section enables verification of this constraint — coordinator-judgment claims are explicitly marked
 5. **Verbatim Transmission**: Pass original question unchanged to each perspective
 6. **Sufficiency check**: After synthesis, output full Lens L as text O(L), then present routing options via gate interaction to confirm or extend analysis
 7. **Phase-dependent topology**: Analysis (Phase 3) enforces strict isolation; cross-dialogue (Phase 4) uses peer-to-peer negotiation (≤3 exchanges/pair) → structured report → conditional hub-spoke (Synthesizer) → user review via gate interaction

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -63,8 +63,8 @@ P      = Preview: R' → UserVisible(R')               -- per-perspective summar
 Δₛ     = Set(Trigger)                                 -- detected triggers per Trigger Detection Criteria; cite evidence per trigger
 D?     = Conditional dialogue: Δₛ ≠ ∅ → peer negotiation → structured report → conditional hub-spoke → Dᵣ; Δₛ = ∅ → skip dialogue (Dᵣ = ∅)
 Dᵣ     = Set(DialogueReport)                          -- peer negotiation outputs
-DialogueReport = { perspective, final_position, agreement, agreement_strength, divergence, rationale }  -- divergence gates hub-spoke conditional; agreement_strength gates synthesis confidence attribution
-AgreementStrength ∈ {strong, moderate, weak}  -- strong: shared evidence + shared conclusion; moderate: shared conclusion, different evidence paths; weak: partial overlap, significant residual divergence
+DialogueReport = { perspective, final_position, agreement, divergence, rationale }  -- divergence gates hub-spoke conditional
+AgreementStrength ∈ {strong, moderate, weak}  -- coordinator-assessed in Cross-Dialogue Outcomes (horizons fusion); strong: shared evidence + shared conclusion; moderate: shared conclusion, different evidence paths; weak: partial overlap, significant residual divergence
 Syn    = Synthesis: (R', Dᵣ) → (∩, D, A)             -- dual-input: provenance-preserving (Dᵣ = ∅ when Δₛ = ∅)
 L      = Lens { convergence: ∩, divergence: D, assessment: A }
 O      = Output: L → UserVisible(L)                   -- full synthesis presentation as text output before routing question
@@ -163,7 +163,7 @@ Phase 4 Qc (routing)     → always_gated (gated: loop path + team lifecycle)
 PF Qc (preserve)         → always_gated (gated: knowledge preservation scope)
 
 ── CATEGORICAL NOTE ──
-∩ = meet (intersection) over comparison morphisms between perspective outputs
+∩ = graded meet (intersection with coordinator-assessed agreement strength) over comparison morphisms between perspective outputs
 D = join (union of distinct findings) where perspectives diverge
 A = synthesized assessment (additional computation)
 
@@ -286,7 +286,7 @@ MBᵥ.inquiry_intent and MBᵥ.scope_constraint direct which files, systems, and
 
 After context gathering (Phase 1), **present** perspectives via gate interaction with `multiSelect: true`.
 
-**Cross-session enrichment**: Prior framing experiences accumulated through prior Reflexion cycles may guide Phase 2 perspective formulation — previously effective analytical lenses for similar domains provide starting hypotheses. This is a heuristic input that may bias detection toward previously observed patterns; gate judgment remains with the user.
+**Cross-session enrichment**: Prior framing experiences accumulated through prior Reflexion cycles guide Phase 2 perspective formulation bidirectionally — previously effective analytical lenses for similar domains provide starting hypotheses (exploitation), while prior coverage gaps (unaddressed horizon limits) signal domains where novel perspectives should be prioritized (exploration). This is a heuristic input that may bias detection toward previously observed patterns; gate judgment remains with the user.
 
 **Do NOT bypass the gate.** Structured presentation with turn yield is mandatory — presenting content without yielding for response = protocol violation.
 
@@ -333,7 +333,7 @@ Per LOOP Pₛ count tiers for escalation recommendation.
 
 ### Phase 3: Inquiry (Through Selected Lens)
 
-**Plan mode**: When active, `TeamCreate` is unavailable — `Plan` subagents (per perspective) and `Explore` subagent (context) remain available. Phase 3 collects R' from Plan subagent outputs. Phase 4 partially executes: Δ(R') trigger detection and Syn(R', ∅) synthesis (both internal operations) produce a partial Lens L without cross-dialogue refinement. D? (peer negotiation) is skipped — requires persistent agent identity via SendMessage. See `references/conceptual-foundations.md` for quality trade-off.
+**Plan mode**: When active, Phase 3 uses available subagents (Plan, Explore) for per-perspective analysis with isolation preserved. Phase 4 produces a partial Lens via internal operations: Δ(R') trigger detection and Syn(R', ∅) synthesis. See `references/conceptual-foundations.md` for quality trade-off.
 
 **Agent-Perspective Mapping** (before team spawn)
 
@@ -345,7 +345,7 @@ For each selected perspective in Pₛ, check whether available agents match the 
 
 Agent matching is heuristic: compare perspective focus description against agent `description` and `when to use` fields. Matching does not affect perspective selection (theoria) — it only determines execution assignment (praxis). "Placement over Prescription" invariant: /frame places perspectives; agent mapping realizes execution.
 
-**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. For Tier 2 (|Pₛ| ≥ 4): scope-partition each perspective's investigation to MBᵥ-relevant subdomain — full-codebase sweep per perspective is unnecessary when scope_constraint narrows the evidence space. The coordinator's spawn prompt Orientation field directs each perspective's initial investigation target.
+**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. For Tier 2 (|Pₛ| ≥ 4): direct each perspective's initial investigation toward MBᵥ-relevant subdomain — full-codebase sweep per perspective is unnecessary when scope_constraint narrows the evidence space. The coordinator's spawn prompt Orientation field directs each perspective's initial investigation target.
 
 **Team Setup**
 
@@ -433,21 +433,20 @@ After collecting all perspective results (R'), the coordinator reviews for cross
 
 **Cross-Dialogue (Peer Negotiation)**
 
-The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ` and Trigger Detection Criteria) before proceeding to synthesis. For each detected trigger, cite the specific evidence: which perspectives, which claims, and the heuristic criterion met.
+The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ` and Trigger Detection Criteria) before proceeding to synthesis. For each detected trigger, cite evidence per Trigger Detection Criteria.
 
 **If triggers detected**: Coordinator initiates peer negotiation with structured reporting:
 
-1. **Topic signal**: Coordinator identifies the tension topic and sends it to each involved peer via SendMessage, including (a) the exact peer agent name, (b) a trigger-appropriate external label, and (c) the structured report format (5-field: Final position, Agreement points, Agreement strength [strong/moderate/weak per AgreementStrength definition], Remaining divergence, Rationale). Report format is introduced at dialogue time, not at spawn — Phase 3 isolation preservation. The coordinator MUST use the peer's exact `name` from `Λ.team.members` for the SendMessage `to` field — do not paraphrase or abbreviate agent names.
+1. **Topic signal**: Coordinator identifies the tension topic and sends it to each involved peer via SendMessage, including (a) the exact peer agent name, (b) a trigger-appropriate external label, and (c) the structured report format (4-field: Final position, Agreement points, Remaining divergence, Rationale). Report format is introduced at dialogue time, not at spawn — Phase 3 isolation preservation. The coordinator MUST use the peer's exact `name` from `Λ.team.members` for the SendMessage `to` field — do not paraphrase or abbreviate agent names.
 
    **External labels** (internal Δₛ trigger types are coordinator-only; peers receive neutral task framing):
    - Contradiction: "You reached materially different conclusions on [topic Z]. Exchange reasons and report agreement/divergence."
    - Uncorroborated high-stakes: "A consequential claim on [topic Z] needs independent validation. Assess support, uncertainty, and failure impact."
    - Horizon intersection: "Topic [topic Z] warrants additional scrutiny. State your current position, key uncertainty, and one question for the peer."
 2. **Peer exchange**: Peers communicate directly (≤3 exchanges per pair; e.g., A→B, B→A, A→B). Each peer presents their position, responds to the other's reasoning, and works toward common ground. Peers may stop early if agreement is reached. The coordinator does not relay or frame — peers engage with each other's actual arguments.
-3. **Structured report**: Each peer submits a 5-field report to the coordinator:
+3. **Structured report**: Each peer submits a 4-field report to the coordinator:
    - **Final position**: Peer's concluded stance after exchange
    - **Agreement points**: What the peers agreed on
-   - **Agreement strength**: strong (shared evidence + shared conclusion), moderate (shared conclusion, different evidence paths), or weak (partial overlap, significant residual divergence)
    - **Remaining divergence**: Specific unresolved disagreements (empty if fully agreed)
    - **Rationale**: Why this position is held
 4. **Conditional hub-spoke**: If any peer's `remaining_divergence` is non-empty, coordinator initiates hub-spoke reconciliation — one targeted question per divergent peer (e.g., "Peer B argues [X]. Explain the concrete impact of your position on [specific aspect]."). Each peer responds once. Coordinator does not re-engage after receiving responses — synthesis is independent. If `remaining_divergence` is empty for all peers, skip to step 5.
@@ -459,7 +458,7 @@ The coordinator explicitly checks R' for cross-dialogue triggers (per TYPES `Δ`
    ### Tension: [Topic Z]
    **Peers**: [Perspective A] vs [Perspective B]
    **Resolution**: [Agreed / Partial agreement / Persistent divergence]
-   **Agreement Strength**: [strong / moderate / weak — with one-line basis]
+   **Agreement Strength**: [strong / moderate / weak — coordinator assessment with one-line basis from Dᵣ]
    - Agreement: [key agreement points]
    - Divergence: [remaining unresolved points, if any]
    ```
@@ -501,7 +500,7 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 
 ### Convergence (Shared Horizon)
 [Where perspectives agree—indicates robust finding]
-[Per convergence point: agreement strength (strong/moderate/weak) with basis from Dᵣ; when Dᵣ = ∅, label as "independent convergence" — strength not assessable without cross-dialogue]
+[Per convergence point: coordinator-assessed agreement strength (strong/moderate/weak) with basis from Dᵣ; when Dᵣ = ∅, label as "independent convergence" — strength not assessable without cross-dialogue]
 
 ### Divergence (Horizon Conflicts)
 [Where they disagree—different values, evidence standards, or scope]
@@ -520,7 +519,7 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 Note: Perspective Summaries are surfaced earlier via P(R') preview (Phase 3 Collection). The synthesis template focuses on integration — convergence, divergence resolution, and assessment — rather than repeating individual perspective findings.
 
 **Loop behavior**: Per LOOP. Key operational details:
-- **Wrap up**: PF presents L categories (convergence, divergence, assessment highlights) via multiSelect gate interaction; selected items migrate to session TaskCreate after TeamDelete. When presenting convergence evidence, annotate each perspective's contribution with which Lens section(s) (∩, D, A) the perspective influenced and whether unique findings survived synthesis. This annotation serves as Reflexion extraction input for cross-session perspective enrichment.
+- **Wrap up**: PF presents L categories (convergence, divergence, assessment highlights) via multiSelect gate interaction; selected items migrate to session TaskCreate after TeamDelete. When presenting convergence evidence, annotate each perspective's contribution with which Lens section(s) (∩, D, A) the perspective influenced, whether unique findings survived synthesis, and each perspective's horizon limits that remained unaddressed. Coverage gaps (union of unaddressed horizon limits across all perspectives) are recorded alongside survival signals — enabling cross-session enrichment that balances exploitation (proven perspectives) with exploration (perspectives addressing prior blind spots).
 
 All other routing options (Extend, Add input, withdraw) and convergence behavior Per LOOP.
 
@@ -535,13 +534,14 @@ Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidenc
 | **Contradiction** | R'[pᵢ].assessment ≠ R'[pⱼ].assessment on shared referent | Which perspectives, which claims, on what topic |
 | **Horizon Intersection** | R'[pᵢ].horizon_limits ∩ R'[pⱼ].epistemic_contribution ≠ ∅ | Which horizon limit overlaps which contribution |
 | **Uncorroborated High-Stakes** | ∃ claim ∈ R'[p] : stakes(claim) = high ∧ ¬∃ q≠p confirming claim | The claim, the perspective, why high-stakes |
+| **Emergent** | Coherence tension outside named trigger types (e.g., non-overlapping coverage masking disagreement) | The tension, involved perspectives, why named triggers do not capture it |
 
 ## Rules
 
 1. **Mission Brief confirmation**: Always present Mission Brief for confirmation via gate interaction before context gathering (Phase 0 → Phase 1 gate). Pre-filled text (`/frame "text"`) still requires confirmation.
 2. **Recognition over Recall**: Present structured options via gate interaction and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation
 3. **Epistemic Integrity**: Each perspective analyzes in isolated teammate context within an agent team; main agent direct analysis = protocol violation (violates isolation requirement). Mode 1 (recommend) is exempt — no team or isolation (Pₛ selection only). Phase topology per Rule 7
-4. **Synthesis Constraint**: Integration only combines what perspectives provided; no new analysis. Synthesis constitution (horizons fusion) is integration, not analysis — explicitly marked in Synthesis Basis for verification
+4. **Synthesis Constraint**: Integration derives only from what perspectives provided; no new analysis. Synthesis constitution (horizons fusion) is integration, not analysis — explicitly marked in Synthesis Basis for verification
 5. **Verbatim Transmission**: Pass original question unchanged to each perspective
 6. **Sufficiency check**: After synthesis, output full Lens L as text O(L), then present routing options via gate interaction to confirm or extend analysis
 7. **Phase-dependent topology**: Analysis (Phase 3) enforces strict isolation; cross-dialogue (Phase 4) uses peer-to-peer negotiation (≤3 exchanges/pair) → structured report → conditional hub-spoke (Synthesizer) → user review via gate interaction

--- a/prothesis/skills/frame/references/conceptual-foundations.md
+++ b/prothesis/skills/frame/references/conceptual-foundations.md
@@ -21,13 +21,13 @@ When combined with Plan mode, Prothesis provides the **Deliberation** phase:
 When multiple perspectives converge on the same recommendation, present as unanimous recommendation to indicate high confidence.
 
 **Phase 3 Degradation**:
-When Prothesis activates within an active plan mode session, `TeamCreate` is unavailable (no persistent team state). The protocol adapts with available tools:
+When Prothesis activates within an active plan mode session, the protocol adapts with available tools:
 
 - Phases 0–2: Execute normally (`AskUserQuestion` available in plan mode)
 - Phase 1: `Explore` subagent available for context collection (`Task(subagent_type="Explore")`)
 - Phase 3: `Plan` subagent available per perspective (`Task(subagent_type="Plan")`); analysis isolation preserved — each perspective analyzed in a separate subagent context (no persistent identity or cross-dialogue capability; coordinator collects results and incorporates into plan output)
-- Phase 4 partial execution: Δ(R') trigger detection (internal operation) and Syn(R', ∅) synthesis without cross-dialogue (internal operation, Dᵣ=∅ always) are accessible. O(L) presents the partial Lens. D? (peer negotiation via SendMessage) is not accessible — persistent agent identity required. J routing loop is not accessible — team lifecycle management not applicable.
-- `ExitPlanMode` presents the partial Lens L (convergence, divergence from isolated analysis, assessment without cross-dialogue refinement) — divergence claims are unresolved hypotheses, not negotiated positions. For full Lens with peer negotiation, start a fresh `/frame` session in normal mode.
+- Phase 4: Coordinator performs Δ(R') trigger detection and Syn(R', ∅) synthesis — both internal operations. O(L) presents the partial Lens.
+- ExitPlanMode presents the partial Lens L: convergence from independent analysis, divergence as unresolved hypotheses, assessment from coordinator synthesis.
 
 **Quality trade-off (partial Lens)**: Without cross-dialogue:
 - Convergence claims are based on independent convergence only (perspectives agree without knowing each other's positions)
@@ -35,7 +35,7 @@ When Prothesis activates within an active plan mode session, `TeamCreate` is una
 - Assessment lacks Dᵣ refinement — the coordinator synthesizes from isolated outputs only
 - Trigger Detection Criteria still apply — the coordinator can identify contradictions and horizon intersections, but cannot initiate peer resolution
 
-This degradation preserves Phase 0–2 epistemic value, Phase 3 analysis isolation, and Phase 4 synthesis capability (trigger detection + synthesis are internal operations requiring no team infrastructure): Mission Brief confirmation, perspective selection, per-perspective subagent isolation, and coordinator synthesis all complete before ExitPlanMode fires.
+This preserves Phase 0–2 epistemic value, Phase 3 analysis isolation, and Phase 4 synthesis capability via internal operations.
 
 ## Distinction from Socratic Method
 

--- a/prothesis/skills/frame/references/conceptual-foundations.md
+++ b/prothesis/skills/frame/references/conceptual-foundations.md
@@ -26,10 +26,16 @@ When Prothesis activates within an active plan mode session, `TeamCreate` is una
 - Phases 0–2: Execute normally (`AskUserQuestion` available in plan mode)
 - Phase 1: `Explore` subagent available for context collection (`Task(subagent_type="Explore")`)
 - Phase 3: `Plan` subagent available per perspective (`Task(subagent_type="Plan")`); analysis isolation preserved — each perspective analyzed in a separate subagent context (no persistent identity or cross-dialogue capability; coordinator collects results and incorporates into plan output)
-- `ExitPlanMode` presents the coordinator's plan output (incorporating Plan subagent analyses) as inquiry blueprint — not L; actual Lens requires `TeamCreate` + normal-mode execution
-- Phases 4–5 (cross-dialogue, synthesis, routing) are not accessible in plan mode; to obtain actual Lens L, start a fresh `/frame` session from Phase 0 in normal mode — the inquiry blueprint serves as reference context when re-specifying the Mission Brief and selecting perspectives
+- Phase 4 partial execution: Δ(R') trigger detection (internal operation) and Syn(R', ∅) synthesis without cross-dialogue (internal operation, Dᵣ=∅ always) are accessible. O(L) presents the partial Lens. D? (peer negotiation via SendMessage) is not accessible — persistent agent identity required. J routing loop is not accessible — team lifecycle management not applicable.
+- `ExitPlanMode` presents the partial Lens L (convergence, divergence from isolated analysis, assessment without cross-dialogue refinement) — divergence claims are unresolved hypotheses, not negotiated positions. For full Lens with peer negotiation, start a fresh `/frame` session in normal mode.
 
-This degradation preserves Phase 0–2 epistemic value and Phase 3 analysis isolation (per-perspective context separation; cross-dialogue and persistent agent identity require normal mode): Mission Brief confirmation, perspective selection, and per-perspective subagent isolation all complete before ExitPlanMode fires. The plan output serves as a blueprint for a subsequent active session.
+**Quality trade-off (partial Lens)**: Without cross-dialogue:
+- Convergence claims are based on independent convergence only (perspectives agree without knowing each other's positions)
+- Divergence claims are unresolved hypotheses — peers have not had the opportunity to narrow disagreement or identify shared ground
+- Assessment lacks Dᵣ refinement — the coordinator synthesizes from isolated outputs only
+- Trigger Detection Criteria still apply — the coordinator can identify contradictions and horizon intersections, but cannot initiate peer resolution
+
+This degradation preserves Phase 0–2 epistemic value, Phase 3 analysis isolation, and Phase 4 synthesis capability (trigger detection + synthesis are internal operations requiring no team infrastructure): Mission Brief confirmation, perspective selection, per-perspective subagent isolation, and coordinator synthesis all complete before ExitPlanMode fires.
 
 ## Distinction from Socratic Method
 


### PR DESCRIPTION
## Summary
- Prothesis Phase 4의 불투명한 내부 연산(Δ, D?, Syn, wrap_up)에 A2 Visibility principle(basis_cited)을 체계적으로 적용
- 6개 개선: Trigger Detection Criteria, AgreementStrength 등급화, Synthesis Basis 가시화, contribution signal, Plan mode partial Lens, cost advisory
- Analogia(gstack ↔ EP) 세션에서 도출 → Telos GoalContract → Epharmoge contextualization → 구현

## Changes
- **P1b**: `## Trigger Detection Criteria` 섹션 신설 (Prosoche Risk Signal Taxonomy 패턴)
- **P1a**: `AgreementStrength ∈ {strong, moderate, weak}` 타입 + DialogueReport 5-field + 템플릿 확장
- **P2**: `### Synthesis Basis` 섹션 + TOOL GROUNDING basis_cited 어노테이션 + Rule 4 검증 연결
- **P3**: wrap_up prose에 contribution signal (formal block 경계 준수)
- **P4a**: Plan mode에서 Δ+Syn 접근 가능 (partial Lens L), D? 제외
- **P4b**: Phase 1/3 cost advisory prose (스코프 분할 지침)

## Test plan
- [x] `/verify` 실행하여 15개 정적 검사 통과 확인
- [ ] CI epistemic review 통과 확인
- [x] AgreementStrength가 spec-vs-impl 경고만 발생하고 fail 아닌지 확인 (DialogueReport 내부 필드로 dead type 아님)
- [x] Plan mode 설명이 conceptual-foundations.md와 SKILL.md 간 일관성 확인
- [x] Trigger Detection Criteria 테이블의 수식 표기가 기존 TYPES 표기법과 일관적인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
