### PR TITLE
fix(epistemic-cooperative): /verify 경고 2건 해소 + version bump

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights",
-  "version": "1.28.4",
+  "version": "1.28.5",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/introspect/SKILL.md
+++ b/epistemic-cooperative/skills/introspect/SKILL.md
@@ -161,7 +161,7 @@ prescriptive rules (what the user says to do, from Agent 1). Surface mismatches:
 - Patterns not captured by any rule
 - Rules that may be redundant or subsumable
 
-Present the analysis to the user. Use AskUserQuestion to validate key findings before
+Present the analysis to the user. call AskUserQuestion to validate key findings before
 proceeding. The user may refine, correct, or add context that changes the analysis.
 
 ---

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -35,6 +35,7 @@ const PLUGINS = [
   { dir: 'epistemic-cooperative', skill: 'compose' },
   { dir: 'epistemic-cooperative', skill: 'report' },
   { dir: 'epistemic-cooperative', skill: 'dashboard' },
+  { dir: 'epistemic-cooperative', skill: 'introspect' },
   { dir: 'epistemic-cooperative', skill: 'sophia' },
   { dir: 'epistemic-cooperative', skill: 'curses' },
   { dir: 'epistemic-cooperative', skill: 'write' },


### PR DESCRIPTION
## Summary

`/verify` static checks 경고 2건 해소:

- `epistemic-cooperative/skills/introspect/SKILL.md:164` **directive-verb** 경고: `"Use AskUserQuestion"` → `"call AskUserQuestion"` (editing-conventions.md의 `"call"` for tool references 규정 준수)
- `scripts/package.js` PLUGINS 배열에 `{ dir: 'epistemic-cooperative', skill: 'introspect' }` 추가 (dashboard 다음, sophia 앞 — 자기분석 계통)
- `epistemic-cooperative/.claude-plugin/plugin.json` 1.28.4 → 1.28.5 bump (plugin directory 변경 반영)

## Test plan

- [x] `/verify` 재실행: pass 76, fail 0, warn 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
