### PR TITLE
feat(epistemic-cooperative): Horizon-Coverage Observer 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -140,7 +140,6 @@ Main's additional candidates (main-lens-limited): [with basis, or "none identifi
 **Trigger conditions** (emit only when at least one holds):
 - C1: One or more Agent tool invocations in this turn
 - C2: /frame or other multi-perspective protocol converged in this turn
-- C3: Turn precedes a commit, file mutation, or synthesis whose direction is set by preceding analysis
 
 The observer is runtime-only — it does not open a gate, does not alter protocol phase transitions, and does not require user response. Its function is to surface lens coverage and main's positionality for user judgment. This observer is a realization of the Definitional-Observational Convergence principle.
 

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -126,6 +126,33 @@ During any active protocol, watch for morphism framing instability — signals t
 
 Emit once per distinct instability pattern per session — subject redefinition, goal mutation, and incompatible categorization are distinct patterns, each warranting at most one emission per session. The observation is runtime-only — it does not alter protocol phase transitions, does not open a gate, and does not require user response. Its function is to make the drift visible so the user can choose to reframe in free response. Grounding condition: the instability must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. This observer is the realization of the Definitional-Observational Convergence principle — runtime AI observation lives in Output Style, not in any SKILL.md.
 
+## Horizon-Coverage Observer
+
+When the turn invokes subagent(s) via Agent tool or converges a multi-perspective protocol (/frame), emit a runtime observer surfacing which lenses operated and where the main agent's lens is positioned. The observer honors the main's epistemic limits by principle — the main never claims dimensions unseen by its own lens. Emit using the `◇` diamond marker immediately after primary response content and before any final gate block:
+
+◇ horizon ──────────────────────────────
+Lenses invoked: {main, <Agent-call list>, <selected /frame perspectives>}
+Main lens positionality: [Output Style X / rule Y / axiom Z emphasis]
+Covered (by invoked lenses): [D₁, D₂, ...]
+Main's additional candidates (main-lens-limited): [with basis, or "none identified"]
+──────────────────────────────────────────
+
+**Trigger conditions** (emit only when at least one holds):
+- C1: One or more Agent tool invocations in this turn
+- C2: /frame or other multi-perspective protocol converged in this turn
+- C3: Turn precedes a commit, file mutation, or synthesis whose direction is set by preceding analysis
+
+The observer is runtime-only — it does not open a gate, does not alter protocol phase transitions, and does not require user response. Its function is to surface lens coverage and main's positionality for user judgment. This observer is a realization of the Definitional-Observational Convergence principle.
+
+**Scope boundary**: This observer addresses (a) runtime lens drift visibility and (b) lens field-of-view coverage across invoked lenses. Principle-basis transmission to lens-generation layers — ensuring subagents carry axiom-priority context from upstream decisions — lies outside this plugin's Audience Reach. Plugin marketplace users resolve that concern in their own environment (personal rules, personal skills, or their own plugin composition), not through this observer.
+
+**Adversarial guards** (A7):
+- `always-audit`: emitting every turn regardless of trigger → noise. Guard: at least one trigger condition must hold.
+- `lens-fabrication`: listing subagents not actually invoked in this turn → false grounding. Guard: reference only Agent tool calls made in this turn's trace.
+- `false-precision`: asserting the "Covered" set as exhaustive → false comprehensiveness. Guard: list only dimensions identified from invoked lenses' outputs; "Main's additional candidates" accepts "none identified" as a valid value.
+- `recursive-self-praise`: main's positionality description drifts into self-justification → A2 Visibility regression. Guard: one-line positionality only, presented in parallel with other lens descriptions.
+- `novel-absolute-claim`: main claiming dimensions beyond its own lens — dimensions no invoked lens captured. Guard: the field name "Main's additional candidates (main-lens-limited)" structurally precludes claims beyond main's lens; dimensions unseen by any lens are omitted by principle — the observer does not speak of what no lens saw.
+
 # Tone and Style
 
 - Clear and educational, balancing insight delivery with task completion


### PR DESCRIPTION
## Summary

- N=7 post-ship drift 인스턴스에서 공통 발견된 "렌즈 field of view 바깥 변수"를 session-level observer로 surface
- `◇ horizon` element를 `⇌ framing` 다음에 배치 — 동일 Definitional-Observational Convergence 레이어
- **방안 C**: Main lens positionality 공개 + `main-lens-limited` rename + 절대 영역 원칙적 omit
- **5 adversarial guards**: `always-audit` / `lens-fabrication` / `false-precision` / `recursive-self-praise` / `novel-absolute-claim`
- **3 trigger conditions**: Agent tool 호출 / multi-perspective 수렴 / commit·file mutation·synthesis 직전
- **Scope boundary 명문화**: 축 2 (원칙-근거 전달)는 plugin marketplace Audience Reach 바깥 — 개별 사용자가 자기 환경에서 자율 해결

## Context

본 세션의 drift 분석(PR #270 XC1-XC4 작업의 post-ship 리뷰에서 발견된 3 drifts를 계기로 확장)이 세 축을 식별:

- **축 1**: task-interior 공리 충돌 순간의 재-게이트 부재 (실행 중 감지)
- **축 2**: 원칙 근거가 crystallize ↔ rehydrate 사이클에서 전달·복원되지 않음
- **축 3**: 렌즈 field of view 바깥 변수 (원칙이 있어도 렌즈가 변수를 포착 못 함)

`◇ horizon`은 **축 1 + 축 3을 session observer 레이어에서 묶음**. 축 2는 개별 사용자 환경 책임(plugin 범위 밖)으로 scope 경계 명시.

## Test plan

- [ ] `◇ horizon` 트리거 조건(C1/C2/C3) 충족 시에만 emit 되는지 2-3 세션 dogfood 관찰
- [ ] `lens-fabrication` guard — 실제 호출하지 않은 agent가 Lenses invoked에 등장하지 않는지 확인
- [ ] `novel-absolute-claim` guard — Main's additional candidates 필드가 렌즈 밖 주장을 포함하지 않는지 확인
- [ ] `/verify` 실행하여 기존 static checks 영향 없음 확인
- [ ] Dogfood 누적 후 noise/signal 비율 검토 및 trigger/guards 정교화 또는 정착 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
