### PR TITLE
refactor(introspect): description 494 → 183 chars, user-invoked 명시

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /write-review for multi-stage editorial pipeline (write × recollect × inquire × gap × contextualize) with browser channel-loop for inline-comment feedback",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/introspect/SKILL.md
+++ b/epistemic-cooperative/skills/introspect/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: introspect
-description: >
-  Deep self-analysis pipeline: collect behavioral data from sessions/rules/usage,
-  analyze patterns across 5 dimensions, identify strengths and their structural costs,
-  ground findings philosophically via Analogia, and produce an HTML report.
-  Use when: "analyze my patterns", "what are my curses", "cognitive profile",
-  "self-analysis", "introspect", "how do I work with AI", "what should I improve",
-  "identity analysis", or any reflective question about working patterns and
-  AI collaboration style.
+description: "Deep self-analysis pipeline: collects session/rule/usage data, analyzes across 5 dimensions (strength-shadow + Analogia grounding), produces HTML report. User-invoked via /introspect."
 ---
 
 # Introspect


### PR DESCRIPTION
## 요약

`introspect` SKILL.md frontmatter description을 494자 → 183자로 축약하여 DESCRIPTION_OVERRIDES 엔트리 없이도 200-char limit 아래로 맞춥니다. `write-review` PR #277 (c245aa2)과 동일한 패턴의 후속 작업 (Task #22).

## 변경 내역

### `epistemic-cooperative/skills/introspect/SKILL.md`
- Folded scalar `description: >` (9줄, 494자) → 단일 줄 inline string (183자)
- Auto-trigger 키워드 목록 제거: "analyze my patterns", "what are my curses", "cognitive profile", "self-analysis", "introspect", "how do I work with AI", "what should I improve", "identity analysis"
- 핵심 파이프라인(5-dimension + strength-shadow + Analogia + HTML report) 유지
- `User-invoked via /introspect.` 명시

### `epistemic-cooperative/.claude-plugin/plugin.json`
- 1.31.2 → 1.32.0 (minor — 트리거 동작 변경)

## 기대 효과

- **per-session token cost 감소**: available_skills 목록 로드 시 description 축약으로 토큰 절감
- **자동 트리거 차단**: "cognitive profile 알려줘" 같은 범용 표현으로 의도하지 않은 invoke 방지 → 반드시 `/introspect` 명시 호출
- **DESCRIPTION_OVERRIDES 정합성**: scripts/package.js의 override 없이도 200자 제한 준수

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` fail/warn 없음 확인 완료
- [x] `node scripts/package.js --dry-run` introspect 2 files / 5994 bytes / 1.32.0 패키지 무결성 확인 완료
- [ ] CI `claude-code-review` 파이프라인 통과
- [ ] CI `claude-epistemic-review` 파이프라인 통과
- [ ] CI `verify-runtime-contract` 파이프라인 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
