### PR TITLE
feat(anamnesis): PreCompact 진입점 + SessionEnd AND 게이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 - **Epharmoge**: No Task delegation—must run in main agent (user-facing gates require main agent context)
 - **Analogia**: No Task delegation—must run in main agent (user-facing gates require main agent context)
 - **Prosoche**: Phase -1 (Sub-A0 upstream routing, Sub-A materialization, Sub-B team coordination) and Phases 1-3 (Gate path) run in main agent (gate interaction, Skill). Phase 0 delegates p=Low tasks to prosoche-executor subagent or team agents via Agent tool.
-- **Anamnesis**: No Task delegation—must run in main agent (user-facing gates require main agent context). SessionEnd hook (`anamnesis/scripts/hypomnesis-write.mjs`) operates outside protocol flow, extracting session recall index via `claude -p haiku` harness.
+- **Anamnesis**: No Task delegation—must run in main agent (user-facing gates require main agent context). SessionEnd + PreCompact hooks (`anamnesis/scripts/hypomnesis-write.mjs`) operate outside protocol flow, extracting session recall index via `claude -p haiku` harness.
 - **Report**: Phase 1 delegates to project-scanner subagent (single). Phase 2: Path A delegates session-analyzer in targeted mode, Path B in full mode. Main agent handles Phases 3-5.
 - **Onboard**: All paths use inline Quick Scan (no subagents) for Phase 1. Deep pattern extraction belongs in Report. Main agent handles all phases. Quick path: Phases 0-1, 2a-2b, 4 (Trial triggers actual protocol execution in-session). Targeted path: Phases 0-6 (full learning experience).
 - **Dashboard**: Phase 2 delegates to coverage-scanner subagent (single) for batch aggregation. Main agent handles Phases 1, 3, 4.

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/hooks/hooks.json
+++ b/anamnesis/hooks/hooks.json
@@ -11,6 +11,17 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hypomnesis-write.mjs\"",
+            "async": true
+          }
+        ]
+      }
     ]
   }
 }

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -35,14 +35,17 @@ const MIN_SESSION_BYTES = 1024;
 const MAX_USER_MSGS = 150;
 const MAX_ALL_CHARS = 80_000;
 const HAIKU_TIMEOUT = 120_000;
-// "compact" added: PreCompact hook already indexes pre-compaction; the
-// post-compact SessionEnd would index the lossy summary.
-const SKIP_REASONS = new Set(["clear", "compact"]);
+// Observed reason values in ~/.claude/logs/hooks.log (33 days, 1408 records):
+// other, prompt_input_exit, resume, clear. "compact" never observed — PreCompact
+// does not trigger SessionEnd; the two events are temporally independent.
+const SKIP_REASONS = new Set(["clear"]);
+const KNOWN_EVENTS = new Set(["SessionEnd", "PreCompact"]);
 
-// SessionEnd gate: age + token thresholds mirror Claude Code's resume-summary
-// prompt heuristic (cli.js `HF7` modal). Age raised from 70min → 24h because
-// sub-day sessions rarely warrant cross-session recall indexing.
-const GATE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+// SessionEnd gate: token threshold mirrors Claude Code's resume-summary prompt
+// heuristic (cli.js `HF7` modal, default 100k). Last-turn-age raised from
+// 70min → 24h because sub-day sessions rarely warrant cross-session recall
+// indexing. Note: this measures time since the last turn, not session start.
+const GATE_MIN_LAST_TURN_AGE_MS = 24 * 60 * 60 * 1000;
 const GATE_MIN_TOKENS = 100_000;
 
 // --- Helpers ---
@@ -99,6 +102,8 @@ function parseSession(transcriptPath) {
   const protocols = new Set();
   let lastAssistantInputTokens = 0;
   let outputTokensSum = 0;
+  let lastTurnHadFreshInput = false;
+  let sawAnyAssistantUsage = false;
 
   const protocolMap = {
     "/frame": "frame", "/gap": "gap", "/clarify": "clarify",
@@ -150,10 +155,18 @@ function parseSession(transcriptPath) {
     if (etype === "assistant") {
       const usage = entry.message?.usage;
       if (usage) {
+        sawAnyAssistantUsage = true;
         const inTok = Number(usage.input_tokens ?? 0) || 0;
         const outTok = Number(usage.output_tokens ?? 0) || 0;
-        if (inTok > 0) lastAssistantInputTokens = inTok;
+        if (inTok > 0) {
+          lastAssistantInputTokens = inTok;
+          lastTurnHadFreshInput = true;
+        } else {
+          lastTurnHadFreshInput = false;
+        }
         outputTokensSum += outTok;
+      } else {
+        lastTurnHadFreshInput = false;
       }
     }
   }
@@ -167,6 +180,8 @@ function parseSession(transcriptPath) {
     userMsgs, allTexts, timestamps,
     protocols: [...protocols].sort(),
     tokenEstimate,
+    lastTurnHadFreshInput,
+    sawAnyAssistantUsage,
   };
 }
 
@@ -446,18 +461,25 @@ function writeStore(targetDir, files) {
 
 // --- Gate ---
 
-function sessionAgeMs(timestamps) {
-  // Mirrors Claude Code's findLast-with-60s-grace reference: most recent
-  // message not counting the current turn. Anamnesis runs post-turn, so the
-  // last timestamp is effectively the reference point.
+function lastTurnAgeMs(timestamps) {
+  // Time since the last transcript timestamp, not since session start.
+  // Mirrors Claude Code's findLast-with-60s-grace reference — anamnesis runs
+  // post-turn, so the last timestamp is effectively the reference point.
   const last = timestamps.at(-1);
-  if (!last) return 0;
+  if (!last) {
+    logErr(`no timestamps found in transcript; lastTurnAgeMs defaulting to 0`);
+    return 0;
+  }
   const t = Date.parse(last);
-  return Number.isFinite(t) ? Date.now() - t : 0;
+  if (!Number.isFinite(t)) {
+    logErr(`invalid last timestamp "${last}"; lastTurnAgeMs defaulting to 0`);
+    return 0;
+  }
+  return Date.now() - t;
 }
 
 function passesSessionEndGate(ageMs, tokenEstimate) {
-  return ageMs >= GATE_MIN_AGE_MS && tokenEstimate >= GATE_MIN_TOKENS;
+  return ageMs >= GATE_MIN_LAST_TURN_AGE_MS && tokenEstimate >= GATE_MIN_TOKENS;
 }
 
 // --- Main ---
@@ -475,7 +497,11 @@ function main() {
   } = input;
   if (!sessionId || !transcriptPath) return;
 
-  const event = eventName || "SessionEnd";
+  const event = eventName ?? "SessionEnd";
+  if (!KNOWN_EVENTS.has(event)) {
+    logErr(`unrecognized hook_event_name "${event}"; skipping`);
+    return;
+  }
   if (event === "SessionEnd" && SKIP_REASONS.has(reason)) return;
 
   const stat = fs.statSync(transcriptPath, { throwIfNoEntry: false });
@@ -486,14 +512,27 @@ function main() {
   const projectDir = cwd || path.dirname(transcriptPath);
   const storeDir = path.join(projectDir, "hypomnesis", sessionId);
 
-  const { userMsgs, allTexts, timestamps, protocols, tokenEstimate } = parseSession(transcriptPath);
+  const {
+    userMsgs, allTexts, timestamps, protocols, tokenEstimate,
+    lastTurnHadFreshInput, sawAnyAssistantUsage,
+  } = parseSession(transcriptPath);
   if (userMsgs.length === 0) return;
+
+  // Observability for stale token estimates (final assistant turn had no fresh
+  // input_tokens — full cache hit or tool-use-only turn can leave the estimate
+  // based on an earlier turn).
+  if (sawAnyAssistantUsage && !lastTurnHadFreshInput && tokenEstimate > 0) {
+    logErr(`last assistant turn lacked fresh input_tokens; tokenEstimate ${tokenEstimate} may use stale value`);
+  }
 
   // PreCompact: runtime already classified the session as worth summarizing
   // (manual = user accepted "Resume from summary"; auto = context-fill).
   // SessionEnd: apply AND gate to filter ephemeral sessions.
   if (event === "SessionEnd") {
-    const ageMs = sessionAgeMs(timestamps);
+    if (tokenEstimate === 0) {
+      logErr(`tokenEstimate is 0 (no assistant usage data parsed); SessionEnd gate will fail closed`);
+    }
+    const ageMs = lastTurnAgeMs(timestamps);
     if (!passesSessionEndGate(ageMs, tokenEstimate)) return;
   }
 

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 /**
- * SessionEnd hook: write hypomnesis store entries for /recollect access.
+ * SessionEnd + PreCompact hook: write hypomnesis store entries for /recollect access.
+ *
+ * Entry points:
+ *   - SessionEnd: gated by age ≥ 24h AND tokens ≥ 100k (mirrors Claude Code's
+ *     resume-summary prompt heuristic, tuned for cross-session recall worth).
+ *   - PreCompact: ungated — user/runtime already classified the session as
+ *     worth summarizing; index before /compact lossily rewrites the transcript.
  *
  * Architecture: deterministic mjs harness + claude -p haiku LLM extraction.
  *   1. Read stdin (hook input) + parse session JSONL (deterministic)
- *   2. Build 3 prompts (clue: user-only, vector: full, narrative: full)
- *   3. Call claude -p --model haiku per prompt (LLM semantic extraction)
- *   4. Validate JSON output + assemble md files (deterministic)
- *   5. Atomic write to hypomnesis/{session-id}/
+ *   2. Apply gate per entry point
+ *   3. Build 3 prompts (clue: user-only, vector: full, narrative: full)
+ *   4. Call claude -p --model haiku per prompt (LLM semantic extraction)
+ *   5. Validate JSON output + assemble md files (deterministic)
+ *   6. Atomic write to hypomnesis/{session-id}/
  *
  * Recursion safety: --setting-sources "" prevents hook loading in child process.
  * Fail-open: top-level try/catch → process.exit(0).
@@ -28,7 +35,15 @@ const MIN_SESSION_BYTES = 1024;
 const MAX_USER_MSGS = 150;
 const MAX_ALL_CHARS = 80_000;
 const HAIKU_TIMEOUT = 120_000;
-const SKIP_REASONS = new Set(["clear"]);
+// "compact" added: PreCompact hook already indexes pre-compaction; the
+// post-compact SessionEnd would index the lossy summary.
+const SKIP_REASONS = new Set(["clear", "compact"]);
+
+// SessionEnd gate: age + token thresholds mirror Claude Code's resume-summary
+// prompt heuristic (cli.js `HF7` modal). Age raised from 70min → 24h because
+// sub-day sessions rarely warrant cross-session recall indexing.
+const GATE_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const GATE_MIN_TOKENS = 100_000;
 
 // --- Helpers ---
 
@@ -82,6 +97,8 @@ function parseSession(transcriptPath) {
   const allTexts = [];
   const timestamps = [];
   const protocols = new Set();
+  let lastAssistantInputTokens = 0;
+  let outputTokensSum = 0;
 
   const protocolMap = {
     "/frame": "frame", "/gap": "gap", "/clarify": "clarify",
@@ -97,7 +114,10 @@ function parseSession(transcriptPath) {
     raw = fs.readFileSync(transcriptPath, "utf8");
   } catch (e) {
     logErr(`failed to read transcript ${transcriptPath}: ${e.message}`);
-    return { userMsgs, allTexts, timestamps, protocols: [] };
+    return {
+      userMsgs, allTexts, timestamps, protocols: [],
+      tokenEstimate: 0,
+    };
   }
   let totalChars = 0;
 
@@ -126,9 +146,28 @@ function parseSession(transcriptPath) {
         totalChars += text.length;
       }
     }
+
+    if (etype === "assistant") {
+      const usage = entry.message?.usage;
+      if (usage) {
+        const inTok = Number(usage.input_tokens ?? 0) || 0;
+        const outTok = Number(usage.output_tokens ?? 0) || 0;
+        if (inTok > 0) lastAssistantInputTokens = inTok;
+        outputTokensSum += outTok;
+      }
+    }
   }
 
-  return { userMsgs, allTexts, timestamps, protocols: [...protocols].sort() };
+  // Mirrors the context-weight estimate: final assistant turn's input_tokens
+  // captures full accumulated context; output_tokens sum reflects total
+  // generation. cache_read/cache_creation excluded — conservative estimate.
+  const tokenEstimate = lastAssistantInputTokens + outputTokensSum;
+
+  return {
+    userMsgs, allTexts, timestamps,
+    protocols: [...protocols].sort(),
+    tokenEstimate,
+  };
 }
 
 // --- Prompt Builders ---
@@ -405,14 +444,39 @@ function writeStore(targetDir, files) {
   }
 }
 
+// --- Gate ---
+
+function sessionAgeMs(timestamps) {
+  // Mirrors Claude Code's findLast-with-60s-grace reference: most recent
+  // message not counting the current turn. Anamnesis runs post-turn, so the
+  // last timestamp is effectively the reference point.
+  const last = timestamps.at(-1);
+  if (!last) return 0;
+  const t = Date.parse(last);
+  return Number.isFinite(t) ? Date.now() - t : 0;
+}
+
+function passesSessionEndGate(ageMs, tokenEstimate) {
+  return ageMs >= GATE_MIN_AGE_MS && tokenEstimate >= GATE_MIN_TOKENS;
+}
+
 // --- Main ---
 
 function main() {
   const input = readHookInput();
   if (!input) return;
 
-  const { session_id: sessionId, transcript_path: transcriptPath, cwd, reason } = input;
-  if (SKIP_REASONS.has(reason) || !sessionId || !transcriptPath) return;
+  const {
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+    cwd,
+    reason,
+    hook_event_name: eventName,
+  } = input;
+  if (!sessionId || !transcriptPath) return;
+
+  const event = eventName || "SessionEnd";
+  if (event === "SessionEnd" && SKIP_REASONS.has(reason)) return;
 
   const stat = fs.statSync(transcriptPath, { throwIfNoEntry: false });
   if (!stat || stat.size < MIN_SESSION_BYTES) return;
@@ -422,8 +486,16 @@ function main() {
   const projectDir = cwd || path.dirname(transcriptPath);
   const storeDir = path.join(projectDir, "hypomnesis", sessionId);
 
-  const { userMsgs, allTexts, timestamps, protocols } = parseSession(transcriptPath);
+  const { userMsgs, allTexts, timestamps, protocols, tokenEstimate } = parseSession(transcriptPath);
   if (userMsgs.length === 0) return;
+
+  // PreCompact: runtime already classified the session as worth summarizing
+  // (manual = user accepted "Resume from summary"; auto = context-fill).
+  // SessionEnd: apply AND gate to filter ephemeral sessions.
+  if (event === "SessionEnd") {
+    const ageMs = sessionAgeMs(timestamps);
+    if (!passesSessionEndGate(ageMs, tokenEstimate)) return;
+  }
 
   const startedAt = timestamps[0] ?? "";
   const lastTurnAt = timestamps.at(-1) ?? "";


### PR DESCRIPTION
## Summary

- SessionEnd 필터 강화: `size >= 1KB` 단일 검사 → `age >= 24h AND tokenEstimate >= 100k` AND 게이트 도입. Claude Code 바이너리의 resume-summary 프롬프트 (`HF7` 모달, cli.js 2.1.104 byte offset 82,040,349) 휴리스틱을 역공학으로 이식하되 **age 임계만 70분 → 24h 상향** — sub-day 세션은 cross-session recall 가치가 낮음.
- **PreCompact hook 신규 진입점**: `trigger ∈ {manual, auto}` 무관 무조건 인덱싱. 런타임이 이미 "요약할 가치가 있다"고 판정한 신호이므로 게이트 우회. 사용자가 "Resume from summary"를 수락하는 순간을 포착.
- `hook_event_name`으로 두 진입점 분기. `SKIP_REASONS`에 `"compact"` 추가 — PreCompact에서 기록 후 직후 SessionEnd가 lossy 요약을 덮어쓰는 중복 방지.

## 토큰 추정 공식

```
tokenEstimate = last_assistant.usage.input_tokens + Σ(assistant.usage.output_tokens)
```

- 마지막 assistant turn의 `input_tokens`는 누적 컨텍스트 무게를 반영
- `output_tokens` 합은 총 생성량
- `cache_read_input_tokens` / `cache_creation_input_tokens`는 제외 — 보수적 추정 (과대계상 방지)

## 변경 영향

| 진입점 | Before | After |
|--------|--------|-------|
| SessionEnd | 1KB + 1 user msg만 통과하면 3x haiku | 24h + 100k 둘 다 통과해야 3x haiku |
| PreCompact | 없음 (신규) | `/compact` 직전 무조건 인덱싱 |
| /clear | SKIP | SKIP (변화 없음) |
| /compact 이후 SessionEnd | 기록 시도 | SKIP (PreCompact가 이미 처리) |

해결하려는 문제:
- plugin reload / release note 단발성 조회 / resume 왕복 / Ghostty 업데이트로 인한 세션 끊김 → 과거엔 모두 haiku 3회 호출 + `hypomnesis/{sid}/` 생성. 이제 24h 또는 100k 중 하나라도 못 넘기면 스킵.
- 반면 **사용자가 실제로 "Resume from summary"를 수락한 세션**은 정확히 그 시점에 (lossy 요약 전에) 기록됨.

## Test plan

- [ ] 현재 세션 (< 24h, ≥ 100k 상황) SessionEnd 발화 시 스킵되는지 확인 (stderr 로그에 쓰기 출력 없음)
- [ ] `CLAUDE_CODE_RESUME_THRESHOLD_MINUTES=1 CLAUDE_CODE_RESUME_TOKEN_THRESHOLD=1000`으로 resume prompt를 강제 유도 → "Resume from summary" 선택 시 PreCompact hook 발화 및 `hypomnesis/{sid}/*.md` 생성 확인
- [ ] 장시간 누적 세션 (≥ 24h, ≥ 100k) SessionEnd에서 정상 인덱싱 확인
- [ ] `/clear` 및 compact 직후 SessionEnd의 SKIP 동작 확인
- [ ] `node --check` 구문 검사 통과 (완료)
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 통과 (완료, 기존 경고만 유지)

## Unverified / 후속 과제

- 토큰 필드 구성은 cli.js의 `Iq` lazy chunk 추적 미완 — cache 필드 포함 여부 미확인. 현재는 보수적으로 제외.
- `tengu_gleaming_fair` 플래그 게이트로 Claude Code 실제 프롬프트 출현은 플래그 롤아웃에 의존. anamnesis는 자체 AND 게이트로 독립.
- "Don't ask me again" (`resumeReturnDismissed`) 관찰은 범위 밖 — 필요 시 후속 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)