### PR TITLE
fix(verify): Horismos Stage 2 — detector loud mode + liveness 자동화

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 const { execFileSync } = require('child_process');
 
 const projectRoot = process.argv[2] || process.cwd();
@@ -1270,11 +1271,22 @@ function checkCrossRefScan() {
         }
       }
     } catch (e) {
-      results.warn.push({
+      // Stage 2 loud mode (upstream scope): this readdir is the ground-truth
+      // source for cross-ref-scan Sources 1, 2, 3, and 4. If it fails,
+      // allPluginDirs is empty, every downstream source sees an empty
+      // filesystem view, every bidirectional diff collapses to zero findings,
+      // and the entire cross-ref-scan check would silently pass with no
+      // detection. This is the exact silent-failure CLASS Stage 2 closes in
+      // Source 3, at an upstream scope that covers all four sources.
+      // Escalate to fail + subCheckFailed per fail-closed policy —
+      // review-ensemble cross-model agreement (Codex gpt-5.4 high +
+      // silent-failure-hunter) flagged this during PR development.
+      results.fail.push({
         check: 'cross-ref-scan',
         file: '.',
-        message: `Could not scan plugin directories: ${e.message}`
+        message: `Could not scan plugin directories (upstream ground truth): ${e.message}`
       });
+      subCheckFailed = true;
     }
 
     // Protocol-only subset (dirs listed in PROTOCOL_FILES)
@@ -1336,37 +1348,84 @@ function checkCrossRefScan() {
     // into verify output. package.js contributors must keep all effects behind
     // function boundaries or the main-module guard.
     const packageJsPath = path.resolve(projectRoot, 'scripts', 'package.js');
-    if (fs.existsSync(packageJsPath)) {
-      let PLUGINS;
+    if (!fs.existsSync(packageJsPath)) {
+      // Loud failure: package.js is a required input for the publication-surface
+      // check. Missing file is a detector-infrastructure problem, not a migration
+      // signal — escalate to subCheckFailed per Stage 2 loud-mode policy.
+      results.fail.push({
+        check: 'cross-ref-scan',
+        file: 'scripts/package.js',
+        message: 'Required file not found — cross-ref-scan Source 3 cannot verify publication surface'
+      });
+      subCheckFailed = true;
+    } else {
+      let PLUGINS = null;
+      let loadFailed = false;
       try {
         // Invalidate require cache so repeated static-check runs pick up edits.
         delete require.cache[require.resolve(packageJsPath)];
         ({ PLUGINS } = require(packageJsPath));
       } catch (e) {
-        results.warn.push({
+        // Stage 2 loud mode: require() failure is a detector-infrastructure
+        // failure (the detector itself cannot run), not a migration signal.
+        // Escalate to subCheckFailed so the bug class that caused the PR #242
+        // critical path.resolve incident cannot recur as a silent no-op.
+        results.fail.push({
           check: 'cross-ref-scan',
           file: 'scripts/package.js',
           message: `Could not load package.js PLUGINS: ${e.message}`
         });
-        PLUGINS = null;
+        subCheckFailed = true;
+        loadFailed = true;
       }
 
-      if (Array.isArray(PLUGINS)) {
-        // Structural guard: filter malformed tuples and emit distinct warnings
-        // for them. Without this, a missing `skill` key produces the string
-        // `"dir/undefined"` which flows into the set-diff as a misleading
-        // `stale-plugins-entry` warning. The filter ensures real shape errors
-        // surface as parse errors, not as phantom filesystem mismatches.
+      if (!loadFailed && !Array.isArray(PLUGINS)) {
+        // Stage 2 loud mode: require() succeeded but the PLUGINS export is
+        // absent or has a non-Array shape (e.g., hand-edit breakage, typo in
+        // module.exports). Treat as detector-infrastructure failure — without a
+        // valid PLUGINS array we cannot diff against the filesystem.
+        // Shape description handles null specially — `typeof null === 'object'`
+        // would produce the misleading "got object" for a null export.
+        const shapeDesc =
+          PLUGINS === undefined ? 'undefined'
+            : PLUGINS === null ? 'null'
+            : typeof PLUGINS;
+        results.fail.push({
+          check: 'cross-ref-scan',
+          file: 'scripts/package.js',
+          message: `PLUGINS export shape invalid — expected Array, got ${shapeDesc}`
+        });
+        subCheckFailed = true;
+      } else if (!loadFailed && Array.isArray(PLUGINS)) {
+        // Structural guard: filter malformed tuples and escalate each to
+        // fail + subCheckFailed (Stage 2 loud mode). Without this, a missing
+        // `skill` key produces the string `"dir/undefined"` which flows into
+        // the set-diff as a misleading `stale-plugins-entry` warning. Loud
+        // mode ensures real shape errors surface as parse errors that block
+        // CI, not as phantom filesystem mismatches tolerated silently.
+        //
+        // Partial-processing note: valid tuples continue through the
+        // bidirectional diff below even when some entries are malformed.
+        // A malformed entry may ALSO produce a downstream publication-gap
+        // warning for the SKILL.md it would have covered — one root cause,
+        // two diagnostics. This is intentional post-escalation noise; the
+        // malformed-plugins-entry fail is the actionable signal, and
+        // contributors should fix that first.
         const validPlugins = [];
         for (const p of PLUGINS) {
           if (p && typeof p.dir === 'string' && typeof p.skill === 'string') {
             validPlugins.push(p);
           } else {
-            results.warn.push({
+            // util.inspect handles circular references, BigInt, and other
+            // values that would make JSON.stringify throw — we must not
+            // abort the verifier through an unguarded serialization error.
+            const serialized = util.inspect(p, { depth: 2, breakLength: 80 });
+            results.fail.push({
               check: 'cross-ref-scan',
               file: 'scripts/package.js',
-              message: `malformed-plugins-entry: expected { dir: string, skill: string } tuple, got ${JSON.stringify(p)}`
+              message: `malformed-plugins-entry: expected { dir: string, skill: string } tuple, got ${serialized}`
             });
+            subCheckFailed = true;
           }
         }
 
@@ -1399,8 +1458,12 @@ function checkCrossRefScan() {
           }
         }
 
-        // Bidirectional diff (tuple-level; warning-only — fail escalation is a
-        // follow-up PR so detector and detected migration land separately).
+        // Bidirectional diff. publication-gap and stale-plugins-entry remain
+        // warning-only — these are migration signals (code and filesystem out
+        // of sync mid-refactor), not detector-infrastructure failures. Stage 2
+        // escalates only the infrastructure failure modes above (file missing,
+        // load failure, shape invalid, malformed entry). Drift-detection
+        // escalation is a separate downstream PR, gated on clean warnings.
         for (const tuple of filesystemTuples) {
           if (!packagePluginTuples.has(tuple)) {
             results.warn.push({

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -9,6 +9,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
 const path = require('node:path');
 const zlib = require('zlib');
 const { parseFrontmatter, serializeFrontmatter, transformSkillMd, createZip, generateReleaseNotes } = require('./package');
@@ -403,14 +404,173 @@ describe('package.js CLI', () => {
         'write.zip',
       ],
     );
-    // Bundle file count decomposition: the prior 22 reflected 13 plugins × avg
-    // ~1.7 files each (SKILL.md + optional plugin.json + optional references).
-    // The 6 new publication-surface plugins (reflexion, write, and the 4
-    // epistemic-cooperative sub-skills) contribute ~16 additional files
-    // (SKILL.md + plugin.json/frontmatter + sporadic references/agents), giving
-    // the 38 total. This assertion is brittle under any new file addition
-    // anywhere in a packaged dir — a follow-up PR will replace it with a
-    // contract invariant (e.g., zip-set contains bundle, PLUGINS.length + 1).
-    assert.equal(bundle.files, 38);
+    // Lower-bound invariant: the 38 baseline reflects 13 original + 6
+    // publication-surface plugins × ~2 files each at PR #242 merge time. Any
+    // additive change (new plugin, new reference doc, new agent) only
+    // increases this count. A shrink indicates an unintended regression
+    // (plugin removed or files accidentally excluded from the packager),
+    // which should fail. This replaces the brittle equality assertion from
+    // PR #242 — three independent reviewers flagged the original as
+    // fragile under additive changes (cross-model convergence).
+    assert.ok(
+      bundle.files >= 38,
+      `expected bundle.files >= 38 (regression guard), got ${bundle.files}`
+    );
+  });
+});
+
+// ============================================================
+// cross-ref-scan detector liveness (Task #22 → automated)
+// ============================================================
+//
+// This block MUST stay in package.test.js (not a separate file). Node's test
+// runner parallelizes across files via child processes but runs top-level
+// tests within a single file sequentially. The liveness test mutates
+// scripts/package.js via fs.writeFileSync, and the CLI describe above spawns
+// a subprocess that reads the same file. Placing the two describes in
+// SEPARATE files would cause a cross-file race (confirmed during Stage 2
+// development: liveness.test.js + package.test.js run concurrently → CLI
+// subprocess sees mutated 19-entry PLUGINS → result.results.length !== 20).
+// Keeping both in this single file guarantees sequential execution of
+// top-level describes, eliminating the race by construction.
+//
+// This is the automated form of the Task #22 manual liveness pattern used
+// during PR #242 review. It proves the detector is ALIVE — i.e., it
+// distinguishes "detector ran and found nothing" (correct, warnings empty)
+// from "detector crashed silently" (regression, warnings empty). By
+// injecting a known publication gap and asserting the warning fires, the
+// test would catch the pre-PR-#242 silent-failure bug class if it ever
+// returned. Stage 2 additionally escalates detector-infrastructure failures
+// to fail+subCheckFailed in static-checks.js Source 3; this test covers the
+// warn-level migration-signal path.
+//
+// Recovery: if this test is interrupted (Ctrl+C) mid-execution, the working
+// tree may contain the injected mutation. Restore via `git checkout
+// scripts/package.js`. A test process that completes normally always
+// restores the file via the finally block.
+
+describe('cross-ref-scan detector liveness', () => {
+  // Regex matches the reflexion PLUGINS tuple with tolerance for whitespace,
+  // quote-style, and trailing-comma variations. `m` flag lets `^`/`$` match
+  // line boundaries; capture group 1 preserves leading indent so the
+  // comment-out replacement stays visually aligned with surrounding entries.
+  // If package.js switches to double quotes, adds internal spaces, or drops
+  // the trailing comma, this match still succeeds — replacing the earlier
+  // exact-string match, which was flagged in review for fragility under
+  // non-semantic reformatting.
+  const REFLEXION_TUPLE_RE =
+    /^([ \t]*)(\{\s*dir:\s*['"]reflexion['"],\s*skill:\s*['"]reflexion['"]\s*\},?)\s*$/m;
+  const PACKAGE_JS_PATH = path.join(__dirname, 'package.js');
+  const REPO_ROOT = path.join(__dirname, '..');
+  const STATIC_CHECKS = path.join(
+    REPO_ROOT,
+    '.claude',
+    'skills',
+    'verify',
+    'scripts',
+    'static-checks.js'
+  );
+
+  it('fires publication-gap warning when reflexion entry is removed', () => {
+    const backup = fs.readFileSync(PACKAGE_JS_PATH, 'utf8');
+
+    // Precondition: ensure we know where to inject the mutation.
+    const match = backup.match(REFLEXION_TUPLE_RE);
+    assert.ok(
+      match,
+      'precondition failed: could not find reflexion PLUGINS tuple in scripts/package.js — ' +
+      'update REFLEXION_TUPLE_RE in package.test.js to match the current formatting'
+    );
+
+    try {
+      // Inject: comment out the reflexion entry (preserve leading indent)
+      const [fullMatch, indent, tuple] = match;
+      const mutated = backup.replace(
+        fullMatch,
+        `${indent}// ${tuple} // liveness test — injected`
+      );
+      assert.notEqual(mutated, backup, 'mutation replacement did not change the file content');
+      fs.writeFileSync(PACKAGE_JS_PATH, mutated);
+
+      // Run the verifier as a subprocess (child-process isolation from our
+      // own require cache). The static-checks.js internally deletes its
+      // require cache entry before re-loading package.js, so it sees our
+      // mutation.
+      //
+      // execFileSync throws on non-zero exit, placing stdout in err.stdout.
+      // We treat any parseable result as authoritative — even if an
+      // unrelated check fails and makes static-checks.js exit 1, we still
+      // want to assert against the JSON output. Only truly unparseable
+      // output (runtime crash in static-checks.js, empty stdout) fails the
+      // liveness test at the execFileSync boundary with a diagnostic error.
+      let output;
+      try {
+        output = execFileSync(
+          process.execPath,
+          [STATIC_CHECKS, REPO_ROOT],
+          { encoding: 'utf8' }
+        );
+      } catch (execErr) {
+        if (execErr && typeof execErr.stdout === 'string' && execErr.stdout.length > 0) {
+          output = execErr.stdout;
+        } else {
+          throw new Error(
+            'liveness test: static-checks.js failed without parseable output. ' +
+            `exit=${execErr && execErr.status}, ` +
+            `stdout=${JSON.stringify(execErr && execErr.stdout)}, ` +
+            `stderr=${JSON.stringify(execErr && execErr.stderr)}`
+          );
+        }
+      }
+      const result = JSON.parse(output);
+
+      // Expectation: exactly one publication-gap warning for reflexion/reflexion.
+      const gaps = (result.warn || []).filter(
+        w =>
+          typeof w.message === 'string' &&
+          w.message.includes('publication-gap: reflexion/reflexion')
+      );
+      assert.equal(
+        gaps.length,
+        1,
+        `expected exactly 1 publication-gap warning for reflexion/reflexion, got ${gaps.length}. ` +
+        'If 0: the detector is silently no-op (regression of PR #242 bug class). ' +
+        'If >1: unexpected duplicate detection — investigate cross-ref-scan loop logic.'
+      );
+
+      // Narrow to cross-ref-scan only: the liveness test asserts that
+      // Source 3's warn-level migration signal (publication-gap) fires
+      // WITHOUT escalating to fail. Other checks (notation, gate-type-
+      // soundness, spec-vs-impl, etc.) may independently fail for unrelated
+      // reasons — those are out of scope for this test and should not
+      // break the liveness signal. Filtering to `check === 'cross-ref-scan'`
+      // keeps the assertion semantically scoped to what the test is about.
+      const crossRefFails = (result.fail || []).filter(
+        f => f && f.check === 'cross-ref-scan'
+      );
+      assert.equal(
+        crossRefFails.length,
+        0,
+        `expected 0 cross-ref-scan fails during liveness test, got ${crossRefFails.length}: ` +
+        JSON.stringify(crossRefFails)
+      );
+    } finally {
+      // Always restore, even if assertions above throw. If the restore
+      // itself fails (disk full, permission revoked, EIO), emit a LOUD
+      // stderr recovery message before re-throwing. Without this, the
+      // original assertion error would be clobbered AND the working tree
+      // would be left in the mutated 18-entry state — a double loss.
+      // CI is safe (ephemeral working tree); this protects local dev runs.
+      try {
+        fs.writeFileSync(PACKAGE_JS_PATH, backup);
+      } catch (restoreErr) {
+        process.stderr.write(
+          '\n\n!!! LIVENESS TEST FAILED TO RESTORE scripts/package.js !!!\n' +
+          'Manual recovery required: git checkout scripts/package.js\n' +
+          `Original restore error: ${restoreErr && restoreErr.message}\n\n`
+        );
+        throw restoreErr;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Mission**: Close the silent-failure bug class itself that PR #242 fixed only one instance of. Escalate all detector-infrastructure failure paths in `cross-ref-scan` Source 3 from warn-level to `fail + subCheckFailed = true`, and automate the Task #22 manual liveness regression pattern as a reusable test.
- **Scope**: `C7 Publication-surface architecture Stage 2` (Stage 1 = PR #242 / b1a2911, Stage 3 = Task #17 HFI behavioral layer, separate session).
- **Value**: The detector now fails loudly at the exact bug class that caused the PR #242 critical incident, and the liveness regression is now a unit test that catches future silent-detector regressions in CI instead of relying on manual discipline.

## Changes

### `.claude/skills/verify/scripts/static-checks.js`

Source 3 (cross-ref-scan publication-surface check) loud mode:

| Path | Before | After |
|------|--------|-------|
| `scripts/package.js` missing | silent skip | **fail**: `"Required file not found — cross-ref-scan Source 3 cannot verify publication surface"` |
| `require()` throws (e.g., syntax error, module-not-found) | warn + `PLUGINS = null` → fall through → silent no-op | **fail**: `"Could not load package.js PLUGINS: ${e.message}"` + `subCheckFailed = true` |
| `PLUGINS` non-Array export (null, undefined, object, string) | silent skip via `if (Array.isArray)` guard | **fail**: `"PLUGINS export shape invalid — expected Array, got <type>"` |
| malformed tuple in PLUGINS (missing `dir` or `skill` key) | warn only | **fail**: `"malformed-plugins-entry: ..."` |
| upstream `allPluginDirs` `readdirSync(projectRoot)` throws | warn only — entire cross-ref-scan silently passes | **fail**: `"Could not scan plugin directories (upstream ground truth): ${e.message}"` |

**Why the upstream escalation is in scope**: `allPluginDirs` is the ground truth for Sources 1, 2, 3, and 4. If `readdirSync` on `projectRoot` fails, every downstream source sees an empty filesystem view, every bidirectional diff collapses to zero findings, and the entire cross-ref-scan silently passes. This is the same silent-failure bug class Stage 2 closes in Source 3, at an upstream scope that covers all four sources. Review-ensemble cross-model agreement (Codex gpt-5.4 high + Claude silent-failure-hunter) surfaced this during PR development; skipping it would leave the bug class half-closed.

Additional polish:
- `loadFailed` sentinel distinguishes catch-path from shape-path → prevents duplicate escalation.
- `util.inspect` replaces `JSON.stringify(p)` in malformed-entry serialization — handles circular references and BigInt values without throwing.
- Shape error message handles `null` explicitly (`typeof null === 'object'` would have produced misleading "got object").
- Partial-processing behavior documented in comment: a malformed entry may ALSO produce a downstream `publication-gap` warning for the SKILL.md it would have covered (one root cause, two diagnostics — intentional post-escalation noise).

**What stays unchanged (invariants from PR #242)**:
- `path.resolve` at L1338 is load-bearing. The 14-line comment block at L1320-L1337 explains why; replacing with `path.join` would re-introduce the exact PR #242 critical bug.
- `publication-gap` and `stale-plugins-entry` stay at `warn` — they are migration signals, not infrastructure failures. Drift-detection escalation is a separate downstream PR, gated on clean warnings.
- `graph.json` stays at 10 protocols. `marketplace.json` untouched. No SKILL.md changes.

### `scripts/package.test.js`

**Tier B — brittle assertion replacement**:

```diff
-assert.equal(bundle.files, 38);
+assert.ok(
+  bundle.files >= 38,
+  `expected bundle.files >= 38 (regression guard), got ${bundle.files}`
+);
```

The equality form was flagged as brittle by three independent reviewers (code-reviewer, silent-failure-hunter, Codex) during PR #242 review. The lower-bound form catches intended-regression shrinks while tolerating additive changes (new plugin, new reference doc, new agent).

**Tier B' — automated liveness regression**:

New `describe('cross-ref-scan detector liveness', ...)` block inside `package.test.js`. Injects a known publication gap (comments out the `reflexion` PLUGINS entry), invokes the verifier as a subprocess, asserts the `publication-gap: reflexion/reflexion` warning fires, and restores the file in a `finally` block. This is the automated form of the Task #22 manual liveness pattern used during PR #242 review.

**Critical design decision**: the liveness test MUST stay in the same file as the CLI test (not a separate file). `node --test` runs files in parallel child processes but runs top-level tests within a single file sequentially. A prior iteration with the liveness test in `scripts/liveness.test.js` triggered a cross-file race where liveness mutated `scripts/package.js` concurrently with the CLI test's subprocess reading it (`result.results.length === 19 !== 20`). Single-file co-location eliminates the race by construction. A prominent comment at the top of the describe block documents this and warns future contributors.

Review-ensemble drove the following robustness fixes to the liveness test (all in the same block):
- **Regex match** instead of exact-string for the reflexion tuple — tolerates whitespace, quote-style, and trailing-comma drift in `scripts/package.js` without requiring a coordinated test update.
- **`execFileSync` error handling** — on non-zero exit, parses `err.stdout` as authoritative output (execFileSync throws and buries JSON in the error). Without this, an unrelated check failing during the liveness run surfaces as an opaque shell error instead of a meaningful assertion.
- **Narrowed fail assertion** — `result.fail.length === 0` is filtered to `check === 'cross-ref-scan'` so the test does not break on unrelated future failures (notation, gate-type-soundness, etc.).
- **`finally`-restore robustness** — the restore write is wrapped in try/catch; if the restore itself throws (disk full, permission revoked), a LOUD stderr recovery message fires (`"Manual recovery required: git checkout scripts/package.js"`) before re-throwing. CI is safe because working trees are ephemeral; this protects local developer machines.

## Verification

| Check | Result |
|-------|--------|
| `node --test scripts/package.test.js` | 40/40 pass (39 prior + 1 new liveness) |
| `node .claude/skills/verify/scripts/static-checks.js .` | `pass=52 fail=0 warn=4` (PR #242 baseline preserved) |
| `git diff scripts/package.js` after liveness run | empty (finally block restored) |
| `node scripts/package.js --dry-run` | `results.length = 20`, `bundle.files = 38`, 20 zips unchanged |
| Smoke A1 — `chmod 100` temp dir (execute-only) | `EACCES` → upstream-fail `"Could not scan plugin directories (upstream ground truth)"` ✓ |
| Smoke — rename `scripts/package.js` to `.bak` | fail `"Required file not found"` ✓ |
| Smoke — syntax-error `package.js` | fail `"Could not load package.js PLUGINS: Unexpected identifier 'is'"` ✓ |
| Smoke — `module.exports = { PLUGINS: null }` | fail `"expected Array, got null"` ✓ |
| Smoke — circular-reference malformed entry | `util.inspect` serializes as `"<ref *1> { dir: 'test', self: [Circular *1] }"` ✓ |

## Review-ensemble findings addressed

Cross-model ensemble ran before /ship: code-reviewer + silent-failure-hunter + Codex gpt-5.4 (high). 8 findings surfaced, all addressed in this commit:

| # | Reviewer(s) | Finding | Fix |
|---|-------------|---------|-----|
| A1 | Codex [high] + hunter [medium] — **cross-model agreement** | Upstream `allPluginDirs` readdirSync catch is warn-only; same bug class at upstream scope | Escalated to fail + subCheckFailed |
| A2 | Codex [suggestion] + code-reviewer [medium] — **cross-model agreement** | `REFLEXION_LINE` whitespace-fragile exact match | Regex match with indent capture |
| B1 | hunter [medium] | Liveness restore throw could clobber original assertion + leave mutation | try/catch + LOUD stderr + rethrow |
| B2 | hunter [medium] | `execFileSync` non-zero exit eats JSON; opaque error on unrelated check fail | try/catch parses `err.stdout` as authoritative |
| B3 | hunter [low] | `result.fail.length === 0` brittle to unrelated check fails | Filter to `check === 'cross-ref-scan'` |
| B4 | hunter [medium] | Malformed partial processing emits fail + warn for same tuple without explanation | Comment clarification added |
| B5 | code-reviewer [medium] | `typeof null === 'object'` → misleading "got object" | Ternary handles `null` explicitly |
| B6 | Codex [medium] | `JSON.stringify(p)` throws on circular ref / BigInt | `util.inspect(p, { depth: 2, breakLength: 80 })` |

## Test plan

- [ ] `node --test scripts/package.test.js` passes 40/40 tests with new lower-bound assertion and new liveness describe block
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` reports pass=52 fail=0 warn=4 (baseline preserved)
- [ ] Manual liveness verification: temporarily rename `scripts/package.js` to `.bak`, run static-checks, confirm fail with `"Required file not found — cross-ref-scan Source 3 cannot verify publication surface"`, restore the rename
- [ ] Manual syntax-error verification: temporarily replace `scripts/package.js` contents with invalid JavaScript, run static-checks, confirm fail with `"Could not load package.js PLUGINS: ..."`, restore from git
- [ ] Manual upstream verification: `chmod 100` on a temp dir with `CLAUDE.md` (execute-only, no read), run static-checks against it, confirm fail with `"Could not scan plugin directories (upstream ground truth): EACCES: ..."`
- [ ] CI pipeline passes (`claude-code-review` + `claude-epistemic-review` workflows)
- [ ] `git diff scripts/package.js` is empty after `node --test` run (liveness test finally block restored the file cleanly)
- [ ] Confirm `path.resolve` at `.claude/skills/verify/scripts/static-checks.js:1338` and the 14-line load-bearing comment at L1320-L1337 are unchanged (PR #242 invariant)
- [ ] Confirm `graph.json`, `marketplace.json`, and all SKILL.md files are unchanged (scope invariant)

## Follow-up

- Task #17 — HFI (Horizon Fusion Integrity) behavioral test layer design. C7 Stage 3. The liveness regression in this PR is a proto-HFI instance; generalizing the recognize/reverse pattern is a separate design session.
- Tier D — `docs/audit-2026-04-11.md` DQ1-DQ8 action items (tracked separately).
- Source 4 `graph.json` silent catch and Source 5 `marketplace.json` warn-level parse are the same bug class at sibling scope, out of this PR per scope discipline. Flagged for a future Stage 2+ PR if/when we want the entire `cross-ref-scan` function fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
