### PR TITLE
fix(anamnesis): SessionEnd gate를 cooldown + discard 기반으로 재설계 (v0.4.3)

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -718,9 +718,8 @@ function writeStore(targetDir, files) {
 // --- Gate ---
 
 function isLowInfo(clue, vector, narrative) {
-  const clueEmpty = !clue?.initial_request?.trim()
-    && (!clue?.key_utterances || clue.key_utterances.length === 0);
-  const vectorEmpty = !vector?.decisions || vector.decisions.length === 0;
+  const clueEmpty = !clue?.initial_request?.trim() && !clue?.key_utterances?.length;
+  const vectorEmpty = !vector?.decisions?.length;
   const narrativeEmpty = !narrative?.origin?.trim() && !narrative?.outcome?.trim();
   // Discard ONLY when all 3 are empty (conservative — retry via next SessionEnd
   // once cooldown expires). Missing extraction (null) is treated as empty.
@@ -769,20 +768,30 @@ function main() {
   if (sawAnyAssistantUsage && !lastTurnHadFreshInput && tokenEstimate > 0) {
     logErr(`last assistant turn lacked fresh input_tokens; tokenEstimate ${tokenEstimate} may use stale value`);
   }
+  // Diagnostic: zero tokenEstimate despite observed assistant usage indicates
+  // corrupted JSONL or format change. No longer gates the write (cooldown gate
+  // replaces tokens threshold), but retained as an anomaly signal.
+  if (sawAnyAssistantUsage && tokenEstimate === 0) {
+    logErr(`tokenEstimate is 0 despite observed assistant usage; possible corrupted JSONL or format change`);
+  }
 
   // PreCompact: runtime already classified the session as worth summarizing
   // (manual = user accepted "Resume from summary"; auto = context-fill).
   // SessionEnd: cooldown gate against narrative.md mtime — silent skip if
-  // last write < 300s ago. Fail-open on stat error (ENOENT = first write).
+  // last write < 300s ago. ENOENT returns undefined via throwIfNoEntry
+  // (first-write path); unexpected errors (EACCES, EIO) are logged and fail open.
   if (event === "SessionEnd") {
     const narrativePath = path.join(storeDir, "narrative.md");
+    let narrativeStat;
     try {
-      const narrativeStat = fs.statSync(narrativePath);
-      if (Date.now() - narrativeStat.mtimeMs < COOLDOWN_MS) {
-        return;
-      }
-    } catch {
-      // ENOENT or stat failure → fail-open, proceed to write (first-write path)
+      narrativeStat = fs.statSync(narrativePath, { throwIfNoEntry: false });
+    } catch (e) {
+      logErr(`narrative.md stat failed unexpectedly (${e.code ?? e.message}); failing open`);
+    }
+    if (narrativeStat && Date.now() - narrativeStat.mtimeMs < COOLDOWN_MS) {
+      const remainingSec = Math.round((COOLDOWN_MS - (Date.now() - narrativeStat.mtimeMs)) / 1000);
+      logErr(`cooldown active — skipping SessionEnd (${remainingSec}s remaining)`);
+      return;
     }
   }
 
@@ -844,6 +853,7 @@ function main() {
   // expires. Two-track extensions (entropy/markers/coinage) are also skipped
   // since ghost sessions lack the semantic content they depend on.
   if (isLowInfo(clueData, vectorData, narrativeData)) {
+    logErr(`low-info discard: all 3 extractions produced empty payloads — skipping write, retry eligible at next SessionEnd`);
     return;
   }
 

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -3,8 +3,9 @@
  * SessionEnd + PreCompact hook: write hypomnesis store entries for /recollect access.
  *
  * Entry points:
- *   - SessionEnd: gated by age ≥ 24h AND tokens ≥ 100k (mirrors Claude Code's
- *     resume-summary prompt heuristic, tuned for cross-session recall worth).
+ *   - SessionEnd: cooldown-gated by narrative.md mtime (skip if last write
+ *     < 300s ago). Post-extraction discard when clue/vector/narrative are all
+ *     empty — enables retry on next SessionEnd once cooldown expires.
  *   - PreCompact: ungated — user/runtime already classified the session as
  *     worth summarizing; index before /compact lossily rewrites the transcript.
  *
@@ -52,12 +53,11 @@ const ENTROPY_MAX_OUTPUT = 40;
 const SKIP_REASONS = new Set(["clear"]);
 const KNOWN_EVENTS = new Set(["SessionEnd", "PreCompact"]);
 
-// SessionEnd gate: token threshold mirrors Claude Code's resume-summary prompt
-// heuristic (cli.js `HF7` modal, default 100k). Last-turn-age raised from
-// 70min → 24h because sub-day sessions rarely warrant cross-session recall
-// indexing. Note: this measures time since the last turn, not session start.
-const GATE_MIN_LAST_TURN_AGE_MS = 24 * 60 * 60 * 1000;
-const GATE_MIN_TOKENS = 100_000;
+// SessionEnd gate: cooldown against narrative.md mtime. Skip if last index
+// write occurred < 300s ago — prevents resume-cycle spam during active
+// multi-day sessions while permitting indexing once activity gap exceeds
+// the cooldown window. PreCompact bypasses cooldown entirely.
+const COOLDOWN_MS = 300 * 1000;
 
 // --- Helpers ---
 
@@ -717,25 +717,14 @@ function writeStore(targetDir, files) {
 
 // --- Gate ---
 
-function lastTurnAgeMs(timestamps) {
-  // Time since the last transcript timestamp, not since session start.
-  // Mirrors Claude Code's findLast-with-60s-grace reference — anamnesis runs
-  // post-turn, so the last timestamp is effectively the reference point.
-  const last = timestamps.at(-1);
-  if (!last) {
-    logErr(`no timestamps found in transcript; lastTurnAgeMs defaulting to 0`);
-    return 0;
-  }
-  const t = Date.parse(last);
-  if (!Number.isFinite(t)) {
-    logErr(`invalid last timestamp "${last}"; lastTurnAgeMs defaulting to 0`);
-    return 0;
-  }
-  return Date.now() - t;
-}
-
-function passesSessionEndGate(ageMs, tokenEstimate) {
-  return ageMs >= GATE_MIN_LAST_TURN_AGE_MS && tokenEstimate >= GATE_MIN_TOKENS;
+function isLowInfo(clue, vector, narrative) {
+  const clueEmpty = !clue?.initial_request?.trim()
+    && (!clue?.key_utterances || clue.key_utterances.length === 0);
+  const vectorEmpty = !vector?.decisions || vector.decisions.length === 0;
+  const narrativeEmpty = !narrative?.origin?.trim() && !narrative?.outcome?.trim();
+  // Discard ONLY when all 3 are empty (conservative — retry via next SessionEnd
+  // once cooldown expires). Missing extraction (null) is treated as empty.
+  return clueEmpty && vectorEmpty && narrativeEmpty;
 }
 
 // --- Main ---
@@ -783,13 +772,18 @@ function main() {
 
   // PreCompact: runtime already classified the session as worth summarizing
   // (manual = user accepted "Resume from summary"; auto = context-fill).
-  // SessionEnd: apply AND gate to filter ephemeral sessions.
+  // SessionEnd: cooldown gate against narrative.md mtime — silent skip if
+  // last write < 300s ago. Fail-open on stat error (ENOENT = first write).
   if (event === "SessionEnd") {
-    if (tokenEstimate === 0) {
-      logErr(`tokenEstimate is 0 (no assistant usage data parsed); SessionEnd gate will fail closed`);
+    const narrativePath = path.join(storeDir, "narrative.md");
+    try {
+      const narrativeStat = fs.statSync(narrativePath);
+      if (Date.now() - narrativeStat.mtimeMs < COOLDOWN_MS) {
+        return;
+      }
+    } catch {
+      // ENOENT or stat failure → fail-open, proceed to write (first-write path)
     }
-    const ageMs = lastTurnAgeMs(timestamps);
-    if (!passesSessionEndGate(ageMs, tokenEstimate)) return;
   }
 
   const startedAt = timestamps[0] ?? "";
@@ -799,6 +793,8 @@ function main() {
 
   const files = {};
   let clueData = null;
+  let vectorData = null;
+  let narrativeData = null;
 
   // --- Clue: user messages only ---
   try {
@@ -816,7 +812,7 @@ function main() {
   // --- Vector: full context ---
   try {
     const vectorRaw = callHaiku(buildVectorPrompt(allTexts));
-    const vectorData = parseHaikuOutput(vectorRaw);
+    vectorData = parseHaikuOutput(vectorRaw);
     if (validateVector(vectorData)) {
       files["vector.md"] = buildVectorMd(sessionId, date, vectorData);
     } else {
@@ -829,7 +825,7 @@ function main() {
   // --- Narrative: full context ---
   try {
     const narrativeRaw = callHaiku(buildNarrativePrompt(allTexts, protocols));
-    const narrativeData = parseHaikuOutput(narrativeRaw);
+    narrativeData = parseHaikuOutput(narrativeRaw);
     if (validateNarrative(narrativeData)) {
       const topics = clueData?.topics ?? [];
       files["narrative.md"] = buildNarrativeMd(
@@ -841,6 +837,14 @@ function main() {
     }
   } catch (e) {
     logErr(`narrative extraction failed: ${e.message}`);
+  }
+
+  // Post-extraction low-info discard: silent skip when all 3 haiku extractions
+  // produced empty payloads — enables retry via next SessionEnd once cooldown
+  // expires. Two-track extensions (entropy/markers/coinage) are also skipped
+  // since ghost sessions lack the semantic content they depend on.
+  if (isLowInfo(clueData, vectorData, narrativeData)) {
+    return;
   }
 
   // --- v0.4.0 Two-Track Extension ---


### PR DESCRIPTION
## Summary

- PR #251에서 도입된 `last_turn_age ≥ 24h AND tokens ≥ 100k` gate가 active-resume multi-day 세션을 **영구 차단**하는 회귀 해결 (예: 4일 span 세션 `e492a7a1`은 자동 indexing 0건)
- Signal axis 전환: **hooks.log 파싱(외부 의존) → narrative.md mtime(자기 상태)**. zelda-sound toggle.sh PID-file guard 패턴 motif
- Ghost session 처리 전환: **pre-extraction tokens gate → post-extraction low-info discard**. 파일 미작성 = 다음 SessionEnd에서 재시도 경로 확보
- v0.4.x two-track dispatch와 **orthogonal** — gate layer만 수정

## Background

### Tension-accumulation 증거 (2026-04-13 /inquire 실측)

| # | 관찰 | 증거 |
|---|------|------|
| 1 | Empty session → empty extraction | `hypomnesis/ce5cfe13` (3.6s plugin install, 유효 schema + 빈 배열) — known limitation |
| 2 | Content truncation (large session) | 48.3MB `e492a7a1` 수동 PreCompact → `vector.md` empty, 80KB full-context cap 미달 |
| 3 | **Active-resume gate miss** | `e492a7a1` SessionEnd 16:47:22 (`reason=prompt_input_exit`) → `last_turn_age=0s` 미달 → silent early-return. 4일 span에 자동 indexing 0건 |

관찰 3이 v0.3.3 gate 가정을 falsify. `hooks.log` 32일 스캔(142k lines, 1402 sessions): SessionEnd 1422건 vs PreCompact 88건 → SessionEnd 자동 경로 dominant signal source. PreCompact-only 대체 시 97% 세션 indexing 손실.

### JSONL append 확인

`e492a7a1` JSONL 51MB, 4일 span 일치 → resume에서 append (reset 아님) → `session_span`으로 "current instance" 식별 불가. 시간 기반 signal은 외부 source(hooks.log) 필요했으나, narrative.md mtime은 anamnesis 자기 write trace로 충분 (Rate-limit semantic: 내부 상태 기반).

## Changes

`anamnesis/scripts/hypomnesis-write.mjs`:
- **Remove**: `GATE_MIN_LAST_TURN_AGE_MS`, `GATE_MIN_TOKENS`, `lastTurnAgeMs()`, `passesSessionEndGate()`
- **Add**: `COOLDOWN_MS = 300 * 1000`, `isLowInfo(clue, vector, narrative)` predicate
- **Gate (SessionEnd only)**: `fs.statSync(narrativePath).mtimeMs` 체크. 300s 이내 write 시 silent skip. ENOENT/stat failure → fail-open (first-write 경로)
- **Post-extraction**: 3 haiku 추출 후 `isLowInfo` 체크 → 모두 empty 시 early return. two-track extension(entropy/markers/coinage)도 skip
- **Variable hoisting**: `vectorData`, `narrativeData`를 try-block const에서 function-scope let으로

`anamnesis/.claude-plugin/plugin.json`: 0.4.2 → 0.4.3

## Invariants 보존

1. **PreCompact 무변경** — cooldown은 `if (event === "SessionEnd")` 분기 안에만
2. **Fail-open** — stat 실패 catch block empty, write 시도 지속
3. **Output schema 불변** — frontmatter 필드 추가 없음 (`turn_count_at_write` 같은 신규 field 없음)

## Rationale: 왜 cooldown + discard인가

Syneidesis 세션에서 signal source 4 축 비교 후 결정:

| 축 | A: session_span | B: hooks.log engagement | D: narrative.md mtime + isLowInfo |
|---|---|---|---|
| Within-system | ✓ | ✗ (user 설정) | ✓ |
| Active-resume rate-limit | **불가** (매 exit 통과) | 시간 기반 | content 기반 (파일 재사용) |
| Ghost session 처리 | tokens 임계 필요 | tokens 임계 필요 | post-extraction discard로 자연스런 재시도 |
| 외부 의존 | 없음 | hooks.log 포맷 | 없음 |

Discard의 핵심: ghost session이 파일을 **미작성**하므로 다음 SessionEnd의 cooldown이 즉시 통과(no mtime) → 세션이 성숙할수록 자연스럽게 indexing.

## Test plan

- [x] `node --check anamnesis/scripts/hypomnesis-write.mjs` 통과
- [x] `node .claude/skills/verify/scripts/static-checks.js .` fail=0 유지
- [x] CI `claude-code-review` workflow 통과
- [x] Post-merge: active-resume 실제 세션 1건에서 300s 이상 경과 후 SessionEnd → `hypomnesis/{session-id}/narrative.md` 생성 확인
- [x] Post-merge: ghost session (짧은 plugin install 등)에서 `isLowInfo` discard 동작 확인 (narrative.md 미생성)
- [x] Post-merge: PreCompact 경로는 gate 우회 유지 확인 (`/compact` 호출 시 즉시 write)
- [x] Merge 후 MEMORY.md L47 addendum 참조 갱신 (v0.4.3 merged 시각 기록)

## Cross-references

- Plan: `~/.claude/plans/hypomnesis-gate-redesign.md` (Option B 원안 — cooldown 단순화로 수렴)
- Memory: `memory/project_anamnesis_reframing.md` 2026-04-14 Supersession Correction addendum
- Preceding: PR #251 (v0.3.3 regression), PR #253 (v0.4.0 two-track), PR #254 (v0.4.2 hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
