### PR TITLE
fix(epistemic-cooperative): Gate abstract-concrete binding 복원

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations",
-  "version": "1.26.9",
+  "version": "1.26.10",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -63,7 +63,7 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 
 ▓▓▓▓▓▓▓░░░ N/M label
 
-**Gate** — present all context, analysis, and evidence as text BEFORE the gate. The gate block contains ONLY the question and numbered options, structured between dividers. Always yield turn after presenting a gate:
+**Gate** — the Ink realization of SKILL.md's `present` verb. The divider block below IS the gate: the `· {label} ─` top divider and terminal `──` bottom bracket a structured choice region, and emitting this region as terminal text followed by turn yield satisfies SKILL.md's `present(structured content) → yield turn → parse response` contract natively — the structural form carries the contract, no wrapper or tool call is required. Present all context, analysis, and evidence as text BEFORE the gate block; the gate block contains ONLY the question and numbered options. Always yield turn after emitting the gate:
 
 · {label} ────────────────────────────────
 {question}


### PR DESCRIPTION
## Summary
- Option S(e5e4852) merge 이후 Gate 영역에서 AskUserQuestion 호출이 기하급수적으로 증가한 회귀의 원인 진단 + 수정
- `epistemic-cooperative/styles/epistemic-ink.md:66` Gate element 서술에 abstract-concrete binding을 명시적으로 복원
- `epistemic-cooperative/.claude-plugin/plugin.json` 1.26.9 → 1.26.10 patch bump

## Context
`/inquire` 세션 진단 결과:

**Option S 이전** (`011171e` 시점): Gate 블록이 `<Ink element="gate">...</Ink>` wrapper로 감싸져 **식별 축**과 **렌더링 축**을 동시에 수행. 그러나 wrapper가 리터럴 tag로 방출되면 block element의 silent drop 현상 발생 → 사용자에게 옵션 비가시 회귀.

**Option S** (`e5e4852`): 7개 wrapper 전수 제거로 렌더링 실패 모드를 방어. 의도는 "재회귀 방지".

**Option S의 부작용**: schema marker가 수행하던 **식별 축** 기능(`gate`라는 추상 이름을 구체 divider template에 binding하는 self-referential anchor)이 함께 제거됨. Realization Mapping 테이블은 `present → gate`를 선언하지만, 파일 내부 어디에도 `gate`라는 이름이 붙은 구체 인스턴스가 부재. LLM이 SKILL.md의 `present` verb를 realize할 때 파일 내에서 완결된 근거 경로를 찾지 못해 **tool-backed fallback**(AskUserQuestion)으로 수렴.

메모리 `project_ink_rendering_mechanism.md`는 "block silent drop" 렌더링 축은 기술하지만, schema marker의 식별 축 기능은 별도로 다루지 않음. 두 축이 분리되어 있었고 Option S가 렌더링 축 수정 과정에서 식별 축을 부수 훼손한 것이 이번 회귀의 구조적 원인.

## Changes

`epistemic-cooperative/styles/epistemic-ink.md:66` Gate element 서술:

**Before**:
> **Gate** — present all context, analysis, and evidence as text BEFORE the gate. The gate block contains ONLY the question and numbered options, structured between dividers. Always yield turn after presenting a gate:

**After**:
> **Gate** — the Ink realization of SKILL.md's \`present\` verb. The divider block below IS the gate: the \`· {label} ─\` top divider and terminal \`──\` bottom bracket a structured choice region, and emitting this region as terminal text followed by turn yield satisfies SKILL.md's \`present(structured content) → yield turn → parse response\` contract natively — the structural form carries the contract, no wrapper or tool call is required. Present all context, analysis, and evidence as text BEFORE the gate block; the gate block contains ONLY the question and numbered options. Always yield turn after emitting the gate:

Template 본체(line 68-71 divider 패턴)는 **변경 없음**.

## Design 원칙

세 가지 binding을 한 문장 안에 명시:

1. **이름 → 계약**: "the Ink realization of SKILL.md's \`present\` verb"
2. **형태 → 이름**: "the divider block below IS the gate" (동일성 관계)
3. **형태 → 계약**: "the structural form carries the contract"

**White bear problem 회피**: 특정 tool 이름(AskUserQuestion)을 명시적으로 배제하지 않음. 대신 divider 형태가 이미 `present → yield → parse` 계약의 realizer로 충분함을 positive rationale로 선언 — "no wrapper or tool call is required"는 일반적 부정이며 특정 tool을 이름으로 환기하지 않음.

## Non-Goals

- line 25, 29의 기존 negative framing(\"never wrap\", \"Do not degrade\")은 **건드리지 않음** — 별도 이슈, traceable diff 원칙에 따라 이번 scope 밖
- Realization Mapping table(line 41)은 **건드리지 않음** — Gate element 서술의 \"IS the gate\" 앵커가 이미 binding을 완성하므로 중복 수정 불필요

## Test plan
- [ ] \`node .claude/skills/verify/scripts/static-checks.js .\` 실행하여 0 fail 확인 (기존 warning은 이번 변경과 무관)
- [ ] CI 리뷰 pipeline (claude-code-review.yml) 통과 확인
- [ ] 새 세션에서 `/inquire` 또는 `/gap` 등 Gate를 사용하는 프로토콜 호출 시 divider block이 inline text로 방출되고 AskUserQuestion으로 fallback하지 않는지 육안 확인
- [ ] 새 세션에서 Epistemic Ink Output Style 재로딩 후 Gate 블록의 option 가시성 확인 (011171e 시점의 silent drop 회귀가 재발하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)