### PR TITLE
fix(anamnesis): PR #253 리뷰 피드백 반영 (v0.4.1)

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -459,10 +459,15 @@ const ENTROPY_EXTRACTORS = [
 function extractEntropyRefs(allTexts) {
   const refs = new Map();
   for (const text of allTexts) {
+    const urlSpans = [];
     for (const { name, pattern } of ENTROPY_EXTRACTORS) {
       for (const match of text.matchAll(pattern)) {
         const literal = match[0];
         if (literal.length > 300) continue;
+        const start = match.index;
+        const end = start + literal.length;
+        if (name === "path_ref" && urlSpans.some(([s, e]) => start >= s && end <= e)) continue;
+        if (name === "url") urlSpans.push([start, end]);
         const existing = refs.get(literal);
         if (existing) {
           existing.count += 1;
@@ -547,13 +552,19 @@ function computeCoinage(userMsgs, allTexts, corpusPath, currentSessionId, budget
         const cluePath = path.join(corpusPath, entry, "clue.md");
         if (!fs.existsSync(cluePath)) continue;
         try {
+          const timeBeforeRead = Date.now();
           const content = fs.readFileSync(cluePath, "utf8").toLowerCase();
+          if (Date.now() - start > budgetMs) {
+            logErr(`coinage: budget overrun by ${Date.now() - timeBeforeRead}ms on ${entry}`);
+          }
           for (const match of content.matchAll(tokenRe)) {
             const t = match[0];
             corpusCounts.set(t, (corpusCounts.get(t) ?? 0) + 1);
           }
           corpusSampled += 1;
-        } catch {}
+        } catch (e) {
+          if (e.code !== "ENOENT") logErr(`coinage: failed to read ${cluePath}: ${e.message}`);
+        }
       }
     }
   } catch (e) {
@@ -661,7 +672,11 @@ function buildCoinageMd(sessionId, date, result, skipped, skipReason) {
 }
 
 function escMd(s) {
-  return String(s).replace(/[`|]/g, "").replace(/\n/g, " ");
+  return String(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/`/g, "\\`")
+    .replace(/\n/g, " ");
 }
 
 // --- Atomic Writer ---

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -447,6 +447,10 @@ function extractCrossRefs(userMsgs, allTexts) {
 // Output: entropy.md (IdentifierTuples), markers.md (MarkerProfile), coinage.md (CoinageSet).
 
 // extract: Session → Set(IdentifierTuple) — entropy-track anchors
+// ORDER INVARIANT: "url" must precede "path_ref". extractEntropyRefs records url
+// spans during iteration and suppresses path_ref matches that fall inside them.
+// Reordering without updating the dedup logic will silently break URL-substring
+// dedup (path_ref would count github.com/foo/bar.ts on top of the matching URL).
 const ENTROPY_EXTRACTORS = [
   { name: "url", pattern: /\bhttps?:\/\/[^\s<>"'`)\]]+/g },
   { name: "pr_ref", pattern: /\bPR\s*#\d+\b/gi },
@@ -552,10 +556,9 @@ function computeCoinage(userMsgs, allTexts, corpusPath, currentSessionId, budget
         const cluePath = path.join(corpusPath, entry, "clue.md");
         if (!fs.existsSync(cluePath)) continue;
         try {
-          const timeBeforeRead = Date.now();
           const content = fs.readFileSync(cluePath, "utf8").toLowerCase();
           if (Date.now() - start > budgetMs) {
-            logErr(`coinage: budget overrun by ${Date.now() - timeBeforeRead}ms on ${entry}`);
+            logErr(`coinage: budget overrun by ${(Date.now() - start) - budgetMs}ms (triggered on ${entry})`);
           }
           for (const match of content.matchAll(tokenRe)) {
             const t = match[0];

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -49,7 +49,7 @@ Hint             = String   -- user recall context from Socratic probe
 InputType        ∈ {StructuredIdentifier, NaturalRecall, Mixed}      -- classified from V + Σ
 Track            ∈ {entropy, salience, hybrid}                       -- dispatched from InputType
 Source           = String   -- opaque: store location identifier (substrate-agnostic)
-IdentifierTuple  = { literal: String, source: Source, precision: ℝ } -- entropy-track anchor
+IdentifierTuple  = { literal: String, source: Source, precision: ℝ[0,1] } -- entropy-track anchor
 MarkerProfile    = { coinage: Set(Token), actor: Set(Entity),
                      temporal: Set(TimeRef), emotional: Set(Marker),
                      cognitive: Set(Marker), singularity: Set(Event) }  -- salience-track profile
@@ -71,7 +71,7 @@ R                = Recognition ∈ {Recognize(Candidate), Refine, Reorient(descr
 H                = Hint     -- answer from Socratic probe gate (Qs)
 ClueVector_prose = String
 RecalledContext  = session text containing ClueVector_prose
-NullMatch        = |Scan(Store, Track, trace)| = 0 after all enrichment attempts
+NullMatch        = predicate; canonical definition in ── CONVERGENCE ──
 Phase            ∈ {0, 1, 2, 3}
 
 ── V-BINDING ──
@@ -165,7 +165,10 @@ precision(t, corpus) = 1 / (1 + |occ(t, corpus \ {t.source})|)
 reject(t, θ) ≡ precision(t, corpus) < θ                                    -- derivable, not enumerated
 
 extractor registry:
-  core (bootstrap) = { URL_path_literal, ExplicitRef_literal, Citation_literal }
+  core (bootstrap) = { URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, Citation_literal }
+                     -- semantic categories: URL_path group {URL_literal, PathRef_literal},
+                     --                      ExplicitRef group {PR_literal, Issue_literal, Commit_literal},
+                     --                      Citation group {Citation_literal}
   plugin           = { domain-specific extractors conforming to laws }
 
 dispatch binding: InputType = StructuredIdentifier → Track = entropy
@@ -183,6 +186,7 @@ coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
   -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
 
 dispatch binding: InputType = NaturalRecall → Track = salience
+                  InputType = Mixed → Track = hybrid    -- union scan: entropy ∪ salience
 
 ── STORE TOPOLOGY ──
 Store = SSOT ⊕ INDEX

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -165,10 +165,10 @@ precision(t, corpus) = 1 / (1 + |occ(t, corpus \ {t.source})|)
 reject(t, θ) ≡ precision(t, corpus) < θ                                    -- derivable, not enumerated
 
 extractor registry:
-  core (bootstrap) = { URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, Citation_literal }
+  core (bootstrap) = { URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, SessionID_literal }
                      -- semantic categories: URL_path group {URL_literal, PathRef_literal},
                      --                      ExplicitRef group {PR_literal, Issue_literal, Commit_literal},
-                     --                      Citation group {Citation_literal}
+                     --                      Citation group {SessionID_literal}  -- UUIDs as session citations
   plugin           = { domain-specific extractors conforming to laws }
 
 dispatch binding: InputType = StructuredIdentifier → Track = entropy


### PR DESCRIPTION
## 요약

PR #253 리뷰 피드백 8건을 기계적으로 반영한 hotfix. Critical 3건(`escMd` / `path_ref` / registry), Suggestions 2건(coinage error log), Non-blocking 3건(SKILL.md 정합성).

- **Previous PR**: #253 (merged as `dcfa103`)
- **Review thread**: https://github.com/jongwony/epistemic-protocols/pull/253#issuecomment-4241712680
- **Maintainer feedback** (follow-up 예정): substrate-agnostic 재설계 + `SSOT ⊕ INDEX` 표기 검토

## 주요 변경

### `anamnesis/scripts/hypomnesis-write.mjs`

- **`escMd` identity 법칙 복원**: strip → escape (`\\`, `\|`, `` \` ``). 백슬래시 최우선 이스케이프로 이중 escape 방지 (리뷰 #1).
- **`path_ref` URL span dedup**: URL 매치 span 기록 후 path_ref가 URL span 내부에 포함되면 skip (리뷰 #2).
- **coinage `catch` 개선**: `ENOENT` 정상 처리 + 그 외 오류 `logErr` 출력 (리뷰 #4).
- **Budget overrun log**: `readFileSync` 전후 경과시간 측정 + budget 초과 시 `logErr` (리뷰 #5).

### `anamnesis/skills/recollect/SKILL.md`

- **ENTROPY EXTRACTION registry 재구성**: 3 추상 카테고리 → 6 formal 이름 열거 (`URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, Citation_literal`); 카테고리 그룹핑 주석 보존 (리뷰 #3).
- **`Mixed → hybrid` dispatch binding 추가**: SALIENCE MARKERS 블록에 명시 (리뷰 #6).
- **`NullMatch` canonical 지정**: CONVERGENCE 정의를 canonical, TYPES는 참조로 변경 (`attempts > 0` guard 포함) (리뷰 #7).
- **`precision: ℝ[0,1]` 범위 annotation 추가**: threshold 비교 근거 명시 (리뷰 #8).

### `anamnesis/.claude-plugin/plugin.json`

- Version bump: 0.4.0 → 0.4.1 (version-staleness check 해소).

## Skip 항목

- **리뷰 #9 (FUTURE_WORK.md dangling refs)**: 해당 파일은 리포 내 미존재 (`~/.claude/plans/anamnesis-future-work.md`는 리포지토리 외부). PR 스코프 밖.

## Test plan

- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 실행 후 version-staleness 에러 해소 확인
- [ ] `node --test scripts/package.test.js` 실행 (선행 SKILL.md 500-line 가이드라인 위반은 본 PR 스코프 밖)
- [ ] CI checks (claude-code-review + claude-epistemic-review) 통과 확인
- [ ] Merge 후 다음 세션에서 `/recollect` 호출 시 v0.4.1 SKILL.md 로드 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
