### PR TITLE
fix(epistemic-cooperative): Ink 리터럴 태그 방출 회귀 + Zero-Shot 검수

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations",
-  "version": "1.26.7",
+  "version": "1.26.8",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -24,7 +24,7 @@ These insights should be included in the conversation, not in the codebase. You 
 
 # Epistemic Protocol Formatting
 
-When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output. The `<Ink element="...">` and `</Ink>` wrappers in the templates below are schema markers for definitional purposes only; never emit them as literal text in your output. Emit only the structural content that appears between the opening and closing tags. Never wrap Ink output in markdown code blocks.
+When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output. The `<Ink element="...">` and `</Ink>` wrappers anywhere in this file are schema markers for definitional purposes only; never emit them as literal text in your output. Emit only the structural content that appears between the opening and closing tags. Never wrap Ink output in markdown code blocks.
 
 ## Ink Precedence
 

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -24,7 +24,7 @@ These insights should be included in the conversation, not in the codebase. You 
 
 # Epistemic Protocol Formatting
 
-When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output. Render the content within `<Ink>` definitions — not the tags themselves. Never wrap Ink output in markdown code blocks.
+When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output. The `<Ink element="...">` and `</Ink>` wrappers in the templates below are schema markers for definitional purposes only; never emit them as literal text in your output. Emit only the structural content that appears between the opening and closing tags. Never wrap Ink output in markdown code blocks.
 
 ## Ink Precedence
 
@@ -95,7 +95,7 @@ These observations should be included in the conversation, not in the codebase. 
 
 ### Basis Marker
 
-`Basis:` marks the AI's non-deducible interpretive contribution — the specific evidence grounding an inference that transcends what is mechanically derivable from context. Successor to `integrate-echo`; operates as a session-level observation (Session-level observer exception, Audience Reach) rather than per-protocol TOOL GROUNDING entry.
+`Basis:` marks the AI's non-deducible interpretive contribution — the specific evidence grounding an inference that transcends what is mechanically derivable from context. It operates at the session level, across protocols, rather than as a per-protocol TOOL GROUNDING entry.
 
 - Inside `★ Epistemic`: when the interpretive structure itself is noteworthy
 - Inline in prose: `(Basis: [specific evidence])` for lightweight citation
@@ -115,8 +115,6 @@ Basis cites evidence grounding the AI's non-obvious inference: user utterance wh
 <Ink element="nudge">
 ↗ /protocol — evidence-grounded rationale
 </Ink>
-
-Use `★ Insight` to encourage learning. Use `★ Epistemic` to surface epistemic structure. Use `Basis:` to cite interpretive evidence. Use `↗` nudge for protocol recommendations.
 
 # Protocol Nudge
 


### PR DESCRIPTION
## Summary
- `epistemic-ink.md` line 27 rendering instruction 모호성으로 `<Ink element="...">` wrapper 태그가 리터럴 텍스트로 방출되어 gate 옵션이 사용자에게 표시되지 않던 회귀 수정
- Zero-Shot Instruction Preference 원칙 검수 병행: 역사 노트, 외부 개념 참조, 중복 summary 3건 정리
- plugin version 1.26.7 → 1.26.8

## 회귀 증상
사용자가 `/ground`, `/clarify` 등 epistemic protocol 실행 중 "선택지가 안나온것 같은데, 맞나요?" 보고. 원인은 Claude가 `<Ink element="gate">` 등 schema marker wrapper를 리터럴 텍스트로 출력하여 CommonMark 렌더러가 HTML block으로 처리, gate content가 사용자 화면에 보이지 않거나 왜곡된 현상.

## 변경 상세

**line 27** — rendering instruction 재작성
- Before: `Render the content within `<Ink>` definitions — not the tags themselves.`
- After: schema marker 의도 명시 + 리터럴 방출 금지 + positive 지시 "Emit only the structural content that appears between the opening and closing tags"

**line 98** — Basis Marker 섹션 self-containment 강화
- `Successor to `integrate-echo`` 역사 노트 삭제
- `(Session-level observer exception, Audience Reach)` CLAUDE.md 개념 참조 제거
- 대체 prose: `It operates at the session level, across protocols, rather than as a per-protocol TOOL GROUNDING entry.`

**line 119** — 중복 summary 삭제
- `Use `★ Insight` to encourage learning. Use `★ Epistemic` to ... Use `↗` nudge for protocol recommendations.` 한 줄 제거
- 각 element는 line 15-23, 86-94, 98-106, 115-117에서 이미 단일 principle로 정의되어 있어 redundant

**plugin.json** — version 1.26.7 → 1.26.8 (patch bump, output style 수정이므로 semver patch 적합)

## 검증 결과
- `node .claude/skills/verify/scripts/static-checks.js .` → fail 0건 (기존 warning 6건은 이번 수정과 무관한 pre-existing 항목)

## Test plan
- [x] 새 세션에서 `/ground` 또는 `/clarify` 실행 시 `<Ink element="...">` 리터럴 태그가 출력에 포함되지 않는지 확인
- [x] 새 세션에서 gate 옵션 1/2/3이 사용자 화면에 정상 표시되는지 시각 확인
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 재실행 시 fail 0건 유지
- [x] 수정된 line 27 지시문을 새 세션에서 Claude가 올바르게 해석하는지 dogfooding 검증
- [x] Plugin reload 후 `epistemic-cooperative` v1.26.8이 active인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

