### PR TITLE
feat(prothesis): Phase 3 coordinator wait behavior 규칙 추가

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.15.9",
+  "version": "5.16.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
-  "version": "5.15.8",
+  "version": "5.15.9",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -14,7 +14,7 @@ Resolve absent frameworks by placing available epistemic perspectives before the
 ```
 ── FLOW ──
 Prothesis(U) → Q(MB(U), M) → (MBᵥ, m) → G(MBᵥ) → C → {P₁...Pₙ}(C, MBᵥ) → S → Pₛ → LensEstablished →
-  T(Pₛ) → ∥I(T) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
+  T(Pₛ) → ∥I(T) → Await(T) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
 
 ── MORPHISM ──
 Inquiry
@@ -25,6 +25,7 @@ Inquiry
   → LensEstablished                     -- Mode 1 terminus; composable with downstream protocols
   → spawn(team)                         -- assemble perspective team via TeamCreate
   → inquire(parallel)                   -- isolated perspective analysis per teammate
+  → await(notifications)                -- passive wait for teammate completion signals (see TOOL GROUNDING)
   → collect(results)                    -- finalize inquiry outputs, retain team
   → preview(results)                    -- surface collected findings before synthesis
   → dialogue(triggers) → reports        -- peer negotiation → structured dialogue reports
@@ -54,7 +55,11 @@ S      = Selection: {P₁...Pₙ} → Pₛ             -- extern (user choice; P
 Pₛ     = Selected perspectives (Pₛ = Pᵦ ∪ sel({P₁...Pₙ}), |Pₛ| ≥ 2 when m=inquire; |Pₛ| ≥ 1 when m=recommend)
 LensEstablished = Pₛ where lens selection complete  -- intermediate checkpoint; Mode 1 terminus (J=recommend), Mode 2 continues
 T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with shared task list
-∥I     = Parallel inquiry: (∥ p∈T. Inquiry(p)) → R
+∥I     = Parallel inquiry dispatch: T → (∥ p∈T. Inquiry(p) running) [side effect]
+         -- followed by Await in FLOW/MORPHISM to produce R
+Await  = Passive completion barrier: T → R
+         -- realized via IdleNotification arrival per TOOL GROUNDING; teammate→coordinator
+         -- delivery occurs at coordinator turn boundary, not at teammate send time
 Ω      = Collection: R → R', retain(T)               -- finalize results; team lifecycle deferred to loop
 R      = Set(Result)                                  -- raw inquiry outputs
 R'     = Set(Result) post-collection                  -- after Phase 3 collection
@@ -92,7 +97,7 @@ Edge cases:
 Phase 0:  U → MB(U) → Qc(MB, M) → Stop → (MBᵥ, m)              -- combined MB confirmation + mode selection [Tool]
 Phase 1:  MBᵥ → G(MBᵥ) → C                                      -- targeted context acquisition
 Phase 2:  (C, MBᵥ) → Sc({P₁...Pₙ}(C, MBᵥ)) → Stop → Pₛ → LensEstablished  -- perspective selection [Tool]
-Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: relay | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + inquiry + collection + preview [Tool]
+Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: relay | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → Await[Notification](T) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + inquiry dispatch + wait + collection + preview [Tool]
 Phase 4:  R' → Δ(R') → Δₛ → D?(Δₛ)[SendMessage](T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Qc(routing) → Stop → J  -- triggers, cross-dialogue, synthesis, presentation & routing [Tool]
           J=wrap_up → PF Qc(select) → Stop → Ω → TeamDelete → TaskCreate(selected)  [Tool]
 
@@ -135,7 +140,8 @@ Phase 0 Qc (gate)        → present (combined: Q1=Mission Brief confirmation, Q
 Sc (gate)                → present (mandatory; multiSelect: true; Esc key → loop termination at LOOP level)
 T (dispatch)             → TeamCreate tool (parallel topology: creates team with shared task list); agent-aware realization: match available agents to selected perspectives before spawn — 0 matches: proceed with AI-generated teammates; 1 match: relay (auto-assign); 2+ matches: ELIDABLE gate (user confirms agent-perspective mapping, each option genuinely viable under different value weightings per A5)
 ∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates — each receives MBᵥ + perspective only; no Phase 1 context G passed)
-∥I (track)               → TaskCreate/TaskUpdate (parallel topology: shared task list for inquiry coordination)
+∥I (track)               → TaskCreate/TaskUpdate (parallel topology: shared task list for inquiry coordination — dispatch phase)
+Await (sense)            → IdleNotification (platform realization: teammate SubagentStop events surface as coordinator idle notifications; teammate→coordinator message delivery occurs at coordinator turn boundary, not at teammate send time — passive wait, no coordinator poll; async message-passing execution model)
 Phase 3 P (relay)        → TextPresent+Proceed (per-perspective epistemic contribution + key finding summaries)
 Phase 4 Δ (sense)        → Internal operation (trigger check per Trigger Detection Criteria; cite evidence per detected trigger)
 Phase 4 D? (dispatch)    → SendMessage tool (conditional topology: coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke; skip if Δₛ = ∅)
@@ -408,11 +414,6 @@ Multiple selections → parallel teammates (never sequential).
 
 Teammates analyze independently. Results arrive via idle notifications.
 
-**Coordinator wait behavior during Inquiry**:
-- Teammate→coordinator messages reach the coordinator's context at the *next* coordinator turn start — coordinator Stop events do not drain the inbox. The next tool call or notification opens a turn during which queued messages are read.
-- Do not re-prompt a teammate within 2 minutes of the prior prompt. Shorter intervals risk interrupting mid-composition and inducing content revision rather than resolving silence.
-- When waiting, rely on idle notifications to resume — do not poll or issue ping-style prompts.
-
 **Collection and Preview**
 
 Collect inquiry results into R'. Team remains active — shutdown/retain decisions are deferred to the LOOP section after Phase 4 routing, where the user's sufficiency judgment determines team lifecycle.
@@ -561,3 +562,4 @@ Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidenc
 11. **Concrete routing**: Phase 4 routing options must include session-specific rationale derived from L. Generic labels without Lens-grounded content = protocol violation (analogical application of Full Taxonomy Confirmation — session-grounded concreteness over generic labels)
 12. **Option-set relay test**: Before presenting gate options, apply the relay test to the option set: if AI analysis converges to a single dominant option (option-level entropy→0), the interaction is relay — present the finding directly instead of wrapping it in false options. Each gate option must be genuinely viable under different user value weightings
 13. **Gate integrity**: Do not inject options not in the definition, delete defined options, or substitute defined options with different ones (gate mutation). Type-preserving materialization — specializing a generic option into a concrete term while preserving the TYPES coproduct structure — is permitted and distinct from mutation
+14. **Wait discipline (A7 guard)**: During Phase 3 Await, the coordinator MUST NOT poll, ping, or re-prompt teammates — short-interval re-prompts interrupt teammate mid-composition and induce content revision rather than resolving apparent silence. Platform-specific delivery mechanics are documented in TOOL GROUNDING (Await realization); epistemic prose depends only on the existence of a completion signal, not on its platform form. Recovery from indefinite wait is user-initiated via `user_esc` per LOOP convergence; coordinator-side polling fallback = protocol violation

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -408,6 +408,11 @@ Multiple selections → parallel teammates (never sequential).
 
 Teammates analyze independently. Results arrive via idle notifications.
 
+**Coordinator wait behavior during Inquiry**:
+- Teammate→coordinator messages reach the coordinator's context at the *next* coordinator turn start — coordinator Stop events do not drain the inbox. The next tool call or notification opens a turn during which queued messages are read.
+- Do not re-prompt a teammate within 2 minutes of the prior prompt. Shorter intervals risk interrupting mid-composition and inducing content revision rather than resolving silence.
+- When waiting, rely on idle notifications to resume — do not poll or issue ping-style prompts.
+
 **Collection and Preview**
 
 Collect inquiry results into R'. Team remains active — shutdown/retain decisions are deferred to the LOOP section after Phase 4 routing, where the user's sufficiency judgment determines team lifecycle.

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -14,7 +14,7 @@ Resolve absent frameworks by placing available epistemic perspectives before the
 ```
 ── FLOW ──
 Prothesis(U) → Q(MB(U), M) → (MBᵥ, m) → G(MBᵥ) → C → {P₁...Pₙ}(C, MBᵥ) → S → Pₛ → LensEstablished →
-  T(Pₛ) → ∥I(T) → Await(T) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
+  T(Pₛ) → ∥I(T) → Await(T_running) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
 
 ── MORPHISM ──
 Inquiry
@@ -55,11 +55,9 @@ S      = Selection: {P₁...Pₙ} → Pₛ             -- extern (user choice; P
 Pₛ     = Selected perspectives (Pₛ = Pᵦ ∪ sel({P₁...Pₙ}), |Pₛ| ≥ 2 when m=inquire; |Pₛ| ≥ 1 when m=recommend)
 LensEstablished = Pₛ where lens selection complete  -- intermediate checkpoint; Mode 1 terminus (J=recommend), Mode 2 continues
 T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with shared task list
-∥I     = Parallel inquiry dispatch: T → (∥ p∈T. Inquiry(p) running) [side effect]
-         -- followed by Await in FLOW/MORPHISM to produce R
-Await  = Passive completion barrier: T → R
-         -- realized via IdleNotification arrival per TOOL GROUNDING; teammate→coordinator
-         -- delivery occurs at coordinator turn boundary, not at teammate send time
+T_running = Team with inquiries in flight             -- intermediate state between dispatch and completion
+∥I     = Parallel inquiry dispatch: T → T_running    -- per-teammate Inquiry(p) launched
+Await  = Passive completion barrier: T_running → R   -- see TOOL GROUNDING (Await entry) for realization
 Ω      = Collection: R → R', retain(T)               -- finalize results; team lifecycle deferred to loop
 R      = Set(Result)                                  -- raw inquiry outputs
 R'     = Set(Result) post-collection                  -- after Phase 3 collection
@@ -97,7 +95,7 @@ Edge cases:
 Phase 0:  U → MB(U) → Qc(MB, M) → Stop → (MBᵥ, m)              -- combined MB confirmation + mode selection [Tool]
 Phase 1:  MBᵥ → G(MBᵥ) → C                                      -- targeted context acquisition
 Phase 2:  (C, MBᵥ) → Sc({P₁...Pₙ}(C, MBᵥ)) → Stop → Pₛ → LensEstablished  -- perspective selection [Tool]
-Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: relay | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → Await[Notification](T) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + inquiry dispatch + wait + collection + preview [Tool]
+Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: relay | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → Await[IdleNotification](T_running) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + inquiry dispatch + wait + collection + preview [Tool]
 Phase 4:  R' → Δ(R') → Δₛ → D?(Δₛ)[SendMessage](T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Qc(routing) → Stop → J  -- triggers, cross-dialogue, synthesis, presentation & routing [Tool]
           J=wrap_up → PF Qc(select) → Stop → Ω → TeamDelete → TaskCreate(selected)  [Tool]
 
@@ -116,6 +114,11 @@ After LensEstablished (mode branching):
       Pₛ.count = 1 → lightweight context modifier for downstream protocol
       Pₛ.count ≥ 2 → domain-narrowing (Tier 1) or escalate to Mode 2 (Tier 2)
   J = inquire → Continue to Phase 3 (team spawn → parallel inquiry → synthesis → FramedInquiry)
+
+During Phase 3 (Inquiry, including Await):
+  Coordinator is passive during Await: no polling, no status checks, no passive observation per Rule 14 wait discipline
+  Esc key → tool-level termination (no gate tool open; team orphaned per user_esc)
+  -- Recovery from indefinite wait is user-initiated; no timeout or polling fallback
 
 After Phase 4 (routing):
   J = extend     → Qc(add perspective | deepen existing | review execution results) → Stop
@@ -141,7 +144,7 @@ Sc (gate)                → present (mandatory; multiSelect: true; Esc key → 
 T (dispatch)             → TeamCreate tool (parallel topology: creates team with shared task list); agent-aware realization: match available agents to selected perspectives before spawn — 0 matches: proceed with AI-generated teammates; 1 match: relay (auto-assign); 2+ matches: ELIDABLE gate (user confirms agent-perspective mapping, each option genuinely viable under different value weightings per A5)
 ∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates — each receives MBᵥ + perspective only; no Phase 1 context G passed)
 ∥I (track)               → TaskCreate/TaskUpdate (parallel topology: shared task list for inquiry coordination — dispatch phase)
-Await (sense)            → IdleNotification (platform realization: teammate SubagentStop events surface as coordinator idle notifications; teammate→coordinator message delivery occurs at coordinator turn boundary, not at teammate send time — passive wait, no coordinator poll; async message-passing execution model)
+Await (sense)            → IdleNotification (passive wait: teammate SubagentStop events surface as coordinator idle notifications; teammate→coordinator message delivery occurs at coordinator turn boundary, not at teammate send time; async message-passing execution model; no coordinator poll per Rule 14)
 Phase 3 P (relay)        → TextPresent+Proceed (per-perspective epistemic contribution + key finding summaries)
 Phase 4 Δ (sense)        → Internal operation (trigger check per Trigger Detection Criteria; cite evidence per detected trigger)
 Phase 4 D? (dispatch)    → SendMessage tool (conditional topology: coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke; skip if Δₛ = ∅)
@@ -412,7 +415,7 @@ Multiple selections → parallel teammates (never sequential).
 
 **Inquiry**
 
-Teammates analyze independently. Results arrive via idle notifications.
+Teammates analyze independently. Coordinator awaits completion signals per Rule 14 wait discipline (passive wait, no polling, no status observation).
 
 **Collection and Preview**
 
@@ -562,4 +565,12 @@ Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidenc
 11. **Concrete routing**: Phase 4 routing options must include session-specific rationale derived from L. Generic labels without Lens-grounded content = protocol violation (analogical application of Full Taxonomy Confirmation — session-grounded concreteness over generic labels)
 12. **Option-set relay test**: Before presenting gate options, apply the relay test to the option set: if AI analysis converges to a single dominant option (option-level entropy→0), the interaction is relay — present the finding directly instead of wrapping it in false options. Each gate option must be genuinely viable under different user value weightings
 13. **Gate integrity**: Do not inject options not in the definition, delete defined options, or substitute defined options with different ones (gate mutation). Type-preserving materialization — specializing a generic option into a concrete term while preserving the TYPES coproduct structure — is permitted and distinct from mutation
-14. **Wait discipline (A7 guard)**: During Phase 3 Await, the coordinator MUST NOT poll, ping, or re-prompt teammates — short-interval re-prompts interrupt teammate mid-composition and induce content revision rather than resolving apparent silence. Platform-specific delivery mechanics are documented in TOOL GROUNDING (Await realization); epistemic prose depends only on the existence of a completion signal, not on its platform form. Recovery from indefinite wait is user-initiated via `user_esc` per LOOP convergence; coordinator-side polling fallback = protocol violation
+14. **Wait discipline**: During Phase 3 Await, the coordinator MUST NOT (a) re-prompt teammates regardless of interval duration — any re-prompt risks interrupting teammate mid-composition and inducing content revision rather than resolving apparent silence; (b) observe teammate state passively (TaskList reads, agent memory inspection, filesystem reads under team directories) as a basis for behavioral decisions before the completion signal arrives — passive observation defeats passive-wait semantics and is an A7 rationalization path disguised as "task tracking, not polling"; (c) proceed with partial R — Await converges only when all teammates in T have signaled completion, and partial collection without `user_esc` violates A3 Convergence Persistence. Scope: Phase 3 inquiry wait only; Phase 4 hub-spoke step 4 content-bearing follow-ups are sent after peers have idled and are out of scope. Platform-specific delivery mechanics are documented in TOOL GROUNDING (Await entry); epistemic prose depends only on the existence of a completion signal, not on its platform form. Recovery from indefinite wait is user-initiated via `user_esc` per LOOP; any of (a)/(b)/(c) = protocol violation
+
+## Known Limitations
+
+**SubagentStop signal semantics**: The Await completion signal (IdleNotification) is realized on top of the platform's SubagentStop event. Whether SubagentStop fires on all teammate exits (including crashes, errors, and silent failures) is platform-specific and not guaranteed by the protocol definition. If SubagentStop is unary (fires on all exits), a crashed teammate produces an IdleNotification with empty output — the coordinator observes failure indirectly via the Preview P(R') step. If SubagentStop does not fire on abnormal termination, a crashed teammate produces no signal, and Await must rely on `user_esc` recovery per LOOP.
+
+**Teammate crash vs. composition indistinguishability**: The protocol defines no direct failure signal for teammates. A teammate still mid-composition and a teammate that has crashed are indistinguishable at the protocol layer until a completion signal (or `user_esc`) arrives. The coordinator cannot distinguish these states without violating Rule 14's passive-wait discipline. User experience of the wait is the primary failure-detection surface.
+
+**TaskUpdate vs. IdleNotification release ordering**: Teammates use TaskUpdate to mark task status (observability track); IdleNotification is the Await-release signal (completion track). In the typical path, a teammate's final SendMessage and TaskUpdate precede its SubagentStop, so IdleNotification dominates TaskUpdate in release ordering. Abnormal paths (crash before TaskUpdate; idle without task completion) are not strictly ordered by the protocol and surface as empty or partial output at Preview P(R').


### PR DESCRIPTION
## Summary
- Prothesis Phase 3 Inquiry에 **Coordinator wait behavior** 3-bullet 가이드 추가
- hooks.log session `03165894` 실증 분석에서 확인된 turn-end flush × main Stop coordination deficit 해결
- `prothesis/.claude-plugin/plugin.json` 5.15.8 → 5.15.9 patch bump
- **Update (commit `007f899`)**: 리뷰 피드백 수용하여 formal-first 재작성 — 3-bullet 제거 후 FLOW/MORPHISM/TYPES/PHASE TRANSITIONS/TOOL GROUNDING/Rules 6개 formal layer에 분산, plugin.json 5.15.9 → 5.16.0 MINOR bump. 상세는 [이 comment](https://github.com/jongwony/epistemic-protocols/pull/234#issuecomment-4225116592) 참조.

## Context
Claude Code Team messaging 바이너리 조사 (2.1.94 ~ 2.1.100 바이트 단위 동일) 결과:
- `teammate→main` SendMessage handler는 inbox 파일 write만 수행하며 **동기 wake 호출 없음**
- Main의 inbox 반영은 **main의 다음 turn 시작 시점**에 conversation context로 재조립
- Main이 대기 중 반복 Stop 또는 짧은 간격 재촉을 보낼 때 설계와 상호작용하여 지연 인지 + teammate revision 유발

Empirical evidence (session `03165894-a2d3-416c-bde4-df527773d892`):

| 시각 | 이벤트 |
|---|---|
| 16:20:25 | rel-eng → team-lead 전송 |
| 16:20:48 | main → sec-eng 2차 독촉 (rel-eng 인지 실패) |
| 16:20:52 | main Stop last_message: `"sec-eng에 재요청. api-arch, rel-eng, shell-eng 완료 대기 중"` |
| 16:22:04, 16:22:38 | main → api-arch 재촉 (34초 간격) |
| 16:23:25, 16:24:42 | api-arch → team-lead 수정본 재전송 (6684 vs 6862 bytes) |

## Changes (최종, commit `007f899` 기준)

Formal-first 재작성 — FLOW/MORPHISM/TYPES/PHASE TRANSITIONS/TOOL GROUNDING/Rules 6개 layer에 분산:

1. **FLOW**: `∥I(T) → Await(T) → R`로 wait 단계 명시
2. **MORPHISM**: `await(notifications)` step 삽입
3. **TYPES**: `∥I` → dispatch(side effect) 재정의, `Await: T → R` 신규 타입
4. **PHASE TRANSITIONS** Phase 3: `Await[Notification](T)` 단계 삽입
5. **TOOL GROUNDING**: `Await (sense) → IdleNotification` realization entry
6. **Rules**: Rule 14 "Wait discipline (A7 guard)" 신설
7. Phase 3 Inquiry prose: 초기 커밋의 3-bullet 제거 (formal layer가 받치므로 불필요)

`plugin.json`: `5.15.8` → `5.15.9` → `5.16.0` (MINOR, 형식 블록 구조 변경)

**Breaking**: `∥I` 시그니처 `T → R` → `T → (side effect)`. 외부 참조 없음 (Prothesis 내부만).

## Verification
- `/verify` static-checks 15종 **pass (fail=0)** — 두 차례 확인
- 기존 warning 6건 모두 pre-existing (이번 변경 무관)
- Aitesis + Analogia + Epharmoge 3단계 epistemic checkpoint로 empirical 증거 검증 후 변경

## Test plan
- [x] `node .claude/skills/verify/scripts/static-checks.js .` 실행하여 fail=0 재확인
- [ ] 다음 `/frame` Mode 2 활성화 세션에서 main agent가 Stop 반복 대신 대기 유지하는지 관찰
- [ ] 다음 `/frame` Mode 2 세션에서 teammate 재독촉 간격이 2분 이상 유지되는지 관찰
- [ ] `claude-code-review.yml` 3-stage pipeline 통과 (CI)
- [ ] `claude-epistemic-review.yml` (protocol 변경 감지) 통과 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
