### PR TITLE
feat(anamnesis): SubagentStop hook으로 substitute 채널 영속화

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/hooks/hooks.json
+++ b/anamnesis/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Hypomnesis store writer — indexes session content for /recollect access.",
+  "description": "Hypomnesis store writer — indexes session content and substitute channel deposits for /recollect access.",
   "hooks": {
     "SessionEnd": [
       {
@@ -18,6 +18,17 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hypomnesis-write.mjs\"",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hypomnesis-subagent-hook.mjs\"",
             "async": true
           }
         ]

--- a/anamnesis/scripts/hypomnesis-subagent-hook.mjs
+++ b/anamnesis/scripts/hypomnesis-subagent-hook.mjs
@@ -1,0 +1,72 @@
+/**
+ * SubagentStop hook — substitute channel capture for /btw and /recap.
+ *
+ * Filter: agent_type === "" (non-empty types are typed subagents, not substitute channel).
+ * Output: ~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl (append-only).
+ * Non-goals: cooldown gate, LLM extraction, INDEX integration — raw relay only.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+try { process.on("SIGHUP", () => {}); } catch {}
+
+function logErr(msg) {
+  try { process.stderr.write(`[hypomnesis-subagent-hook] ${msg}\n`); } catch {}
+}
+
+function readHookInput() {
+  try {
+    const raw = fs.readFileSync(0, "utf8").trim();
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (e) {
+    logErr(`stdin parse failed: ${e.message}`);
+    return null;
+  }
+}
+
+function main() {
+  const payload = readHookInput();
+  if (!payload) return;
+
+  const { session_id, transcript_path, agent_id, agent_type, agent_transcript_path, last_assistant_message } = payload;
+
+  if (agent_type !== "") {
+    logErr(`skipping non-empty agent_type="${agent_type}"`);
+    return;
+  }
+  if (!last_assistant_message) {
+    logErr(`empty last_assistant_message; skipping`);
+    return;
+  }
+  if (!transcript_path || !agent_id || !session_id) {
+    logErr(`missing required field(s); skipping`);
+    return;
+  }
+
+  const slugDir = path.dirname(transcript_path);
+  if (slugDir === "." || slugDir === "/") {
+    logErr(`unexpected slugDir="${slugDir}" from transcript_path="${transcript_path}"; skipping`);
+    return;
+  }
+
+  const target = path.join(slugDir, "hypomnesis", "subagent", `${agent_id}.jsonl`);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+
+  const entry = {
+    timestamp: new Date().toISOString(),
+    session_id,
+    agent_id,
+    agent_transcript_path: agent_transcript_path ?? null,
+    last_assistant_message,
+  };
+  fs.appendFileSync(target, JSON.stringify(entry) + "\n");
+}
+
+try {
+  main();
+} catch (e) {
+  logErr(`unhandled: ${e.message}`);
+}
+process.exit(0);

--- a/anamnesis/scripts/hypomnesis-subagent-hook.mjs
+++ b/anamnesis/scripts/hypomnesis-subagent-hook.mjs
@@ -1,8 +1,9 @@
 /**
- * SubagentStop hook — substitute channel capture for /btw and /recap.
+ * SubagentStop hook — substitute channel capture for all substitute channel invocations.
  *
  * Filter: agent_type === "" (non-empty types are typed subagents, not substitute channel).
- * Output: ~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl (append-only).
+ * Output: ~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl
+ *         (append-only; {slug} = dirname(transcript_path)).
  * Non-goals: cooldown gate, LLM extraction, INDEX integration — raw relay only.
  */
 
@@ -32,8 +33,11 @@ function main() {
 
   const { session_id, transcript_path, agent_id, agent_type, agent_transcript_path, last_assistant_message } = payload;
 
+  if (agent_type === undefined) {
+    logErr(`agent_type field absent from payload; skipping`);
+    return;
+  }
   if (agent_type !== "") {
-    logErr(`skipping non-empty agent_type="${agent_type}"`);
     return;
   }
   if (!last_assistant_message) {
@@ -46,13 +50,18 @@ function main() {
   }
 
   const slugDir = path.dirname(transcript_path);
-  if (slugDir === "." || slugDir === "/") {
-    logErr(`unexpected slugDir="${slugDir}" from transcript_path="${transcript_path}"; skipping`);
+  if (!path.isAbsolute(slugDir)) {
+    logErr(`slugDir is not absolute: "${slugDir}" (transcript_path="${transcript_path}"); skipping`);
     return;
   }
 
-  const target = path.join(slugDir, "hypomnesis", "subagent", `${agent_id}.jsonl`);
-  fs.mkdirSync(path.dirname(target), { recursive: true });
+  const safeAgentId = path.basename(agent_id);
+  if (safeAgentId !== agent_id || safeAgentId === "" || safeAgentId === ".") {
+    logErr(`agent_id failed sanitization: "${agent_id}"; skipping`);
+    return;
+  }
+
+  const target = path.join(slugDir, "hypomnesis", "subagent", `${safeAgentId}.jsonl`);
 
   const entry = {
     timestamp: new Date().toISOString(),
@@ -61,7 +70,14 @@ function main() {
     agent_transcript_path: agent_transcript_path ?? null,
     last_assistant_message,
   };
-  fs.appendFileSync(target, JSON.stringify(entry) + "\n");
+
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.appendFileSync(target, JSON.stringify(entry) + "\n");
+  } catch (e) {
+    logErr(`write failed target="${target}": ${e.message}`);
+    return;
+  }
 }
 
 try {

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -120,9 +120,11 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 -- Realization: gate → TextPresent+Stop; relay → TextPresent+Proceed
 -- Store binding:
 --   {slug} = dirname(transcript_path) — Claude Code's project partition identifier
---   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl                    (session JSONL, append-only)
---   INDEX ↦ ~/.claude/projects/{slug|session-id}/hypomnesis/     (narrative/clue/vector/hook — classified by writer category annotation)
---         ∪ ~/.claude/projects/{slug|session-id}/memory/         (user-curated insights)
+--   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl                                 (session JSONL, append-only)
+--   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/{session-id}/                (per-session recall index from SessionEnd/PreCompact)
+--         ∪ ~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl    (substitute channel capture from SubagentStop)
+--         ∪ ~/.claude/projects/{slug}/memory/                                 (user-curated insights)
+--   slug-partitioned: prevents cwd-scattered INDEX; cross-cwd /recollect reaches one canonical location
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -121,11 +121,8 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 -- Store binding:
 --   {slug} = dirname(transcript_path) — Claude Code's project partition identifier
 --   SSOT  ↦ ~/.claude/projects/{slug}/*.jsonl                    (session JSONL, append-only)
---   INDEX ↦ ~/.claude/projects/{slug}/hypomnesis/{session-id}/   (SessionEnd/PreCompact hook;
---                                                                 writer topology follows
---                                                                 Claude Code's slug partition,
---                                                                 preventing cwd-scattered INDEX)
---         ∪ ~/.claude/projects/{slug}/memory/                    (user-curated insights)
+--   INDEX ↦ ~/.claude/projects/{slug|session-id}/hypomnesis/     (narrative/clue/vector/hook — classified by writer category annotation)
+--         ∪ ~/.claude/projects/{slug|session-id}/memory/         (user-curated insights)
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)


### PR DESCRIPTION
## Summary
- `/btw`, `/recap` forked API 호출은 hook으로 직접 가로챌 수 없어 `SubagentStop` 이벤트의 `agent_type == ""` payload를 **substitute 채널**로 포착
- Anamnesis v0.4.x에 **세 번째 트랙 — raw relay** 추가: SessionEnd/PreCompact의 LLM 추출 + deterministic 2트랙과 직교
- 경로: `~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl` (flat agent_id 네임스페이스, append-only JSONL)
- `/recollect` INDEX 경로를 slug-partitioned 토폴로지로 명시 (cwd-scattered 방지, cross-cwd canonical 보장)

## 설계 경로
- `/clarify` + `/inquire` (composition) — intent 명료화 + context 충분성 검증
- `/bound` (Horismos) — 6 도메인 boundary 분류 (filter/script/location/processing/cooldown/version)
- `/contextualize` (Epharmoge) — 3 불일치 중 1 Adapt(INDEX 토폴로지 명시) + 2 Dismiss
- `/attend` (Prosoche) — 5 task p=Low batch delegation → 15/15 static check pass

## 리뷰 반영 (8건)
**Critical**
- agent_id path traversal 방어: `path.basename` + 동등성/공백/`.` 검증
- agent_type undefined 명시 분기; typed subagent silent return (오인 로그 제거)

**High / Medium**
- SKILL.md TOOL GROUNDING: `{slug|session-id}` 모호 표기 제거 → slug-partitioned 구조 + SubagentStop 경로 라인 추가
- 미정의 forward-reference (`narrative/clue/vector/hook`) 제거; slug-partition 근거 복원
- 쓰기 실패 시 inner try-catch로 `target` 경로 로깅 (`mkdirSync`/`appendFileSync` 컨텍스트 보존)
- `path.isAbsolute(slugDir)` guard로 상대경로(`..` 등) 우회 차단

**Minor**
- 헤더 주석: "/btw, /recap" → "all substitute channel invocations" (필터 의미 정확화)
- `{slug} = dirname(transcript_path)` 도출 주석 명시

## Test plan
- [ ] 플러그인 재로드 후 새 세션에서 `/btw` 또는 `/recap` 실행
- [x] `ls ~/.claude/projects/-Users-choi-Downloads-github-private-epistemic-protocols/hypomnesis/subagent/` 로 `{agent_id}.jsonl` 생성 확인 *(정적 단위 검증: 합성 payload → 파일 생성 확인)*
- [x] `cat ~/.claude/projects/-Users-choi-Downloads-github-private-epistemic-protocols/hypomnesis/subagent/*.jsonl | jq .` 로 필드 검증 (timestamp, session_id, agent_id, agent_transcript_path, last_assistant_message) *(5개 필드 모두 확인; ISO-8601 timestamp)*
- [x] `tail -n 20 ~/.claude/logs/hooks.log | grep SubagentStop` 로 hook 호출 확인 *(2건 entry 확인 @ 2026-04-15 13:46-13:47, `agent_type=""` 필터 매칭)*
- [x] `agent_type` non-empty 케이스(예: Explore subagent) 발생 시 파일 미생성 육안 확인 *(정적 단위 검증: `agent_type="Explore"` → 파일 수 불변, silent return)*
- [ ] `/recollect` 실행 시 subagent/ 하위 deposit이 스캔 범위 포함 여부 확인
- [x] path traversal 회귀: `agent_id="../escape"` 시뮬레이션 → sanitization 로그 + 파일 미생성 확인 *(5/5 guard pass: `../escape`, `a/b`, 상대 transcript, undefined agent_type, legit write)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
