### PR TITLE
fix(anamnesis): v0.4.4 INDEX 경로 {cwd}에서 ~/.claude/projects/{slug}/로 이전

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ dist/
 dist-site/
 node_modules/
 
-# Anamnesis hook output — session INDEX is written to user working dir
-# (cwd/hypomnesis/{session-id}/), containing per-session clue/vector/
-# narrative + entropy/markers/coinage. Personal session content; never
-# commit even in self-hosting dogfood context.
+# Anamnesis hook output — v0.4.4+ writes INDEX to ~/.claude/projects/{slug}/
+# hypomnesis/{session-id}/ (outside repo). This pattern remains to ignore any
+# pre-v0.4.4 residue at {cwd}/hypomnesis/ until the transitional data is
+# archived or removed. Personal session content; never commit.
 hypomnesis/

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -15,7 +15,10 @@
  *   3. Build 3 prompts (clue: user-only, vector: full, narrative: full)
  *   4. Call claude -p --model haiku per prompt (LLM semantic extraction)
  *   5. Validate JSON output + assemble md files (deterministic)
- *   6. Atomic write to hypomnesis/{session-id}/
+ *   6. Atomic write to ~/.claude/projects/{slug}/hypomnesis/{session-id}/
+ *      (slug derived from transcript_path dirname — sibling to SSOT JSONL.
+ *      v0.4.4 moved this from {cwd}/hypomnesis/ so writer topology follows
+ *      Claude Code's own slug partition, preventing cwd-scattered INDEX.)
  *
  * Recursion safety: --setting-sources "" prevents hook loading in child process.
  * Fail-open: top-level try/catch → process.exit(0).
@@ -735,7 +738,6 @@ function main() {
   const {
     session_id: sessionId,
     transcript_path: transcriptPath,
-    cwd,
     reason,
     hook_event_name: eventName,
   } = input;
@@ -751,10 +753,11 @@ function main() {
   const stat = fs.statSync(transcriptPath, { throwIfNoEntry: false });
   if (!stat || stat.size < MIN_SESSION_BYTES) return;
 
-  // Store lives in user's working directory so /recollect can find it,
-  // not in Claude's internal transcript storage (~/.claude/projects/...).
-  const projectDir = cwd || path.dirname(transcriptPath);
-  const storeDir = path.join(projectDir, "hypomnesis", sessionId);
+  // INDEX is sibling to SSOT under ~/.claude/projects/{slug}/ so that /recollect
+  // reaches a single canonical location regardless of invocation cwd. transcript_path
+  // is always ~/.claude/projects/{slug}/{session-id}.jsonl, so dirname is the slug dir.
+  const slugDir = path.dirname(transcriptPath);
+  const storeDir = path.join(slugDir, "hypomnesis", sessionId);
 
   const {
     userMsgs, allTexts, timestamps, protocols, tokenEstimate,
@@ -886,7 +889,7 @@ function main() {
         `budget ${TWO_TRACK_BUDGET_MS}ms exhausted after ${elapsed}ms`,
       );
     } else {
-      const corpusRoot = path.join(projectDir, "hypomnesis");
+      const corpusRoot = path.join(slugDir, "hypomnesis");
       const result = computeCoinage(userMsgs, allTexts, corpusRoot, sessionId, remaining);
       files["coinage.md"] = buildCoinageMd(sessionId, date, result, false, null);
     }

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -756,7 +756,13 @@ function main() {
   // INDEX is sibling to SSOT under ~/.claude/projects/{slug}/ so that /recollect
   // reaches a single canonical location regardless of invocation cwd. transcript_path
   // is always ~/.claude/projects/{slug}/{session-id}.jsonl, so dirname is the slug dir.
+  // Shape guard: unexpected transcript_path format makes dirname return "." (writes
+  // to ./hypomnesis/, defeating the v0.4.4 migration silently). Log but fail-open
+  // so indexing still proceeds when the assumption breaks.
   const slugDir = path.dirname(transcriptPath);
+  if (!slugDir || slugDir === ".") {
+    logErr(`transcript_path "${transcriptPath}" lacks directory component; slugDir="${slugDir}" — INDEX may write to wrong location`);
+  }
   const storeDir = path.join(slugDir, "hypomnesis", sessionId);
 
   const {

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -119,12 +119,13 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 -- (see ── SUBSTRATE AGNOSTICISM ──). Any substrate satisfying the morphism laws realizes Anamnesis.
 -- Realization: gate → TextPresent+Stop; relay → TextPresent+Proceed
 -- Store binding:
+--   {slug} = dirname(transcript_path) — Claude Code's project partition identifier
 --   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl                    (session JSONL, append-only)
 --   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/{session-id}/   (SessionEnd/PreCompact hook;
---                                                                 sibling to SSOT so cross-cwd
---                                                                 /recollect reaches a single
---                                                                 canonical location)
---         ∪ ~/.claude/projects/{slug}/memory/                    (curated insights, sibling to SSOT)
+--                                                                 writer topology follows
+--                                                                 Claude Code's slug partition,
+--                                                                 preventing cwd-scattered INDEX)
+--         ∪ ~/.claude/projects/{slug}/memory/                    (user-curated insights)
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -119,13 +119,12 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 -- (see ── SUBSTRATE AGNOSTICISM ──). Any substrate satisfying the morphism laws realizes Anamnesis.
 -- Realization: gate → TextPresent+Stop; relay → TextPresent+Proceed
 -- Store binding:
---   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl          (session JSONL, append-only)
---   INDEX ↦ {cwd}/hypomnesis/{session-id}/              (SessionEnd/PreCompact hook writes to
---                                                         user working dir, colocated with
---                                                         user artifacts so /recollect's
---                                                         Read/Grep can reach it from cwd;
---                                                         PR #249 decision 2026-04-13)
---         ∪ ~/.claude/projects/{slug}/memory/           (curated insights, sibling to SSOT)
+--   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl                    (session JSONL, append-only)
+--   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/{session-id}/   (SessionEnd/PreCompact hook;
+--                                                                 sibling to SSOT so cross-cwd
+--                                                                 /recollect reaches a single
+--                                                                 canonical location)
+--         ∪ ~/.claude/projects/{slug}/memory/                    (curated insights, sibling to SSOT)
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)


### PR DESCRIPTION
## Summary

- **v0.4.4 INDEX 경로 이전**: `{cwd}/hypomnesis/` → `~/.claude/projects/{slug}/hypomnesis/` (SSOT·memory/ 형제 위치)
- **근본 원인**: v0.4.3 이하 hook이 `cwd`를 primary partition key로 사용해 writer가 세션 cwd마다 산재. stable key(slug) 대신 unstable runtime key(cwd)를 택한 결과, writer topology가 reader locality(cwd-local Read/Grep)에 결박되어 cross-cwd `/recollect` 불가
- **PR #249 결정 반전**: reader locality 제약을 writer 배치에 투영한 설계를 철회. Claude Code가 이미 SSOT에 적용 중인 slug 파티션을 INDEX가 그대로 따르도록 정렬

## 변경 사항

| 축 | v0.4.3 (문제) | v0.4.4 (수정) |
|---|---|---|
| Partition key | `cwd` (unstable runtime) | `slug` (stable, SSOT-파생) |
| Writer 수 | distinct cwd 수만큼 산재 | slug당 1개 (Claude Code 관례) |
| Reader 접근 | cwd-local Read/Grep | canonical 경로 단일 접근 |
| 새 이관 폴더 | 세션 cwd 변할 때마다 생성 | 발생하지 않음 |

- `anamnesis/scripts/hypomnesis-write.mjs`: `cwd` destructure 제거, `slugDir = path.dirname(transcriptPath)`로 재바인드 (storeDir + corpusRoot 2개 site), docstring에 v0.4.4 전환 사유 주석
- `anamnesis/skills/recollect/SKILL.md`: TOOL GROUNDING INDEX 바인딩 교정
- `anamnesis/.claude-plugin/plugin.json`: 0.4.3 → 0.4.4
- `.gitignore`: 전환기 residue 설명으로 코멘트 갱신 (패턴은 유지)

## 이관 대상 (pre-v0.4.4 residue)

다음 4개 cwd 산재 폴더는 일회성 수동 이관 또는 삭제 대상 (v0.4.4 자동 이관 안 함):

- `/Users/choi/ralph-test/hypomnesis`
- `/Users/choi/Downloads/github/org/infra/hypomnesis`
- `/Users/choi/Downloads/github/org/profile-service/hypomnesis`
- `/Users/choi/Downloads/github/private/epistemic-protocols/hypomnesis`

새 canonical 경로: `~/.claude/projects/{encoded-cwd}/hypomnesis/`. 각 항목은 사용자가 수동 이동·보관·삭제 중 선택. 다음 SessionEnd/PreCompact부터 hook이 새 경로에 씁니다.

## Test plan

- [ ] `node --check anamnesis/scripts/hypomnesis-write.mjs` — 구문 검증
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` — static checks pass=56 warn=8 fail=0 (baseline 유지) 확인
- [ ] CI `claude-epistemic-review.yml` 워크플로우 통과
- [ ] PR 머지 후 새 세션에서 SessionEnd 발화 시 `~/.claude/projects/{slug}/hypomnesis/{session-id}/`에 clue/vector/narrative/entropy/markers/coinage 6파일 생성 확인
- [ ] 머지 후 새 세션에서 `/recollect` 호출 시 새 canonical 경로에서 INDEX 스캔 동작 확인
- [ ] pre-v0.4.4 residue 4개 폴더 이관/삭제 정책 수동 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
