### PR TITLE
feat(anamnesis): two-track dispatch + domain-neutral spec (v0.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 dist/
 dist-site/
 node_modules/
+
+# Anamnesis hook output — session INDEX is written to user working dir
+# (cwd/hypomnesis/{session-id}/), containing per-session clue/vector/
+# narrative + entropy/markers/coinage. Personal session content; never
+# commit even in self-hosting dogfood context.
+hypomnesis/

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -35,6 +35,17 @@ const MIN_SESSION_BYTES = 1024;
 const MAX_USER_MSGS = 150;
 const MAX_ALL_CHARS = 80_000;
 const HAIKU_TIMEOUT = 120_000;
+
+// v0.4.0 two-track extension budgets.
+// Soft cap on deterministic extract/detect/coinage; the haiku calls above are
+// bounded separately by HAIKU_TIMEOUT and are unaffected by this budget.
+const TWO_TRACK_BUDGET_MS = 5_000;
+const COINAGE_MIN_REMAINING_MS = 500;
+const COINAGE_PRECISION_THRESHOLD = 0.5;
+const COINAGE_MIN_SESSION_OCC = 2;
+const COINAGE_MAX_OUTPUT = 30;
+const MARKER_CAT_LIMIT = 30;
+const ENTROPY_MAX_OUTPUT = 40;
 // Observed reason values in ~/.claude/logs/hooks.log (33 days, 1408 records):
 // other, prompt_input_exit, resume, clear. "compact" never observed — PreCompact
 // does not trigger SessionEnd; the two events are temporally independent.
@@ -426,6 +437,233 @@ function extractCrossRefs(userMsgs, allTexts) {
   return [...refs].sort().slice(0, 10);
 }
 
+// --- v0.4.0 Two-Track Extension: deterministic extract / detect / coinage ---
+//
+// Morphism laws (see SKILL.md ── ENTROPY EXTRACTION ── and ── SALIENCE MARKERS ──):
+//   extract: identity, locality, compositionality (pattern registry union)
+//   detect:  monotonicity, locality, idempotence (pure pattern match, modulo truncation)
+//   coinage: corpus-comparative (Zipf deviation), budget-bounded
+//
+// Output: entropy.md (IdentifierTuples), markers.md (MarkerProfile), coinage.md (CoinageSet).
+
+// extract: Session → Set(IdentifierTuple) — entropy-track anchors
+const ENTROPY_EXTRACTORS = [
+  { name: "url", pattern: /\bhttps?:\/\/[^\s<>"'`)\]]+/g },
+  { name: "pr_ref", pattern: /\bPR\s*#\d+\b/gi },
+  { name: "issue_ref", pattern: /(?<![\w-])#\d{1,5}\b/g },
+  { name: "session_id", pattern: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g },
+  { name: "commit_sha", pattern: /(?<![\w-])[0-9a-f]{7,40}(?![\w-])/g },
+  { name: "path_ref", pattern: /\b[\w.-]+\/[\w./-]+\.\w{1,6}\b/g },
+];
+
+function extractEntropyRefs(allTexts) {
+  const refs = new Map();
+  for (const text of allTexts) {
+    for (const { name, pattern } of ENTROPY_EXTRACTORS) {
+      for (const match of text.matchAll(pattern)) {
+        const literal = match[0];
+        if (literal.length > 300) continue;
+        const existing = refs.get(literal);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          refs.set(literal, { literal, source: name, count: 1 });
+        }
+      }
+    }
+  }
+  return [...refs.values()]
+    .sort((a, b) => b.count - a.count || a.literal.localeCompare(b.literal))
+    .slice(0, ENTROPY_MAX_OUTPUT);
+}
+
+// detect: Session → MarkerProfile — salience-track profile
+// Laws: monotonicity/locality hold exactly; idempotence holds up to output truncation.
+const MARKER_PATTERNS = {
+  actor: /@[\w-]{2,40}\b/g,
+  temporal: /\b(\d{4}-\d{2}-\d{2}|\d{1,2}[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?|yesterday|today|tomorrow|last\s+\w+|next\s+\w+|어제|오늘|내일|이번주|지난주|다음주|주말)\b/gi,
+  emotional: /(?:!{2,}|\?{2,}|\bwow\b|\bexactly\b|\bperfect\b|완벽|맞습니다|최고|중요합니다?)/gi,
+  cognitive: /\b(?:however|therefore|because|hence|thus|nonetheless|moreover)\b|따라서|그래서|왜냐하면|그러나|하지만|결국/gi,
+};
+const COINAGE_PATTERN = /\b(?:[a-z]+(?:[A-Z][a-z]+)+|[A-Z][a-z]+(?:[A-Z][a-z]+){1,3})\b/g;
+
+function detectMarkers(userMsgs, allTexts) {
+  const profile = {
+    coinage: new Set(),
+    actor: new Set(),
+    temporal: new Set(),
+    emotional: new Set(),
+    cognitive: new Set(),
+    singularity: new Set(),
+  };
+  for (const text of allTexts) {
+    for (const match of text.matchAll(COINAGE_PATTERN)) {
+      if (profile.coinage.size >= MARKER_CAT_LIMIT) break;
+      profile.coinage.add(match[0]);
+    }
+    for (const [category, pattern] of Object.entries(MARKER_PATTERNS)) {
+      if (profile[category].size >= MARKER_CAT_LIMIT) continue;
+      for (const match of text.matchAll(pattern)) {
+        if (profile[category].size >= MARKER_CAT_LIMIT) break;
+        profile[category].add(match[0]);
+      }
+    }
+  }
+  for (const msg of userMsgs.slice(0, 30)) {
+    if (profile.singularity.size >= 10) break;
+    const text = cleanText(msg.text).trim();
+    if (text.length >= 80 && text.length <= 500 && /[!?]|\*\*/.test(text)) {
+      profile.singularity.add(text.slice(0, 200));
+    }
+  }
+  return Object.fromEntries(
+    Object.entries(profile).map(([k, v]) => [k, [...v]])
+  );
+}
+
+// coinage: Session × Corpus × θ → CoinageSet
+// salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
+function computeCoinage(userMsgs, allTexts, corpusPath, currentSessionId, budgetMs) {
+  const start = Date.now();
+  const sessionText = [
+    ...userMsgs.map((m) => m.text),
+    ...allTexts,
+  ].join(" ").toLowerCase();
+  const tokenRe = /\b[a-zA-Z가-힣_][a-zA-Z가-힣_0-9-]{3,29}\b/g;
+  const sessionCounts = new Map();
+  for (const match of sessionText.matchAll(tokenRe)) {
+    const t = match[0];
+    sessionCounts.set(t, (sessionCounts.get(t) ?? 0) + 1);
+  }
+
+  const corpusCounts = new Map();
+  let corpusSampled = 0;
+  try {
+    if (fs.existsSync(corpusPath)) {
+      const entries = fs.readdirSync(corpusPath);
+      for (const entry of entries) {
+        if (entry === currentSessionId) continue;
+        if (Date.now() - start > budgetMs) break;
+        const cluePath = path.join(corpusPath, entry, "clue.md");
+        if (!fs.existsSync(cluePath)) continue;
+        try {
+          const content = fs.readFileSync(cluePath, "utf8").toLowerCase();
+          for (const match of content.matchAll(tokenRe)) {
+            const t = match[0];
+            corpusCounts.set(t, (corpusCounts.get(t) ?? 0) + 1);
+          }
+          corpusSampled += 1;
+        } catch {}
+      }
+    }
+  } catch (e) {
+    logErr(`coinage corpus scan failed: ${e.message}`);
+  }
+
+  const coinage = [];
+  for (const [token, sessionOcc] of sessionCounts.entries()) {
+    if (sessionOcc < COINAGE_MIN_SESSION_OCC) continue;
+    const corpusOcc = corpusCounts.get(token) ?? 0;
+    const precision = sessionOcc / (1 + corpusOcc);
+    if (precision >= COINAGE_PRECISION_THRESHOLD) {
+      coinage.push({ token, precision, sessionOcc, corpusOcc });
+    }
+  }
+  coinage.sort((a, b) => b.precision - a.precision);
+  return {
+    coinage: coinage.slice(0, COINAGE_MAX_OUTPUT),
+    corpus_sessions_sampled: corpusSampled,
+    elapsed_ms: Date.now() - start,
+  };
+}
+
+function buildEntropyMd(sessionId, date, refs) {
+  const lines = [
+    "---",
+    `session_id: ${sessionId}`,
+    `date: ${date}`,
+    `identifier_count: ${refs.length}`,
+    `extractors: [${ENTROPY_EXTRACTORS.map((e) => e.name).join(", ")}]`,
+    "---",
+    "",
+    "## Identifier Tuples",
+    "",
+  ];
+  if (refs.length === 0) {
+    lines.push("No structured identifiers extracted.");
+  } else {
+    lines.push("| literal | source | session_count |");
+    lines.push("|---------|--------|---------------|");
+    for (const r of refs) {
+      lines.push(`| \`${escMd(r.literal)}\` | ${r.source} | ${r.count} |`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+function buildMarkersMd(sessionId, date, profile) {
+  const counts = Object.fromEntries(
+    Object.entries(profile).map(([k, v]) => [k, v.length])
+  );
+  const lines = [
+    "---",
+    `session_id: ${sessionId}`,
+    `date: ${date}`,
+    `marker_categories: [${Object.keys(profile).join(", ")}]`,
+    `marker_counts: ${JSON.stringify(counts)}`,
+    "---",
+    "",
+    "## MarkerProfile",
+    "",
+  ];
+  for (const [category, items] of Object.entries(profile)) {
+    lines.push(`### ${category} (${items.length})`);
+    if (items.length === 0) {
+      lines.push("_none_");
+    } else {
+      for (const item of items) {
+        lines.push(`- ${escMd(item)}`);
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n") + "\n";
+}
+
+function buildCoinageMd(sessionId, date, result, skipped, skipReason) {
+  const lines = [
+    "---",
+    `session_id: ${sessionId}`,
+    `date: ${date}`,
+    `coinage_count: ${result?.coinage.length ?? 0}`,
+    `budget_skipped: ${skipped}`,
+    `corpus_sessions_sampled: ${result?.corpus_sessions_sampled ?? 0}`,
+    `elapsed_ms: ${result?.elapsed_ms ?? 0}`,
+    `threshold: ${COINAGE_PRECISION_THRESHOLD}`,
+    "---",
+    "",
+    "## Zipf-Deviation Coinage Set",
+    "",
+  ];
+  if (skipped) {
+    lines.push(`Coinage computation skipped: ${skipReason}.`);
+    lines.push("MarkerProfile and IdentifierTuples remain intact (Anamnesis R1 fallback).");
+  } else if (!result || result.coinage.length === 0) {
+    lines.push("No high-precision coinage detected against current corpus.");
+  } else {
+    lines.push("| token | precision | session_occ | corpus_occ |");
+    lines.push("|-------|-----------|-------------|------------|");
+    for (const c of result.coinage) {
+      lines.push(`| \`${escMd(c.token)}\` | ${c.precision.toFixed(3)} | ${c.sessionOcc} | ${c.corpusOcc} |`);
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+function escMd(s) {
+  return String(s).replace(/[`|]/g, "").replace(/\n/g, " ");
+}
+
 // --- Atomic Writer ---
 
 function writeStore(targetDir, files) {
@@ -585,6 +823,43 @@ function main() {
     }
   } catch (e) {
     logErr(`narrative extraction failed: ${e.message}`);
+  }
+
+  // --- v0.4.0 Two-Track Extension ---
+  // Deterministic extract/detect run first; coinage runs if budget allows.
+  // Soft cap: TWO_TRACK_BUDGET_MS. On exhaustion, coinage is skipped while
+  // markers + entropy refs remain intact (Anamnesis R1 fallback).
+  const twoTrackStart = Date.now();
+
+  try {
+    const refs = extractEntropyRefs(allTexts);
+    files["entropy.md"] = buildEntropyMd(sessionId, date, refs);
+  } catch (e) {
+    logErr(`entropy extraction failed: ${e.message}`);
+  }
+
+  try {
+    const profile = detectMarkers(userMsgs, allTexts);
+    files["markers.md"] = buildMarkersMd(sessionId, date, profile);
+  } catch (e) {
+    logErr(`marker detection failed: ${e.message}`);
+  }
+
+  try {
+    const elapsed = Date.now() - twoTrackStart;
+    const remaining = TWO_TRACK_BUDGET_MS - elapsed;
+    if (remaining < COINAGE_MIN_REMAINING_MS) {
+      files["coinage.md"] = buildCoinageMd(
+        sessionId, date, null, true,
+        `budget ${TWO_TRACK_BUDGET_MS}ms exhausted after ${elapsed}ms`,
+      );
+    } else {
+      const corpusRoot = path.join(projectDir, "hypomnesis");
+      const result = computeCoinage(userMsgs, allTexts, corpusRoot, sessionId, remaining);
+      files["coinage.md"] = buildCoinageMd(sessionId, date, result, false, null);
+    }
+  } catch (e) {
+    logErr(`coinage extraction failed: ${e.message}`);
   }
 
   if (Object.keys(files).length > 0) {

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -120,8 +120,12 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 -- Realization: gate → TextPresent+Stop; relay → TextPresent+Proceed
 -- Store binding:
 --   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl          (session JSONL, append-only)
---   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/       (SessionEnd hook-generated)
---         ∪ ~/.claude/projects/{slug}/memory/           (curated insights)
+--   INDEX ↦ {cwd}/hypomnesis/{session-id}/              (SessionEnd/PreCompact hook writes to
+--                                                         user working dir, colocated with
+--                                                         user artifacts so /recollect's
+--                                                         Read/Grep can reach it from cwd;
+--                                                         PR #249 decision 2026-04-13)
+--         ∪ ~/.claude/projects/{slug}/memory/           (curated insights, sibling to SSOT)
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -16,7 +16,8 @@ Resolve vague recall into recognized context through AI-guided contextual scan a
 ── FLOW ──
 Anamnesis(V) → Detect(V) →
   not-empty_intention(V): skip → deactivate
-  empty_intention(V): Scan(store, trace(V)) → Rank(C[]) →
+  empty_intention(V): Classify(V, Σ) → InputType → Dispatch(InputType) → Track ∈ {entropy, salience, hybrid} →
+    Scan_{Track}(Store, trace(V)) → Rank(C[]) →
     |C[]| = 0 ∧ attempts = 0: Probe(V, Σ) → Qs(probe) → Stop → H → enrich(V, H) → re-scan
     |C[]| = 0 ∧ attempts > 0: NullMatch → inform(V, Σ) → deactivate
     |C[]| > 0: Qc(C[top], evidence, progress) → Stop → R →
@@ -27,7 +28,9 @@ Anamnesis(V) → Detect(V) →
 ── MORPHISM ──
 VagueRecall
   → detect(empty_intention)              -- recognize vague recall state
-  → scan(store, recall_trace)            -- search hypomnesis/ + memory/
+  → classify(input_type)                 -- InputType ∈ {StructuredIdentifier, NaturalRecall, Mixed}
+  → dispatch(input_type)                 -- Track ∈ {entropy, salience, hybrid}
+  → scan(Store, Track, recall_trace)     -- track-specific scan (see STORE TOPOLOGY)
   → rank(candidates, recall_trace)       -- order by relevance
   → present(candidate, Socratic)         -- Socratic candidate presentation
   → recognize(candidate, user)           -- synthesis of identification (Husserl CM §§38-39)
@@ -35,34 +38,41 @@ VagueRecall
   → RecalledContext
 requires: empty_intention(V)              -- phenomenological trigger
 deficit:  RecallAmbiguous                 -- activation precondition (Layer 1/2)
-preserves: stores                         -- hypomnesis/ ∪ memory/ are read-only; V is enriched/rebound during protocol
+preserves: Store                          -- SSOT ⊕ INDEX are read-only; V is enriched/rebound during protocol
 invariant: Recognition over Retrieval
 
 ── TYPES ──
-V              = VagueRecall { trace: RecallTrace, enrichments: List(Hint) }
-RecallTrace    = { keywords: Set(String), temporal: Optional(String),
-                   associations: Set(String) }
-Hint           = String   -- user recall context from Socratic probe
-store          = hypomnesis/ ∪ memory/     -- hypomnesis/: ~/.claude/projects/{slug}/hypomnesis/{session-id}/ (recall INDEX, written by SessionEnd hook); memory/: ~/.claude/projects/{slug}/memory/ (curated insights)
-Scan           = (store, RecallTrace) → List(Candidate)
-Candidate      = { session_id: Optional(SessionId),
-                   topic: String,
-                   keywords: Set(String),
-                   fingerprint: Prose,
-                   cross_refs: List(Anchor),
-                   confidence: ∈ {low, medium, high},
-                   resumption_hint: Optional(String) }
-Anchor         = String   -- opaque: memory path, URL, session ID, doc path
-Prose          = String   -- source-agnostic NL description
-Rank           = List(Candidate) → List(Candidate)
-Probe          = (V, Σ) → List(SocraticQuestion)
+V                = VagueRecall { trace: RecallTrace, enrichments: List(Hint), input_type: InputType }
+RecallTrace      = { keywords: Set(String), temporal: Optional(String),
+                     associations: Set(String), identifiers: Set(IdentifierTuple) }
+Hint             = String   -- user recall context from Socratic probe
+InputType        ∈ {StructuredIdentifier, NaturalRecall, Mixed}      -- classified from V + Σ
+Track            ∈ {entropy, salience, hybrid}                       -- dispatched from InputType
+Source           = String   -- opaque: store location identifier (substrate-agnostic)
+IdentifierTuple  = { literal: String, source: Source, precision: ℝ } -- entropy-track anchor
+MarkerProfile    = { coinage: Set(Token), actor: Set(Entity),
+                     temporal: Set(TimeRef), emotional: Set(Marker),
+                     cognitive: Set(Marker), singularity: Set(Event) }  -- salience-track profile
+Store            = SSOT ⊕ INDEX               -- see ── STORE TOPOLOGY ── block
+Scan             = (Store, Track, RecallTrace) → List(Candidate)
+Candidate        = { session_id: Optional(SessionId),
+                     topic: String,
+                     keywords: Set(String),
+                     fingerprint: Prose,
+                     cross_refs: List(Anchor),
+                     confidence: ∈ {low, medium, high},
+                     resumption_hint: Optional(String) }
+Anchor           = String   -- opaque: memory path, URL, session ID, doc path
+Prose            = String   -- source-agnostic NL description
+Rank             = List(Candidate) → List(Candidate)
+Probe            = (V, Σ) → List(SocraticQuestion)
 SocraticQuestion = { dimension: ∈ {temporal, associative, contextual}, question: String }
-R              = Recognition ∈ {Recognize(Candidate), Refine, Reorient(description)}
-H              = Hint     -- answer from Socratic probe gate (Qs)
+R                = Recognition ∈ {Recognize(Candidate), Refine, Reorient(description)}
+H                = Hint     -- answer from Socratic probe gate (Qs)
 ClueVector_prose = String
 RecalledContext  = session text containing ClueVector_prose
-NullMatch       = |Scan(store, trace)| = 0 after all enrichment attempts
-Phase          ∈ {0, 1, 2, 3}
+NullMatch        = |Scan(Store, Track, trace)| = 0 after all enrichment attempts
+Phase            ∈ {0, 1, 2, 3}
 
 ── V-BINDING ──
 bind(V) = explicit_arg ∪ colocated_expr ∪ prev_user_turn
@@ -79,7 +89,8 @@ Edge cases:
 
 ── PHASE TRANSITIONS ──
 Phase 0: V → Detect(V) → empty_intention(V)?                    -- trigger (silent)
-Phase 1: V → Scan(store, trace(V)) → Rank(C[]) → C[ranked]     -- search + rank [Tool]
+           → Classify(V, Σ) → InputType → Track                  -- dispatch (silent)
+Phase 1: V → Scan_{Track}(Store, trace(V)) → Rank(C[]) → C[ranked]  -- track-dispatched scan + rank [Tool]
            |C[ranked]| = 0 ∧ attempts = 0 → Probe(V, Σ) → Qs → Stop → H → enrich(V, H) → Phase 1
            |C[ranked]| = 0 ∧ attempts > 0 → NullMatch → inform → deactivate
 Phase 2: C[top] → Qc(C[top], evidence, progress) → Stop → R    -- recognition gate [Tool]
@@ -104,9 +115,18 @@ NullMatch = |C[]| = 0 ∧ attempts > 0 ∧ (attempts = max ∨ enrichments exhau
 progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 
 ── TOOL GROUNDING ──
+-- A4 realization binding (Claude Code substrate). Non-normative with respect to protocol essence
+-- (see ── SUBSTRATE AGNOSTICISM ──). Any substrate satisfying the morphism laws realizes Anamnesis.
 -- Realization: gate → TextPresent+Stop; relay → TextPresent+Proceed
+-- Store binding:
+--   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl          (session JSONL, append-only)
+--   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/       (SessionEnd hook-generated)
+--         ∪ ~/.claude/projects/{slug}/memory/           (curated insights)
 Phase 0 Detect      (sense)    → Internal analysis
-Phase 1 Scan        (observe)  → Read, Grep, Glob (hypomnesis/ + memory/)
+Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
+Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)
+Phase 1 Scan_salience (observe)  → Read, Grep, Glob (MarkerProfile match over INDEX; SSOT fallback on degraded_scan)
+Phase 1 Scan_hybrid   (observe)  → union of above
 Phase 1 Rank        (sense)    → Internal analysis (conditional: haiku scoring for large candidate sets)
 Phase 2 Qc          (gate)     → present (narrative Socratic candidate; mandatory)
 Phase 3 integrate   (track)    → Internal state update
@@ -129,6 +149,89 @@ Phase 3 Qs (Socratic probe)  → always_gated (only user accesses own retention 
 
 ── COMPOSITION ──
 *: product — (D₁ × D₂) → (R₁ × R₂). graph.json edges preserved. Dimension resolution emergent via session context.
+
+── ENTROPY EXTRACTION ──
+extract : Session → Set(IdentifierTuple)
+laws:
+  identity:          extract(∅) = ∅
+  locality:          extract(s₁ ⊔ s₂) = extract(s₁) ⊔ extract(s₂)          -- disjoint sessions
+  compositionality:  extract(s) = ⋃ᵢ extractor_i(s)                         -- plugin-summable
+
+precision(t, corpus) = 1 / (1 + |occ(t, corpus \ {t.source})|)
+reject(t, θ) ≡ precision(t, corpus) < θ                                    -- derivable, not enumerated
+
+extractor registry:
+  core (bootstrap) = { URL_path_literal, ExplicitRef_literal, Citation_literal }
+  plugin           = { domain-specific extractors conforming to laws }
+
+dispatch binding: InputType = StructuredIdentifier → Track = entropy
+
+── SALIENCE MARKERS ──
+detect : Session → MarkerProfile
+categories: { coinage, actor, temporal, emotional, cognitive, singularity }   -- working hypothesis (Emergent admitted)
+laws:
+  monotonicity:   s₁ ⊆ s₂ ⟹ detect(s₁) ⊆ detect(s₂)
+  locality:       detect(s₁ ⊔ s₂) = detect(s₁) ⊔ detect(s₂)                 -- disjoint sessions
+  idempotence:    detect(witnesses(detect(s))) = detect(s)                    -- second pass stable
+
+coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
+  where salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
+  -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
+
+dispatch binding: InputType = NaturalRecall → Track = salience
+
+── STORE TOPOLOGY ──
+Store = SSOT ⊕ INDEX
+  SSOT  = authoritative session record (complete, append-only)
+  INDEX = recall accelerator (derived, rebuildable, lossy)
+
+scan_{Track} : (Store, Trace) → List(Candidate)
+  scan_entropy(Store, trace)    = exact-match over IdentifierTuples        -- uses SSOT ∪ INDEX
+  scan_salience(Store, trace)   = MarkerProfile match (ranked by Σ)        -- INDEX-accelerated; SSOT fallback
+  scan_hybrid(Store, trace)     = scan_entropy ∪ scan_salience
+
+degraded_scan: INDEX = ∅ ⟹ scan'(SSOT, Track, trace)                      -- SSOT sufficient for recall
+  -- INDEX accelerates; SSOT guarantees. Cold start falls back to SSOT directly.
+  -- Precondition for Cold-Start invariant (see Verification).
+
+── SUBSTRATE AGNOSTICISM ──
+The protocol essence (form) consists of FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, and the
+formal blocks ENTROPY EXTRACTION / SALIENCE MARKERS / STORE TOPOLOGY / KNOWN FAILURE MODES.
+The essence makes no reference to specific tools, agents, platforms, schedulers, or storage
+media. Any realization (matter) satisfying the morphism laws and the store topology realizes
+Anamnesis.
+
+form ⊥ matter:
+  form   = ⟨FLOW, MORPHISM, TYPES, laws of extract/detect/scan⟩             -- protocol definition
+  matter = ⟨tool names, file paths, language, scheduler, storage backend⟩   -- realization
+
+TOOL GROUNDING below specifies one such realization (Claude Code substrate); it is
+non-normative with respect to the protocol's epistemic content.
+
+Referent: A4 Semantic Autonomy (contributor axiom). This section locally inscribes the
+realization boundary for user-visible clarity; the local inscription is intentional and
+preserves the hermeneutic circle until a marketplace shared-document mechanism exists.
+
+── KNOWN FAILURE MODES ──
+FalseAnchor       : extract(s) contains t with high precision but t ≠ recall_target
+                    -- cause: precision threshold locally calibrated but semantically wrong
+                    -- detection: Qc Recognize=false despite scan_entropy match
+
+ExtractorLacking  : recall_target ∈ s ∧ ∄ extractor_i : recall_target ∈ extractor_i(s)
+                    -- cause: domain-specific extractor absent from registry
+                    -- detection: NullMatch on scan_entropy ∧ user can cite literal
+
+NullMatch₁        : scan_entropy(Store, trace) = ∅ ∧ InputType = StructuredIdentifier
+                    -- cause: literal absent from SSOT/INDEX (pre-store, lifecycle gap)
+                    -- recovery: offer Aitesis handoff with accumulated trace
+
+NullMatch₂        : scan_salience(Store, trace) = ∅ ∧ InputType = NaturalRecall
+                    -- cause: profile too vague or target session lacks distinctive markers
+                    -- recovery: Socratic probe enrichment → Phase 1 re-scan
+
+MutualNull        : scan_entropy = ∅ ∧ scan_salience = ∅ on Track = hybrid
+                    -- structural risk: recall target genuinely absent from Store
+                    -- action: NullMatch pathway with full scope disclosure (principal failure mode)
 ```
 
 ## Core Principle
@@ -137,7 +240,7 @@ Phase 3 Qs (Socratic probe)  → always_gated (only user accesses own retention 
 
 The scan finds candidates; the narrative Qc enables recognition; the user constitutes the identity match. Three constitutive distinctions from search/retrieval:
 
-1. **Context-primary trace**: The current session context is the primary search signal, not user-supplied keywords which may be inaccurate or incomplete. The protocol assists in finding together with the user, not merely executes a keyword query.
+1. **Input-typed dispatch**: V's input type determines the scan track. Structured identifiers (URLs, explicit references, citations) route to the entropy track where high-precision literal matching dominates; natural recall (temporal hedges, existence claims, vague topical references) routes to the salience track where marker profiles and session context (Σ) rank candidates. Treating every input as Σ-primary keyword query has structural blind spots; track-appropriate scanning resolves them.
 
 2. **Narrative presentation**: Candidates are presented as discussion narratives (question asked → direction taken → outcome reached), not as result summaries. Narrative enables recognition by providing the contextual story that triggers identification; result-only summaries require additional investigation that defeats the protocol's purpose.
 
@@ -256,7 +359,7 @@ Heuristic signals for empty intention detection (not hard gates):
 Detect empty intention and extract contextual trace. This phase is **silent** — no user interaction.
 
 1. **Detect empty intention**: Analyze user expression for vague recall markers — self-referential past tense, existence claims without specification, temporal references without anchors
-2. **Extract trace**: `extract_trace(input, Sigma)` — session context (Sigma) is the **primary** signal, user expression keywords are **secondary** (user's recall may be inaccurate or point to a similar but different discussion)
+2. **Extract trace + classify input type**: `extract_trace(input, Σ)` populates `RecallTrace` (keywords, temporal, associations, identifiers); `classify(V, Σ)` assigns `InputType` ∈ {StructuredIdentifier, NaturalRecall, Mixed} which binds `Track` ∈ {entropy, salience, hybrid} for Phase 1 dispatch. Within the salience track, session context (Σ) is the primary ranking signal; within the entropy track, literal precision dominates ranking.
    - **Context extraction**: What is the user currently working on? What topic area does the vague recall relate to? The current conversation structure and direction are the strongest clues for narrowing the search space
    - **Keyword extraction**: Specific terms from user expression — treated as heuristic hints, not definitive search terms
    - **Temporal extraction**: Any time references — converted to search window constraints
@@ -270,24 +373,27 @@ Detect empty intention and extract contextual trace. This phase is **silent** �
 
 **Scan scope**: Bound text, conversation context, session history. Does NOT modify files or call external services.
 
-### Phase 1: Contextual Scan + Rank
+### Phase 1: Track-Dispatched Scan + Rank
 
-Scan hypomnesis and memory stores with contextual awareness, then rank candidates.
+Dispatch the scan on the classified `Track`, execute track-appropriate lookup over `Store = SSOT ⊕ INDEX`, then rank candidates.
 
-1. **Contextual scan strategy** (not keyword-only):
-   - **Session context match**: Find sessions and documents discussing topics similar to current session context (Sigma) — this is the primary search dimension
-   - **Keyword match**: Find mentions of trace keywords across stores — secondary, potentially inaccurate
-   - **Temporal neighborhood**: When a temporal signal exists, explore sessions in that time range AND their adjacent sessions — what was discussed before and after the candidate
-   - **Adjacent vector discovery**: For each candidate session, collect what other topics were discussed alongside — these become concrete Refine hints in Phase 2
+1. **Track-dispatched scan strategy**:
+   - **entropy track** (`InputType = StructuredIdentifier`): execute `scan_entropy` over `SSOT ∪ INDEX` — literal match on `IdentifierTuple.literal`; precision-thresholded (low-frequency, high-entropy identifiers win). URL path literals, explicit references, citation tokens dominate.
+   - **salience track** (`InputType = NaturalRecall`): execute `scan_salience` over `INDEX` (SSOT fallback on degraded_scan) — match against `MarkerProfile` (coinage / actor / temporal / emotional / cognitive / singularity); session context (Σ) supplies ranking signal within this track.
+   - **hybrid track** (`InputType = Mixed`): union of entropy and salience results.
 
-   **Call Read/Grep/Glob** across `hypomnesis/ ∪ memory/` with contextual search strategy.
+   **Common ranking signals** (track-internal, not track-selecting):
+   - **Temporal neighborhood**: When a temporal signal exists, explore sessions in that time range AND their adjacent sessions — what was discussed before and after the candidate.
+   - **Adjacent vector discovery**: For each candidate session, collect what other topics were discussed alongside — these become concrete Refine hints in Phase 2.
+
+   Tool realization (Claude Code substrate): `Read/Grep/Glob` over the Store binding declared in TOOL GROUNDING.
 
 2. **Adaptive behavior based on trace ambiguity**:
    - **High ambiguity**: Present hypomnesis store overview as orientation text (relay) — surface the store's structure and major topic clusters so the user can orient their recall. This is informational, not a gated interaction; the overview provides context for the subsequent targeted scan.
-   - **Moderate ambiguity**: Broaden scan scope to include semantic similarity and temporal neighborhood
-   - **Low ambiguity**: Direct targeted scan with context + keyword convergence
+   - **Moderate ambiguity**: Broaden scan scope to include semantic similarity and temporal neighborhood.
+   - **Low ambiguity**: Direct targeted scan using the dispatched track.
 
-3. **Rank candidates**: Order by relevance with weight hierarchy: context match > keyword match > temporal proximity. Each candidate carries:
+3. **Rank candidates**: Ranking is track-internal. On the entropy track, precision (low occurrence in corpus) dominates; on the salience track, Σ-match + marker-profile overlap + temporal proximity compose the weight. Each candidate carries:
    - Its core topic and narrative summary
    - Adjacent topics from the same session or time period
    - Confidence level based on trace alignment
@@ -381,7 +487,7 @@ After integration:
 | Rule | Structure | Effect |
 |------|-----------|--------|
 | Gate specificity | `activate(Anamnesis) only if empty_intention(V)` | Prevents false activation on specific references |
-| Context-primary scan | Phase 1 uses Sigma context + trace, not keywords alone | Reduces keyword-only blind spots |
+| Track-dispatched scan | Phase 1 dispatches by InputType → entropy/salience/hybrid | Prevents single-strategy blind spots (keyword-only, Σ-only) |
 | Narrative Qc | Phase 2 presents discussion story, not result summary | Enables recognition without additional investigation |
 | Guided recall orientation in Refine | Refine includes adjacent vectors from store | Prevents cognitive load from hint-less Refine |
 | One candidate per cycle | Present highest-priority candidate per Phase 2 | Prevents recognition overload |
@@ -398,13 +504,13 @@ After integration:
 
 2. **Recognition over Recall**: Present narrative candidates via gate interaction and yield turn — structured content must reach the user with response opportunity. Bypassing the gate (presenting content without yielding turn) = protocol violation.
 
-3. **Context-primary trace**: Session context (Sigma) is the primary trace signal for Phase 1 scan. User-supplied keywords are secondary and may be inaccurate. The protocol assists in finding with the user — it is a cognitive partner, not a query executor.
+3. **Input-typed dispatch**: Phase 1 scan is dispatched by `InputType` classified from V and Σ — `StructuredIdentifier` routes to entropy track (exact-literal precision scan via `scan_entropy`), `NaturalRecall` routes to salience track (MarkerProfile match via `scan_salience`), `Mixed` routes to hybrid. Σ-primary scan survives only as a special case within the salience track's ranking layer, not as an absolute rule across all inputs. The track determines which scan is authoritative; the session context (Σ) enriches ranking within the selected track.
 
 4. **Narrative Qc presentation**: Phase 2 presents candidates as discussion narratives (origin → direction → outcome), not result summaries. Narrative enables recognition by providing the contextual story; result-only presentation forces additional investigation that defeats the protocol's purpose.
 
 5. **Guided recall orientation in Refine**: When user selects Refine, present structured navigation through adjacent memory vectors from the store — concrete alternative topics with brief narratives. Open-ended questions shift cognitive burden to the user; structured alternatives enable Recognition (A1) in the recall-deepening process itself.
 
-6. **Contextual scan strategy**: Phase 1 scan uses session context match, keyword match, temporal neighborhood, and adjacent vector discovery. Keyword-only scan has structural blind spots; contextual scan addresses them by treating the current conversation as the primary search signal.
+6. **Track-internal ranking strategy**: Ranking within a track composes the signals appropriate to that track — on the entropy track, literal precision (rarity in corpus) dominates; on the salience track, Σ-match, marker-profile overlap, temporal neighborhood, and adjacent vector discovery compose the weight. Single-signal scans (keyword-only or Σ-only) have structural blind spots regardless of track; track-appropriate composite ranking addresses them.
 
 7. **Adaptive ambiguity handling**: When trace ambiguity is high (0-1 specific signals), present hypomnesis store overview or consider /clarify composition before targeted scanning. Do not scan blindly on vague expressions — orient the user first.
 
@@ -436,6 +542,8 @@ After integration:
 
 21. **Cross-LOOP narrative persistence**: Narrative format, adjacent vector enrichment, and guided recall orientation persist across all LOOP iterations. Second and subsequent attempts reference prior presented candidates and explain the differential. Continuity across loops prevents repetitive presentation and builds cumulative orientation.
 
+22. **Substrate non-coupling**: FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, and the five formal blocks (ENTROPY EXTRACTION, SALIENCE MARKERS, STORE TOPOLOGY, SUBSTRATE AGNOSTICISM, KNOWN FAILURE MODES) must not name specific tools, agents, platforms, schedulers, or storage media. Realization bindings (tool names, concrete file paths, language, backend) belong exclusively to TOOL GROUNDING. Violation = substrate leakage into protocol essence, which A4 Semantic Autonomy forbids.
+
 ## Known Limitations
 
-**Sigma-primary scan bias**: The context-primary scan design (Rule 3) assumes correlation between the user's current session context and their recall target. When the user's current work has diverged from the topic they are trying to recall (e.g., they have moved on to a different task), the Sigma-primary scan may bias candidates toward the current topic rather than the recalled topic. In such cases, user-supplied keywords become the more reliable signal. The adaptive ambiguity handling (Rule 7: falling back to broader scan on high ambiguity) partially mitigates this, but practitioners should be aware that the context-primary design trades keyword-only blind spots for context-divergence blind spots. The Refine path provides a natural recovery mechanism when initial candidates are biased by Sigma divergence.
+Known failure modes of the two-track dispatch and store topology are formally specified in the `── KNOWN FAILURE MODES ──` block above (FalseAnchor, ExtractorLacking, NullMatch₁/₂, MutualNull). The prior v0.3.3 "Σ-primary scan bias" hypothesis is deprecated: with input-typed dispatch (Rule 3), Σ-weighting is bounded to the salience track's ranking layer, not the scan layer — Σ-divergence is therefore a ranking concern within a single track, not a structural flaw of the protocol. MutualNull (genuine absence from Store) replaces it as the principal structural failure mode.


### PR DESCRIPTION
## 요약

Anamnesis 프로토콜을 **single-track Σ-primary scan**에서 **input-typed two-track dispatch**로 재구조화. Hypomnesis SessionEnd/PreCompact hook을 salience marker + entropy ref + coinage를 생성하는 dual-track index producer로 확장. A4 Semantic Autonomy의 substrate-agnostic 원칙을 SKILL.md 로컬 전문 인스크립션으로 실현 (marketplace shared-doc 메커니즘 부재로 인한 임시 대응; follow-up issue #252 참조).

- **Issue**: #252 (marketplace shared-doc convention)
- **Session**: `405e6d94-94c8-4014-9048-a6b89c2a2be3` (2026-04-14, /grasp × /telos × /ground × /crystallize × /epharmoge)
- **Plan**: `~/.claude/plans/anamnesis-two-track-integration.md`
- **Future-work backlog**: `~/.claude/plans/anamnesis-future-work.md` (out-of-repo plan + memory link; version-tracked repo 유지보수 부담 회피)

## 주요 변경

### `anamnesis/skills/recollect/SKILL.md` (v0.4.0 spec)

- **FLOW / MORPHISM / TYPES / PHASE TRANSITIONS**: `Classify(V, Σ) → InputType → Dispatch → Track ∈ {entropy, salience, hybrid}`. `scan_{Track}(Store, trace)`로 분기.
- **5개 신규 formal block**:
  - `── ENTROPY EXTRACTION ──` — `extract : Session → Set(IdentifierTuple)`. Laws: identity / locality / compositionality. `reject`는 precision 임계값에서 derivable (열거 아님).
  - `── SALIENCE MARKERS ──` — `detect : Session → MarkerProfile` (coinage / actor / temporal / emotional / cognitive / singularity). Laws: monotonicity / locality / idempotence.
  - `── STORE TOPOLOGY ──` — `Store = SSOT ⊕ INDEX`; `degraded_scan` (INDEX 부재 시 SSOT로 fallback).
  - `── SUBSTRATE AGNOSTICISM ──` — form ⊥ matter 구분; A4 realization binding은 TOOL GROUNDING에 국한. Marketplace shared-doc 메커니즘 부재로 로컬 전문 인스크립션.
  - `── KNOWN FAILURE MODES ──` — FalseAnchor / ExtractorLacking / NullMatch₁ / NullMatch₂ / MutualNull (principal structural failure mode).
- **Rule 3** "Context-primary trace" → **Input-typed dispatch** 교체. Σ-primary scan은 salience track ranking layer의 special case로만 생존.
- **Rule 22** 추가: Substrate non-coupling (protocol essence는 specific tool/agent/platform naming 금지).
- **TOOL GROUNDING**: A4 realization binding annotation + explicit Store binding (SSOT ↦ JSONL, INDEX ↦ `hypomnesis/` ∪ `memory/`).
- **Known Limitations**: "Σ-primary scan bias" 가설 deprecate; MutualNull이 principal structural failure mode로 대체.

### `anamnesis/scripts/hypomnesis-write.mjs` (hook 확장)

기존 `clue.md` / `vector.md` / `narrative.md`에 3개 파일 추가:

- **`entropy.md`** — deterministic regex extractor registry (URL / PR / issue / session_id / commit SHA / path ref). Morphism 법칙 준수.
- **`markers.md`** — 6개 category 결정론적 marker detection.
- **`coinage.md`** — corpus-relative Zipf deviation (`|occ(t, s)| / (1 + |occ(t, corpus \ {s})|) ≥ θ`).

**Soft cap 5s**: extract → detect → coinage 순서. 예산 소진 시 coinage skip, markers + entropy 유지.

### `anamnesis/.claude-plugin/plugin.json`

`0.3.3 → 0.4.0` (additive; backward-compat 파일 contract).

### Future-work (out-of-repo)

Phonetic/fuzzy recall, marketplace shared-doc (#252), cross-ref expansion, external API plugins, evaluation harness, hypomnesis backfill, Store binding abstraction — 모두 `~/.claude/plans/anamnesis-future-work.md`에서 추적. `project_anamnesis_direction.md` 메모리에서 링크. Repo 유지보수 부담 없이 scope 진화 가능.

## Invariants (I1-I5)

plan 기준 preserve 됨:

- **I1** Category-theoretic domain-neutrality — SE 특정 열거 없음; `reject` derivable
- **I2** Two-track dispatch as refined Rule 3 — Σ-primary은 salience-track special case
- **I3** A4 Semantic Autonomy 로컬 인스크립션 — marketplace shared-doc 이슈(#252) resolve 전까지 유지
- **I4** Mutual null as real failure mode — Σ-bias 가설 대체됨
- **I5** Substrate-agnostic hook binding — detect / coinage / persist 만 normative; 언어/스토리지/스케줄러 substitutable

## Test plan

- [x] `node --check hypomnesis-write.mjs` 통과
- [x] Entropy extractor regex smoke test (URL, PR ref, UUID 파편 제외, commit SHA, path ref)
- [x] Coinage pattern 검증 (camelCase/PascalCase)
- [ ] **새 세션 생성 → SessionEnd/PreCompact hook 실행 → entropy/markers/coinage.md 존재 확인** (post-merge dogfood)
- [ ] **`/recollect https://github.com/delightroom/...` → entropy track → literal 즉시 매칭** (post-merge dogfood)
- [ ] **`/recollect "어제 그 sailiance 논의"` → salience track → marker profile match** (phonetic/fuzzy는 future-work plan)
- [ ] **Cold start (`hypomnesis/` 삭제 후) → degraded_scan on SSOT 동작 확인** (post-merge dogfood)

## Risks & Mitigation

- **R1** Hook 5s soft cap violation — 대형 corpus에서 Zipf deviation 오버. Coinage skip fallback으로 markers+entropy 보장.
- **R2** Plugin registry 부재 — Core spec이 참조하나 미구현. Bootstrap extractor(URL/ExplicitRef/Citation)를 hook에 inline; plugin interface는 future-work plan.
- **R3** Two-track 실증 필요 — 본 PR 머지 후 dogfood 세션 3개 이상으로 검증 예정.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
