### PR TITLE
feat(epistemic-cooperative): introspect 스킬 추가 + 정의-관찰 수렴 원칙 문서화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -57,7 +57,7 @@
     {
       "name": "epistemic-cooperative",
       "source": "./epistemic-cooperative",
-      "description": "/catalog for protocol handbook, /report for Growth Map (epistemic analysis + insights), /onboard for quest-based protocol learning, /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match, /curses for strength-shadow analysis, /write for multi-perspective blog drafting"
+      "description": "/catalog for protocol handbook, /report for Growth Map (epistemic analysis + insights), /onboard for quest-based protocol learning, /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match, /curses for strength-shadow analysis, /write for multi-perspective blog drafting"
     },
     {
       "name": "anamnesis",

--- a/.claude/rules/architectural-principles.md
+++ b/.claude/rules/architectural-principles.md
@@ -28,6 +28,10 @@ Inter-protocol guidance operates through two distinct mechanisms at different ab
 
 **Emergent boundary annotations**: Routing hints in Emergent sections of SKILL.md (e.g., `→ /clarify`, `→ /gap` in Emergent gap types or mismatch dimensions) are dialogue interaction dynamics — potential conversational routing that emerges from user-AI turn interaction. These belong to the Output Style nudge layer, not graph.json. They do not constitute structural advisory edges and must not be formalized in graph.json.
 
+**Definitional-Observational convergence**: AI-observation concerns without constitutive user authority (runtime detection, cross-cutting commentary, session-context nudges) have repeatedly converged into Output Style rather than SKILL.md. Observed instances (N=4): Post-Convergence traversal → Output Style nudge (archived); Integration+basis runtime display → Output Style echo format; protocol nudge arrow (↗) → Output Style session observer; Basis marker → Output Style session-level citation (deliberately placed outside per-protocol TOOL GROUNDING). Definitional structure (TYPES, FLOW, PHASE TRANSITIONS, gate interactions) lives in SKILL.md; observational commentary lives in Output Style. This convergence is not a design imposition but a recurring empirical outcome of applying the Dual Advisory Layer division.
+
+**Authoring checkpoint**: Before inscribing AI-detection prose into SKILL.md, apply the test: "Does this concern require gated user constitution (differential futures, constitutive choice), or is it runtime AI observation that the user can immediately recognize or dismiss?" Gated constitution → SKILL.md. Runtime observation → Output Style. Prevents SKILL.md bloat; preserves definitional minimality against the gravitational pull of new AI-observation ideas.
+
 ## Coexistence over Mirroring
 
 Protocols coexist with Claude Code built-in commands (`/simplify`, `/batch`) as orthogonal tools occupying different layers:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ epistemic-protocols/
 │       ├── report/SKILL.md            # Usage analysis report from session patterns
 │       ├── onboard/SKILL.md           # Quick recommendation + protocol learning (quick proof + targeted learning)
 │       ├── dashboard/SKILL.md          # Full-session coverage dashboard
+│       ├── introspect/SKILL.md         # Deep self-analysis pipeline (behavioral profile + HTML report)
 │       ├── catalog/SKILL.md           # Protocol handbook — instant reference
 │       ├── compose/SKILL.md           # Protocol composition authoring assistant
 │       ├── sophia/SKILL.md            # Philosopher match via behavioral dimensions
@@ -96,7 +97,7 @@ epistemic-protocols/
 | Epharmoge | `/contextualize` | ApplicationDecontextualized → ContextualizedExecution |
 | Anamnesis | `/recollect` | RecallAmbiguous → RecalledContext |
 
-**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/dashboard`, `/compose`, `/sophia`, `/curses`, `/write`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
+**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/dashboard`, `/compose`, `/introspect`, `/sophia`, `/curses`, `/write`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
 
 ## Axioms
 
@@ -203,6 +204,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 - **Report**: Phase 1 delegates to project-scanner subagent (single). Phase 2: Path A delegates session-analyzer in targeted mode, Path B in full mode. Main agent handles Phases 3-5.
 - **Onboard**: All paths use inline Quick Scan (no subagents) for Phase 1. Deep pattern extraction belongs in Report. Main agent handles all phases. Quick path: Phases 0-1, 2a-2b, 4 (Trial triggers actual protocol execution in-session). Targeted path: Phases 0-6 (full learning experience).
 - **Dashboard**: Phase 2 delegates to coverage-scanner subagent (single) for batch aggregation. Main agent handles Phases 1, 3, 4.
+- **Introspect**: Phase 1 launches 3 ad-hoc inline Task(general-purpose) invocations in parallel (rules/config collection, usage stats collection, session behavior collection). Main agent handles Phase 2 (5-dimension analysis, Strength-Shadow, normative-descriptive conflict surface + user dialogue gate). Phase 3 main agent optionally composes `/analogia:ground`. Phase 4 main agent generates HTML output; `references/report-guide.md` used for CSS/component templates.
 - **Catalog**: No delegation—text-only output, main agent handles all. Read tool for scenarios.md detail mode only.
 - **Compose**: No delegation—main agent handles all phases. Read/Grep for graph.json and ELIDABLE CHECKPOINTS extraction, Write for template generation.
 - **Sophia**: Phase 1 delegates to coverage-scanner then dimension-profiler subagents (serial chain). Main agent handles Phases 2-4 (matching, presentation, report).

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights",
-  "version": "1.27.2",
+  "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights",
+  "version": "1.28.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/introspect/SKILL.md
+++ b/epistemic-cooperative/skills/introspect/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: introspect
+description: >
+  Deep self-analysis pipeline: collect behavioral data from sessions/rules/usage,
+  analyze patterns across 5 dimensions, identify strengths and their structural costs,
+  ground findings philosophically via Analogia, and produce an HTML report.
+  Use when: "analyze my patterns", "what are my curses", "cognitive profile",
+  "self-analysis", "introspect", "how do I work with AI", "what should I improve",
+  "identity analysis", or any reflective question about working patterns and
+  AI collaboration style.
+---
+
+# Introspect
+
+A self-analysis pipeline that collects behavioral context, identifies patterns, and produces
+actionable insights as an HTML report. The pipeline has 4 phases, each building on the previous.
+
+## Pipeline Overview
+
+| Phase | What | Mode | Output |
+|-------|------|------|--------|
+| 1. Collect | Gather data from 4 sources | 3 parallel subagents | Raw findings |
+| 2. Analyze | Synthesize into profile | AI + user dialogue | Strengths, costs, conflicts |
+| 3. Ground | Map to philosophical frameworks | Optional Analogia | Validated mapping |
+| 4. Report | Generate HTML report | Automated | `.html` file |
+
+If the user provides a specific question (e.g., "What are my curses?"), orient the analysis
+toward answering that question rather than producing a generic profile.
+
+---
+
+## Phase 1: Data Collection
+
+Launch 3 parallel subagents. Each collects from different sources and returns structured findings.
+All prompts are English per delegation rules; search keywords in quotes are exempt.
+
+### Agent 1: Rules & Configuration
+
+```
+PURPOSE: Extract the user's explicitly stated preferences and constraints from their
+Claude Code configuration.
+
+COLLECT:
+1. Read ~/.claude/CLAUDE.md — extract all stated preferences, principles, and constraints
+2. Read all files in ~/.claude/rules/ — extract each rule with its rationale
+3. Read ~/.claude/projects/*/memory/MEMORY.md — extract persistent session memory
+
+RETURN FORMAT:
+## Stated Preferences
+- [preference]: [source file]
+
+## Constraints & Boundaries
+- [constraint]: [source file]
+
+## Rule Inventory
+- Total rules: N
+- Categories: [list]
+- Potential redundancies: [if any rules overlap or subsume others]
+
+## Memory Highlights
+- [key patterns from session memory]
+```
+
+### Agent 2: Usage Patterns (Quantitative)
+
+```
+PURPOSE: Extract quantitative behavioral patterns from usage data.
+
+COLLECT:
+1. Read ~/.claude/usage-data/report.html — extract key statistics (messages, tools,
+   friction types, outcomes, satisfaction, session types)
+2. Sample 5-10 facet files from ~/.claude/usage-data/facets/ — extract
+   recurring themes, tool usage patterns, satisfaction signals
+3. Sample 5-10 session-meta files from ~/.claude/usage-data/session-meta/ —
+   extract session types, durations, goal patterns
+
+RETURN FORMAT:
+## Quantitative Profile
+- Messages: N across M sessions
+- Top tools: [ranked list]
+- Top goals: [ranked list]
+- Outcome distribution: [fully/mostly/partially/not achieved]
+
+## Behavioral Signals
+- Session type distribution: [multi-task, iterative, single, exploration]
+- Friction patterns: [top 3 with counts]
+- Satisfaction distribution
+
+## Notable Patterns
+- [3-5 patterns that stand out from the quantitative data]
+```
+
+### Agent 3: Session Behavior (Qualitative)
+
+```
+PURPOSE: Extract qualitative behavioral patterns from recent session transcripts.
+
+COLLECT:
+1. List session files in ~/.claude/projects/ (find recent, large sessions)
+2. Sample 3-5 substantive sessions (>50KB) — use Grep to extract:
+   - User correction patterns (interruptions, redirections)
+   - Decision-making patterns (how user makes choices)
+   - Protocol usage patterns (which epistemic protocols, how often)
+   - Communication style (directive, collaborative, exploratory)
+3. Cross-reference with .insights/ files for existing analysis
+
+RETURN FORMAT:
+## Interaction Style
+- [3-5 observed patterns with session evidence]
+
+## Decision Patterns
+- [how the user approaches decisions, with examples]
+
+## Correction Patterns
+- [what the user corrects most often, what triggers corrections]
+
+## Protocol/Tool Preferences
+- [which tools/protocols are preferred and when]
+```
+
+---
+
+## Phase 2: Pattern Analysis
+
+After all 3 agents return, synthesize findings across 5 dimensions.
+
+### 5-Dimension Framework
+
+Analyze each dimension by cross-referencing data from all 3 agents:
+
+| Dimension | What to look for | Sources |
+|-----------|-----------------|---------|
+| **Communication Style** | Directive vs collaborative, interruption patterns, feedback style | Agent 1 (rules), Agent 3 (sessions) |
+| **Technical Preferences** | Tool choices, language preferences, architecture patterns | Agent 1 (rules), Agent 2 (usage) |
+| **Cognitive/Decision Patterns** | Verification depth, risk tolerance, abstraction appetite | Agent 2 (friction), Agent 3 (decisions) |
+| **Domain/Context** | Primary work areas, domain switching patterns | Agent 2 (goals), Agent 3 (sessions) |
+| **Premise** | Core values, what drives engagement, what causes frustration | All agents |
+
+### Strength-Shadow Analysis
+
+For each strength identified, find its structural cost (the "shadow"):
+
+```
+Pattern: [observed strength]
+Evidence: [specific data from agents]
+Shadow: [structural cost that comes with this strength]
+Mechanism: [why the strength produces this specific cost]
+```
+
+The key insight: every strength has a shadow, and the shadows often share a common
+structure (precision creates new complexity, optimization creates blind spots).
+
+### Conflict Surface
+
+Compare descriptive patterns (what the user actually does, from Agent 2/3) against
+prescriptive rules (what the user says to do, from Agent 1). Surface mismatches:
+
+- Rules that the user's own behavior contradicts
+- Patterns not captured by any rule
+- Rules that may be redundant or subsumable
+
+Present the analysis to the user. Use AskUserQuestion to validate key findings before
+proceeding. The user may refine, correct, or add context that changes the analysis.
+
+---
+
+## Phase 3: Philosophical Grounding
+
+Map identified patterns to philosophical frameworks, giving the user a conceptual
+vocabulary for understanding their cognitive style.
+
+### When to activate
+
+Always offer this phase. If the user accepts, invoke `/analogia:ground` with the key
+findings as the grounding target. The Analogia protocol handles mapping validation
+through user dialogue.
+
+### Mapping candidates
+
+Common correspondences to consider (not exhaustive):
+
+| Pattern | Candidate frameworks |
+|---------|---------------------|
+| UU exploration preference | Popper (Critical Rationalism), Peirce (Abduction) |
+| AI delegation strategy | Clark & Chalmers (Extended Mind), Ricardo (Comparative Advantage) |
+| Openness to new problems | Zen Beginner's Mind, Socratic questioning |
+| Verification depth | Aristotelian phronesis, Cartesian doubt |
+| System building tendency | Kantian architectonic, Systems thinking |
+
+The Analogia process may refine or reject these candidates. User counter-arguments
+are often the most valuable part — as when "curse" was reframed as "strategy"
+through an AI-delegation counter-hypothesis.
+
+---
+
+## Phase 4: Report Generation
+
+Generate an HTML report and save to `~/.claude/usage-data/`.
+
+### Design System
+
+Read the existing `~/.claude/usage-data/report.html` to extract the CSS design system.
+Match its visual style: Inter font, #f8fafc background, white cards with #e2e8f0 border.
+See `references/report-guide.md` for section templates and component patterns.
+
+### Required Sections
+
+1. **At a Glance** — 4-bullet summary (identity, strengths, costs, recommendations)
+2. **Philosophical Identity** — 2x2 grid of philosophy cards (if Phase 3 completed)
+3. **Division of Labor** — Human-AI role visualization (if applicable)
+4. **Strengths** — Green cards with evidence and source dimension tag
+5. **Structural Costs** — White cards with severity badge and mitigation strategy
+6. **Attitude Recommendations** — Gradient cards, ranked by ROI
+7. **Practice Matrix** — Table mapping situations to principles and actions
+8. **Extended Mind Health** — Green/yellow/red indicators for monitoring metrics
+9. **Next Steps** — Horizon cards with concrete next actions
+
+### Output
+
+Save as `~/.claude/usage-data/cognitive-partnership-profile.html`
+(date-stamped variant if previous report exists).
+Open in browser after generation: `open <filepath>`
+
+---
+
+## Edge Cases
+
+- **First-time run**: If report.html missing, use CSS from `references/report-guide.md`.
+- **Missing data**: Note limitations in the report, focus on available sources.
+- **Specific question**: Orient entire analysis toward the question, not a generic profile.
+- **Skip grounding**: If user declines Phase 3, proceed directly to Phase 4.
+  Philosophical identity section becomes optional in the report.

--- a/epistemic-cooperative/skills/introspect/SKILL.md
+++ b/epistemic-cooperative/skills/introspect/SKILL.md
@@ -19,7 +19,7 @@ actionable insights as an HTML report. The pipeline has 4 phases, each building 
 
 | Phase | What | Mode | Output |
 |-------|------|------|--------|
-| 1. Collect | Gather data from 4 sources | 3 parallel subagents | Raw findings |
+| 1. Collect | Gather data from 4 sources | 3 parallel inline Task invocations | Raw findings |
 | 2. Analyze | Synthesize into profile | AI + user dialogue | Strengths, costs, conflicts |
 | 3. Ground | Map to philosophical frameworks | Optional Analogia | Validated mapping |
 | 4. Report | Generate HTML report | Automated | `.html` file |
@@ -31,7 +31,9 @@ toward answering that question rather than producing a generic profile.
 
 ## Phase 1: Data Collection
 
-Launch 3 parallel subagents. Each collects from different sources and returns structured findings.
+Launch 3 parallel ad-hoc inline Task(general-purpose) invocations. These are not pre-registered
+agent files — each is an inline prompt task launched for this pipeline only. Each collects from
+different sources and returns structured findings.
 All prompts are English per delegation rules; search keywords in quotes are exempt.
 
 ### Agent 1: Rules & Configuration
@@ -195,7 +197,7 @@ through an AI-delegation counter-hypothesis.
 
 ## Phase 4: Report Generation
 
-Generate an HTML report and save to `~/.claude/usage-data/`.
+Generate an HTML report and save to `~/.claude/epistemic-cooperative/introspect/`.
 
 ### Design System
 
@@ -217,9 +219,9 @@ See `references/report-guide.md` for section templates and component patterns.
 
 ### Output
 
-Save as `~/.claude/usage-data/cognitive-partnership-profile.html`
+Save as `~/.claude/epistemic-cooperative/introspect/cognitive-partnership-profile.html`
 (date-stamped variant if previous report exists).
-Open in browser after generation: `open <filepath>`
+After saving, print the file path so the user can open it manually.
 
 ---
 

--- a/epistemic-cooperative/skills/introspect/references/report-guide.md
+++ b/epistemic-cooperative/skills/introspect/references/report-guide.md
@@ -1,0 +1,178 @@
+# Report Generation Guide
+
+CSS and HTML component reference for the Introspect report.
+Read this when generating the HTML report in Phase 4.
+
+## Design Tokens
+
+```css
+/* Typography */
+font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif
+h1: 32px/700, color #0f172a
+h2: 20px/600, color #0f172a
+body: 14px/400, color #334155, line-height 1.65
+label: 11px/600, uppercase, color #64748b
+
+/* Colors */
+background: #f8fafc
+card-bg: white
+card-border: #e2e8f0
+text-primary: #0f172a
+text-secondary: #475569
+text-muted: #64748b
+
+/* Semantic colors */
+strength: bg #f0fdf4, border #86efac, text #166534
+cost-structural: bg #fce7f3, text #9d174d
+cost-conditional: bg #fef3c7, text #92400e
+cost-recurring: bg #fee2e2, text #991b1b
+highlight: bg gradient(135deg, #fef3c7, #fde68a), border #f59e0b
+horizon: bg gradient(135deg, #faf5ff, #f5f3ff), border #c4b5fd
+attitude-primary: bg gradient(135deg, #faf5ff, #f5f3ff), border #c4b5fd
+attitude-default: bg gradient(135deg, #eff6ff, #f0f9ff), border #93c5fd
+insight: bg #f0fdf4, border #bbf7d0, text #166534
+health-green: #22c55e
+health-yellow: #eab308
+health-red: #ef4444
+
+/* Layout */
+container: max-width 800px, margin 0 auto
+card: border-radius 8px, padding 16px
+grid-2col: grid-template-columns 1fr 1fr, gap 16px
+```
+
+## Component Patterns
+
+### At a Glance (top summary)
+```html
+<div class="at-a-glance">
+  <div class="glance-title">At a Glance</div>
+  <div class="glance-sections">
+    <div class="glance-section"><strong>Label:</strong> Text <a href="#id" class="see-more">Link →</a></div>
+  </div>
+</div>
+```
+
+### Philosophy Card (2x2 grid)
+```html
+<div class="philosophy-grid"> <!-- grid-template-columns: 1fr 1fr -->
+  <div class="philosophy-card [type]"> <!-- type: popper, extended, zen, bridge -->
+    <div class="philosophy-dim">DIMENSION LABEL</div>
+    <div class="philosophy-name">Framework Name</div>
+    <div class="philosophy-desc">Description text</div>
+    <div class="philosophy-role"><span>Mapping:</span> Correspondence</div>
+  </div>
+</div>
+```
+Each card has a colored 3px top border via `::before`.
+
+### Strength Card
+```html
+<div class="strength-card">
+  <div class="strength-title">Title <span class="strength-tag">DIMENSION</span></div>
+  <div class="strength-desc">Description</div>
+  <div class="strength-evidence">Evidence: specific data</div>
+</div>
+```
+
+### Cost Card
+```html
+<div class="cost-card">
+  <div class="cost-header">
+    <div class="cost-title">Title</div>
+    <span class="cost-severity [level]">LEVEL</span> <!-- structural|conditional|recurring -->
+  </div>
+  <div class="cost-source">Source: strength shadow origin</div>
+  <div class="cost-desc">Description</div>
+  <div class="cost-mitigation">
+    <div class="cost-mitigation-label">MITIGATION</div>
+    <div class="cost-mitigation-text">Strategy text</div>
+  </div>
+</div>
+```
+
+### Attitude Card
+```html
+<div class="attitude-card [primary]"> <!-- add .primary for highest ROI -->
+  <div class="attitude-number">Principle N</div>
+  <div class="attitude-title">Title</div>
+  <div class="attitude-principle">Explanation</div>
+  <div class="attitude-application">
+    <div class="attitude-app-label">APPLICATION</div>
+    <div class="attitude-app-text">How to apply</div>
+  </div>
+</div>
+```
+
+### Practice Matrix
+```html
+<table class="practice-table">
+  <thead><tr><th>Situation</th><th>Principle</th><th>Action</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>When X</td>
+      <td>Principle N</td>
+      <td>Do Y<div class="practice-when">trigger: condition</div></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Health Indicator
+```html
+<div class="health-card">
+  <div class="health-title">CATEGORY</div>
+  <div class="health-metric">
+    <div class="health-dot [green|yellow|red]"></div>
+    <div class="health-label">Metric name</div>
+    <div class="health-status">Status text</div>
+  </div>
+</div>
+```
+
+### Horizon Card
+```html
+<div class="horizon-card">
+  <div class="horizon-title">Title</div>
+  <div class="horizon-possible">Description</div>
+  <div class="horizon-tip"><strong>Tip:</strong> Actionable advice</div>
+</div>
+```
+
+### Division Diagram
+```html
+<div class="division-diagram">
+  <div class="division-row">
+    <div class="division-actor"><div class="division-label">ACTOR</div></div>
+    <div class="division-bar">
+      <div class="division-segment" style="flex: N; background: COLOR;">Label</div>
+    </div>
+  </div>
+  <div class="division-arrow">&darr; Bridge &darr;</div>
+  <!-- second row -->
+</div>
+```
+
+### Fun Ending
+```html
+<div class="fun-ending">
+  <div class="fun-headline">"Quote or insight"</div>
+  <div class="fun-detail">Explanation</div>
+</div>
+```
+
+## Google Fonts
+
+Always include in `<head>`:
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+## Responsive
+
+Add at end of CSS:
+```css
+@media (max-width: 640px) {
+  .philosophy-grid, .health-grid { grid-template-columns: 1fr; }
+}
+```


### PR DESCRIPTION
## 개요

두 가지 변경을 하나의 PR로 묶는다. 두 변경은 독립적이지만 동일한 세션에서 생성되었고 `epistemic-cooperative` 범위를 공유한다.

### 1. `/introspect` 유틸리티 스킬 추가 (`epistemic-cooperative`)

4단계 파이프라인 스킬 — 세션 데이터를 수집해 행동 패턴을 분석하고, 철학적 근거를 탐색한 뒤 HTML 인지-협업 프로파일 리포트를 생성한다.

- **Phase 1**: 3개 병렬 서브에이전트(규칙/설정, 사용 통계, 세션 행동) 수집
- **Phase 2**: 5개 차원 분석(커뮤니케이션·기술선호·인지결정·도메인·전제) + 강점-그림자(Strength-Shadow) 분석 + 규범-기술 충돌 표면화
- **Phase 3**: `/analogia:ground`를 통한 철학적 프레임워크 매핑(선택)
- **Phase 4**: `~/.claude/usage-data/cognitive-partnership-profile.html` 생성 + 브라우저 자동 오픈
- `references/report-guide.md`: Phase 4용 CSS 디자인 토큰 및 HTML 컴포넌트 레퍼런스

트리거 예시: "내 패턴을 분석해줘", "나의 curses가 뭐야", "cognitive profile", "introspect"

### 2. Definitional-Observational 수렴 원칙 문서화 (`.claude/rules/architectural-principles.md`)

`§Dual Advisory Layer`에 두 개의 문단 추가:

- **Definitional-Observational convergence**: AI 관찰 우려(런타임 감지, 크로스-커팅 주석, 세션 컨텍스트 넛지)가 SKILL.md가 아닌 Output Style로 반복 수렴하는 패턴을 N=4 관찰 사례와 함께 공식화
- **Authoring checkpoint**: SKILL.md에 AI 감지 산문을 삽입하기 전에 "게이트된 사용자 구성이 필요한가, 아니면 런타임 AI 관찰인가?"를 판별하는 테스트 제공 — SKILL.md 비대화 방지 및 정의적 최소성 보존

---

## Test plan

- [ ] `/verify` 실행 — 16개 정적 체크 모두 통과하는지 확인 (`node .claude/skills/verify/scripts/static-checks.js .`)
- [ ] `introspect` 스킬이 플러그인 시스템에서 로드되는지 확인 — `epistemic-cooperative/.claude-plugin/plugin.json`에 스킬 등록 여부 점검
- [ ] `SKILL.md` 프론트매터 `name: introspect` 및 `description` 필드가 트리거 예시("introspect", "cognitive profile" 등)를 포함하는지 확인
- [ ] `references/report-guide.md`가 `SKILL.md Phase 4`에서 참조하는 경로와 일치하는지 확인 (`references/report-guide.md`)
- [ ] `architectural-principles.md` 변경이 기존 `axioms.md`, `derived-principles.md` 내용과 충돌하지 않는지 크로스-레퍼런스 확인
- [ ] `catalog-sync` 정적 체크 통과 — 새 스킬이 카탈로그에 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
