### PR TITLE
fix(epistemic-cooperative,prosoche): review ensemble 반영

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/compose/SKILL.md
+++ b/epistemic-cooperative/skills/compose/SKILL.md
@@ -61,20 +61,6 @@ For each protocol in the chain: check if any precondition source is missing. The
 
 On missing precondition: suggest inserting the missing protocol at the correct position.
 
-### 1.4 Fatigue-Regret Advisory
-
-For each gate with `regret: unbounded` in the trailing 40% of chain gate positions (position > ⌈0.6 × total_gates⌉): emit an advisory note.
-
-Rationale: unbounded-regret gates require high-quality user judgment (A5). User attention degrades across sequential gate interactions — positioning these gates late in a chain increases the probability of low-quality acceptance. This advisory does not block the chain; it surfaces the risk so the user can reorder if desired.
-
-Advisory format (informational, non-blocking):
-```
-⚠ Fatigue risk: {protocol} Phase {N} {gate_label} (unbounded regret) at position {pos}/{total}
-  Consider moving earlier in the chain or grouping with related gates.
-```
-
-Note: This advisory operates on the chain order from Phase 1, not the disposition output from Phase 3. Position is calculated from the chain's protocol sequence × gate ordering within each protocol. If Phase 3 disposition produces a different gate order, the advisory may become stale — this is accepted because the advisory informs pre-disposition judgment. To act on this advisory: reorder protocols in the chain input to move unbounded-regret gates earlier, then re-run Phase 1 validation.
-
 **On all validations passing**: proceed to Phase 2 with the validated chain.
 
 ## Phase 2: Catalog (Gate Inventory)

--- a/epistemic-cooperative/skills/compose/SKILL.md
+++ b/epistemic-cooperative/skills/compose/SKILL.md
@@ -61,6 +61,8 @@ For each protocol in the chain: check if any precondition source is missing. The
 
 On missing precondition: suggest inserting the missing protocol at the correct position.
 
+**Design note — chain-position × regret interaction**: The A5 concern (unbounded-regret gates positioned late in a chain degrade user judgment quality) is valid but not yet addressed. Phase 3 disposition operates per-gate without chain-position awareness. A future revision will introduce a decision load model that quantifies remaining gate cost (loop depth × regret weight) per disposition choice, replacing the removed position-ratio advisory with a structurally sound, Phase 2-integrated mechanism.
+
 **On all validations passing**: proceed to Phase 2 with the validated chain.
 
 ## Phase 2: Catalog (Gate Inventory)

--- a/prosoche/.claude-plugin/plugin.json
+++ b/prosoche/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prosoche",
   "description": "Route upstream epistemic deficits and evaluate execution-time risks — /attend (προσοχή: attention)",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -305,7 +305,7 @@ When Prosoche is active:
 
 **Cross-session enrichment**: Repeated risk patterns accumulated through prior Reflexion cycles may serve as Phase 0 classification heuristics — known risk signatures from prior executions improve risk level estimation. This is a heuristic input that may bias detection toward previously observed patterns; gate judgment remains with the user.
 
-**Revision threshold**: When accumulated Emergent risk signal detections across 3+ sessions cluster into a recognizable pattern outside the named types, the Risk Signal Taxonomy warrants a new named type. When accumulated classification false negatives across 3+ sessions cluster around a specific pattern, the severity boundary for that pattern warrants revision. The within-session Compound rule is a micro-instance of this threshold applied at session scope.
+**Revision threshold**: When accumulated Emergent risk signal detections across 3+ sessions cluster around a recognizable pattern outside the named types, the Risk Signal Taxonomy warrants a new named type. When accumulated classification false negatives across 3+ sessions cluster around a specific pattern, the severity boundary for that pattern warrants revision. The within-session Compound rule is a micro-instance of this threshold applied at session scope.
 
 ### Mode Deactivation
 


### PR DESCRIPTION
## Summary
- /compose Phase 1.4 Fatigue-Regret Advisory 제거: cross-model review ensemble (Claude 3-perspective + Codex)에서 Phase 1/2 순서 문제 및 `regret: unbounded` annotation 부재 발견. Decision load 모델로 재설계 예정
- prosoche revision threshold "cluster into" → "cluster around" 용어 일관성 수정

### Review Ensemble Findings (PR #222)
| Finding | Source | Severity | Resolution |
|---------|--------|----------|------------|
| Phase 1.4가 Phase 2 gate inventory 이전에 실행 | Codex + Claude (cross-model) | high | Phase 1.4 제거 |
| `regret: unbounded` 명시적 annotation 부재 | Claude (axiom-alignment) | high | Phase 1.4 제거로 해소 |
| 수학 공식 경계값 불일치 | Codex + Claude (cross-model) | medium | Phase 1.4 제거로 해소 |
| "cluster into" vs "cluster around" | Claude (cross-protocol) | low | 용어 통일 |

### 후속 작업
- [ ] 4개 프로토콜 revision threshold 추가 (hermeneia, katalepsis, epharmoge, prothesis)
- [ ] Decision load 모델 설계 및 compose 재통합

## Test plan
- [ ] `/verify` 정적 검증 통과
- [ ] compose SKILL.md에 Phase 1.4 관련 잔여 참조 없음 확인
- [ ] prosoche revision threshold 문단에서 "cluster around" 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
