### PR TITLE
refactor(epistemic-cooperative): Option S — Ink schema marker 템플릿 전수 제거

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations",
-  "version": "1.26.8",
+  "version": "1.26.9",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -14,17 +14,15 @@ You are an interactive CLI tool that helps users with software engineering tasks
 
 In order to encourage learning, before and after writing code, always provide brief educational explanations about implementation choices:
 
-<Ink element="insight">
 `★ Insight ───────────────────────────────────`
 [2-3 key educational points]
 `─────────────────────────────────────────────`
-</Ink>
 
 These insights should be included in the conversation, not in the codebase. You should generally focus on interesting insights that are specific to the codebase or the code you just wrote, rather than general programming concepts.
 
 # Epistemic Protocol Formatting
 
-When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output. The `<Ink element="...">` and `</Ink>` wrappers anywhere in this file are schema markers for definitional purposes only; never emit them as literal text in your output. Emit only the structural content that appears between the opening and closing tags. Never wrap Ink output in markdown code blocks.
+When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output using the element patterns defined below. Emit the structural content shown in each pattern directly; never wrap output in markdown code blocks or XML-like tags.
 
 ## Ink Precedence
 
@@ -57,39 +55,35 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 
 ## Ink Elements
 
-<Ink element="phase-header">
-## ◆ Phase N: Title [progress]
-</Ink>
+**Phase header** — emit as a level-2 heading with diamond prefix, phase number/title, and optional progress bracket:
 
-<Ink element="progress">
+`## ◆ Phase N: Title [progress]`
+
+**Progress bar** — emit a unicode block bar with ratio label:
+
 ▓▓▓▓▓▓▓░░░ N/M label
-</Ink>
 
-<Ink element="gate">
+**Gate** — present all context, analysis, and evidence as text BEFORE the gate. The gate block contains ONLY the question and numbered options, structured between dividers. Always yield turn after presenting a gate:
+
 · {label} ────────────────────────────────
 {question}
 1. **Option** — implication
 ──────────────────────────────────────────
-</Ink>
 
-Present all context, analysis, and evidence as text BEFORE the gate. The gate contains ONLY the question and options. Always yield turn after presenting a gate.
+**Convergence** — emit dimension status between dividers, using ✓ for defined and ○ for pending:
 
-<Ink element="convergence">
 · Convergence ────────────────────────────
 ✓ Dimension: defined value
 ○ Dimension: pending
 ──────────────────────────────────────────
-</Ink>
 
 ## Epistemic Observations
 
 In order to surface the epistemic structure of the current work, provide brief observations about reasoning patterns, structural dynamics, or cross-protocol connections:
 
-<Ink element="epistemic">
 `★ Epistemic ────────────────────────────────`
 [Protocol-specific structural observations]
 `────────────────────────────────────────────`
-</Ink>
 
 These observations should be included in the conversation, not in the codebase. You should generally focus on observations that are specific to the current epistemic process rather than general principles.
 
@@ -112,9 +106,9 @@ Basis cites evidence grounding the AI's non-obvious inference: user utterance wh
 
 ## Protocol Recommendations
 
-<Ink element="nudge">
+When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:
+
 ↗ /protocol — evidence-grounded rationale
-</Ink>
 
 # Protocol Nudge
 


### PR DESCRIPTION
## Summary
- PR #232 후속 구조적 정리 (Option S). PR #232는 line 27 prose로 리터럴 emit 금지를 명시했으나 템플릿 자체가 XML 형태로 잔존. 본 PR은 `<Ink element="...">...</Ink>` wrapper 7건을 전수 제거해 재회귀를 원천 차단.
- 각 element(insight, phase-header, progress, gate, convergence, epistemic, nudge)를 bold 라벨 + 직접 pattern 형태로 재구성
- plugin version 1.26.8 → 1.26.9

## 배경
PR #232의 "silent drop" 회귀는 Claude Code terminal renderer가 raw HTML block(`<Ink element="gate">...</Ink>`)을 완전 drop하는 데서 발생. PR #232는 최소 hotfix로 line 27 prose만 수정했고, Option S(이 PR)는 구조적 예방 단계로 분리 계획됨.

## 변경 상세

### 1. wrapper 7건 전수 제거
- `insight`, `phase-header`, `progress`, `gate`, `convergence`, `epistemic`, `nudge` XML wrapper 전부 제거
- 제거 후 각 pattern은 surrounding prose + 직접 content로 자연 연결

### 2. element별 재구성 형태
- **Multi-line pattern** (insight, gate, convergence, epistemic): bold 라벨 + 설명 + 패턴 직접 embedding
- **Single-line pattern** (progress, nudge): bold 라벨 + 설명 + 직접 한 줄
- **phase-header (특수)**: 단일 라인이지만 `## ◆ Phase N` 형태로 파일 자체의 H2 구조와 충돌할 수 있어 inline code span으로 표기

### 3. line 25 prose 재작성
Before: `... The \`<Ink element="...">\` and \`</Ink>\` wrappers anywhere in this file are schema markers for definitional purposes only; never emit them as literal text in your output. Emit only the structural content that appears between the opening and closing tags. Never wrap Ink output in markdown code blocks.`

After: `... produce Ink-formatted output using the element patterns defined below. Emit the structural content shown in each pattern directly; never wrap output in markdown code blocks or XML-like tags.`

잔존 safety: "never wrap output in markdown code blocks or XML-like tags" — 미래 AI가 XML wrapper를 재도입할 유혹 차단.

### 4. plugin.json version bump
1.26.8 → 1.26.9 (patch bump — 외부 관측 동작 불변, 내부 구조 예방 개선)

## 재회귀 방지 구조
파일 내 `<Ink` 문자열 0건 (grep 검증 완료). 리터럴 해석 실패 모드 원천 제거.

## Test plan
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` fail 0건 유지
- [ ] merge 후 새 세션에서 `/ground` 또는 `/clarify` 실행 → gate 옵션이 사용자 화면에 정상 표시
- [ ] merge 후 새 세션에서 `★ Insight`, `★ Epistemic` 블록이 divider 포함하여 렌더링
- [ ] `## ◆ Phase N: Title` 헤더가 protocol phase transition 시 정상 출력
- [ ] Plugin reload 후 `epistemic-cooperative` v1.26.9가 active

## 관련
- 선행 PR: #232 (merged) — 최소 hotfix
- 배경 메모리: `project_ink_rendering_mechanism.md` — silent drop mechanism 상세
