### PR TITLE
refactor(epistemic-cooperative): Epistemic Ink observer 자연어화 및 Horizon-Coverage 철회

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights",
-  "version": "1.28.5",
+  "version": "1.29.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -89,7 +89,7 @@ These notes belong in the conversation, not in the codebase. Keep them tied to t
 
 ### Basis Marker
 
-`Basis:` points to the specific evidence behind an AI reading that a reader would not automatically reach from the context alone — the trace for the AI's non-obvious interpretive step. Use it across protocols at the session level, not as a per-protocol TOOL GROUNDING entry. Render the label in the user's language when emitting (for example, `근거:` in Korean).
+`Basis:` points to the specific evidence behind an AI reading that a reader would not automatically reach from the context alone — the trace for the AI's non-obvious interpretive step. Use it across protocols at the session level, not as a per-protocol TOOL GROUNDING entry. Render the label in the user's language when emitting.
 
 - Inside `★ Epistemic`: when the interpretive step itself is worth showing
 - Inline in prose: `(Basis: [specific evidence])` for lightweight citation

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -79,78 +79,52 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 
 ## Epistemic Observations
 
-In order to surface the epistemic structure of the current work, provide brief observations about reasoning patterns, structural dynamics, or cross-protocol connections:
+To make the reasoning structure of the current work visible, add a short note about how the reasoning is moving — the shapes it is taking, the patterns showing up, or the connections across different protocols:
 
 `★ Epistemic ────────────────────────────────`
-[Protocol-specific structural observations]
+[A short observation about how reasoning is moving in this protocol — render in the user's language]
 `────────────────────────────────────────────`
 
-These observations should be included in the conversation, not in the codebase. You should generally focus on observations that are specific to the current epistemic process rather than general principles.
+These notes belong in the conversation, not in the codebase. Keep them tied to the specific epistemic process at hand rather than restating general principles.
 
 ### Basis Marker
 
-`Basis:` marks the AI's non-deducible interpretive contribution — the specific evidence grounding an inference that transcends what is mechanically derivable from context. It operates at the session level, across protocols, rather than as a per-protocol TOOL GROUNDING entry.
+`Basis:` points to the specific evidence behind an AI reading that a reader would not automatically reach from the context alone — the trace for the AI's non-obvious interpretive step. Use it across protocols at the session level, not as a per-protocol TOOL GROUNDING entry. Render the label in the user's language when emitting (for example, `근거:` in Korean).
 
-- Inside `★ Epistemic`: when the interpretive structure itself is noteworthy
+- Inside `★ Epistemic`: when the interpretive step itself is worth showing
 - Inline in prose: `(Basis: [specific evidence])` for lightweight citation
-- Omit when interpretation is mechanical or self-evident (deducibility threshold: would a reader arrive at the same interpretation from the cited context alone?)
+- Omit when the reading is mechanical or self-evident (threshold: would a reader arrive at the same reading from the cited context alone?)
 
-Basis cites evidence grounding the AI's non-obvious inference: user utterance whose interpretation transcends literal meaning, gate option whose downstream implication was uniquely inferred, or prior context entry whose cross-reference produces new insight. Pure relay citations (repeating user-explicit content, mechanical gate classifications) do not warrant `Basis:`.
+Basis points to evidence for an inference that is not obvious: a user utterance whose meaning goes past its literal wording, a gate option whose downstream implication the AI uniquely inferred, or a prior context entry whose cross-reference produces a new reading. Plain relay citations (repeating what the user said explicitly, mechanical gate classifications) do not warrant `Basis:`.
 
-**Cadence**: per-interpretation when non-deducible augmentation exists, not per-iteration or per-phase. Self-regulating: no non-obvious interpretation → no `Basis:`.
+**When to emit**: per-interpretation when a non-obvious reading exists, not per-iteration or per-phase. Self-regulating: no non-obvious interpretation → no `Basis:`.
 
-**Adversarial guards** (A7):
-- `always-basis`: attaching `Basis:` to every statement → noise. Guard: fires only when interpretation is non-deducible.
+**Guards against common failure modes**:
+- `always-basis`: attaching `Basis:` to every statement → noise. Guard: fires only when the reading is not obvious from context.
 - `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission violates A2 Visibility.
-- `basis-as-paraphrase`: citing user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
+- `basis-as-paraphrase`: citing the user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
 
 ## Protocol Recommendations
 
 When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:
 
-↗ /protocol — evidence-grounded rationale
+↗ /protocol — [a short reason for the suggestion, grounded in observed evidence]
 
 # Protocol Nudge
 
-When observing conditions that match a protocol's deficit type, provide a single-line nudge. When an `★ Epistemic` observation surfaces a related deficit, place the nudge immediately after the closing backtick line. During active protocol execution, nudge for deficits distinct from the current protocol's deficit to enable cross-protocol synthesis.
+When the conditions in a protocol's deficit description show up in the current turn, add a single-line nudge. When an `★ Epistemic` observation surfaces a related deficit, place the nudge right after the closing backtick line. During an active protocol, nudge only for deficits distinct from the current protocol's deficit so the two perspectives work together.
 
-Protocol convergence moments — where transformation traces are first assembled as a whole — are high-signal observation points for cross-protocol needs.
+Protocol convergence moments — when transformation traces first come together as a whole — are high-signal places to notice what a different protocol might offer.
 
-Keep nudges non-intrusive and contextually warranted. Do not auto-activate protocols.
+Keep nudges light and clearly grounded in the context. Do not auto-activate protocols.
 
 ## Framing-Instability Observer
 
-During any active protocol, watch for morphism framing instability — signals that the user's working frame of the problem is shifting underfoot, yielding inconsistent inputs across turns. Typical indicators: the user redefines the subject mid-flow, the stated goal silently mutates between turns, or the same entity is addressed under incompatible categorizations within one session. When detected, emit a single-line observer using the `⇌` bidirectional marker (distinct from the `↗` protocol-nudge convention to signal framing oscillation rather than protocol recommendation):
+During any active protocol, watch for signs that the user's working frame of the problem is shifting from turn to turn, so that the inputs become inconsistent even though the topic looks the same. Typical signs: the user redefines the subject mid-flow, the stated goal quietly changes between turns, or the same entity is treated under incompatible categories within one session. When this happens, emit a single-line observer with the `⇌` marker (distinct from the `↗` protocol-nudge convention — `⇌` signals frame oscillation, not protocol recommendation). Render the label in the user's language:
 
-⇌ framing — [one-sentence observation of the instability, grounded in cited turn evidence]
+⇌ framing — [one sentence describing the shift, with the specific turns or utterances it is grounded in]
 
-Emit once per distinct instability pattern per session — subject redefinition, goal mutation, and incompatible categorization are distinct patterns, each warranting at most one emission per session. The observation is runtime-only — it does not alter protocol phase transitions, does not open a gate, and does not require user response. Its function is to make the drift visible so the user can choose to reframe in free response. Grounding condition: the instability must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. This observer is the realization of the Definitional-Observational Convergence principle — runtime AI observation lives in Output Style, not in any SKILL.md.
-
-## Horizon-Coverage Observer
-
-When the turn invokes subagent(s) via Agent tool or converges a multi-perspective protocol (/frame), emit a runtime observer surfacing which lenses operated and where the main agent's lens is positioned. The observer honors the main's epistemic limits by principle — the main never claims dimensions unseen by its own lens. Emit using the `◇` diamond marker immediately after primary response content and before any final gate block:
-
-◇ horizon ──────────────────────────────
-Lenses invoked: {main, <Agent-call list>, <selected /frame perspectives>}
-Main lens positionality: [Output Style X / rule Y / axiom Z emphasis]
-Covered (by invoked lenses): [D₁, D₂, ...]
-Main's additional candidates (main-lens-limited): [with basis, or "none identified"]
-──────────────────────────────────────────
-
-**Trigger conditions** (emit only when at least one holds):
-- C1: One or more Agent tool invocations in this turn
-- C2: /frame or other multi-perspective protocol converged in this turn
-
-The observer is runtime-only — it does not open a gate, does not alter protocol phase transitions, and does not require user response. Its function is to surface lens coverage and main's positionality for user judgment. This observer is a realization of the Definitional-Observational Convergence principle.
-
-**Scope boundary**: This observer addresses (a) runtime lens drift visibility and (b) lens field-of-view coverage across invoked lenses. Principle-basis transmission to lens-generation layers — ensuring subagents carry axiom-priority context from upstream decisions — lies outside this plugin's Audience Reach. Plugin marketplace users resolve that concern in their own environment (personal rules, personal skills, or their own plugin composition), not through this observer.
-
-**Adversarial guards** (A7):
-- `always-audit`: emitting every turn regardless of trigger → noise. Guard: at least one trigger condition must hold.
-- `lens-fabrication`: listing subagents not actually invoked in this turn → false grounding. Guard: reference only Agent tool calls made in this turn's trace.
-- `false-precision`: asserting the "Covered" set as exhaustive → false comprehensiveness. Guard: list only dimensions identified from invoked lenses' outputs; "Main's additional candidates" accepts "none identified" as a valid value.
-- `recursive-self-praise`: main's positionality description drifts into self-justification → A2 Visibility regression. Guard: one-line positionality only, presented in parallel with other lens descriptions.
-- `novel-absolute-claim`: main claiming dimensions beyond its own lens — dimensions no invoked lens captured. Guard: the field name "Main's additional candidates (main-lens-limited)" structurally precludes claims beyond main's lens; dimensions unseen by any lens are omitted by principle — the observer does not speak of what no lens saw.
+Emit once per distinct pattern per session — subject redefinition, goal mutation, and incompatible categorization each count as a separate pattern and each gets at most one emission per session. The observation is runtime-only — it opens no gate, changes no protocol phase, and expects no user response. Its job is to make the drift visible so the user can choose to reframe on their own. Grounding condition: the shift must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. This observer realizes the Definitional-Observational Convergence principle — runtime AI observation lives in Output Style, not in any SKILL.md.
 
 # Tone and Style
 


### PR DESCRIPTION
## 요약

- Epistemic Ink Output Style의 4개 observer(`★ Epistemic`, `Basis:`, `↗ /protocol`, `⇌ framing`) 정의 prose를 자연어화하고 emit 시 사용자 언어로 라벨/내용을 렌더하도록 지침을 명시했습니다.
- `Horizon-Coverage Observer` 섹션을 전부 철회했습니다. 트리거 scope 진단 결과 단일 Explore/debugger 같은 scope-bounded 위임까지 포함되어 noise 비율이 높았고, 사실상 Prothesis(/frame)에서만 의미 있는 형태로 수렴되어 있었습니다.
- 변경 부수효과로 `Adversarial guards (A7)` 라벨을 `Guards against common failure modes`로 교정했습니다(Audience Reach: 배포된 플러그인 end user는 이 레포의 axiom 번호 체계를 로드하지 않으므로 contributor-only 식별자 노출 제거).

## 자연어화 방향

- 학술 표현(`non-deducible interpretive contribution`, `morphism framing instability`, `protocol-specific structural observations`, `evidence-grounded rationale`) → 추론 흐름과 관찰 대상이 자연어로 드러나는 표현으로 풀어쓰기
- 5개 observer 모두 `Render labels and content in the user's language` 지침 명시 (Zero-Shot Instruction Preference 준수: 특정 언어 예시 anchor 회피)

## Horizon-Coverage 철회 근거

1. **Trigger scope mismatch**: 현재 C1(`Agent 도구 호출 1회 이상`)이 단일 Explore, debugger, statusline-setup 등 scope-bounded 위임까지 포함 — horizon block이 담을 coverage space가 사실상 없는 noise 케이스 다수
2. **Empirical evidence 부재**: C2의 `or other multi-perspective protocol` hedge는 `/frame` 외 명명된 사례 없음 (Deficit Empiricism N≥3 미달)
3. **원칙 무영향**: `architectural-principles.md`의 Definitional-Observational Convergence 원칙을 grounding한 N=4 case에 Horizon-Coverage Observer가 포함되지 않음 (Post-Convergence traversal, Integration+basis echo, ↗ nudge, Basis marker — 4개) → 이 observer는 원칙의 application이지 grounding이 아니므로 철회 시 원칙 자체는 보존됨
4. **History precedent**: 도입 직후 C3 trigger가 `always-audit anti-pattern`으로 진단되어 한 차례 축소된 history(`954bea5`) 존재 — C1에 같은 비판이 누적

### Actionable revision criterion trigger (`safeguards.md`)

`safeguards.md`의 Actionable revision criterion 3대 trigger 중 본 철회의 empirical basis:

- **Trigger (3) — compression precedent**: `954bea5`(Horizon 도입 직후 C3 제거)와 `26da87e`(PR #270 XC1-XC4 11-protocol adversarial scaffolding 압축, Opus 4.7 instruction-following premise) 두 선례 모두 `always-audit anti-pattern` / 과도한 scaffolding 진단을 부정 → 같은 줄기에서 C1 scope에 동형 적용
- **A2 visibility 회귀 검토**: Horizon-Coverage 부재 시 multi-lens 커버리지 가시화는 Prothesis(/frame)의 자체 convergence evidence(transformation trace per identified deficit) 단계에 합류 가능 — Output Style의 cross-cutting observer로서의 가치는 trigger scope 정확성에 의존했고, 정확한 좁은 scope로는 Prothesis-only로 수렴되어 별도 observer로 분리할 필요성 미충족

Out-of-lens variable drift 문제(원래 해결 대상)는 (a) Deficit Empiricism에 따른 N≥3 재누적 유예, 또는 (b) 추후 Prothesis SKILL.md convergence evidence 단계 흡수 옵션이 열려 있음.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → 76 checks pass / 0 fail / 0 warn
- `epistemic-cooperative/.claude-plugin/plugin.json` 1.28.5 → 1.29.0 (minor: 의미적 변화)
- `git diff --stat` 결과: `epistemic-ink.md` 18 insertions / 44 deletions, 162 → 136 lines

## Test plan

- [ ] /verify static checks pass 재확인 (CI)
- [ ] PR diff 시각 검토 (자연어화 표현 일관성)
- [ ] 4개 observer 정의 prose 가독성 확인
- [ ] Horizon-Coverage 잔여 참조 없음 확인 (`grep -r "Horizon-Coverage\|◇ horizon"` → 0건)
- [ ] plugin reinstall 후 emit 결과 dogfooding (turn 시 `★ 추론 관찰` / `근거:` / `⇌ 프레이밍 흔들림` 등 사용자 언어 렌더 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
