### PR TITLE
feat(epistemic-cooperative): /review-ensemble 마이그레이션 — cc-plugin → epistemic-protocols

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ epistemic-protocols/
 │   └── scripts/hypomnesis-write.mjs   # mjs harness + claude -p haiku extraction
 ├── epistemic-cooperative/             # Utility skills + agents
 │   ├── agents/                        # project-scanner, session-analyzer, coverage-scanner, dimension-profiler
-│   └── skills/                        # report, onboard, dashboard, introspect, catalog, compose, sophia, curses, write
+│   └── skills/                        # report, onboard, dashboard, introspect, catalog, compose, sophia, curses, write, artifact-review, review-ensemble
 └── src/                               # Landing page (independent sub-project; React + Vite + Tailwind; EN/KO SPA)
 ```
 
@@ -64,7 +64,7 @@ epistemic-protocols/
 | Epharmoge | `/contextualize` | ApplicationDecontextualized → ContextualizedExecution |
 | Anamnesis | `/recollect` | RecallAmbiguous → RecalledContext |
 
-**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/dashboard`, `/compose`, `/introspect`, `/sophia`, `/curses`, `/write`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
+**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/dashboard`, `/compose`, `/introspect`, `/sophia`, `/curses`, `/write`, `/artifact-review`, `/review-ensemble`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
 
 ## Axioms
 
@@ -176,6 +176,7 @@ node .claude/skills/verify/scripts/static-checks.js .
 - **Curses**: Phase 1 delegates to coverage-scanner then dimension-profiler subagents (serial chain). Main agent handles Phases 2-4 (analysis, recommendations, report).
 - **Write**: No delegation—main agent handles all phases. Composes /frame (Prothesis) for perspective analysis; the composed protocol's delegation rules apply when invoked.
 - **Artifact Review**: No delegation—main agent handles all pipeline phases. Composes /inquire × /gap × /contextualize; sub-protocol delegation rules apply when invoked. Channel-loop runs as a background Bun process (not Task delegation).
+- **Review Ensemble**: Main agent handles all phases. Phase 2 launches Codex CLI in background (Bash run_in_background) and invokes `prothesis:frame` foreground via Skill(); composed protocol's delegation rules apply when invoked. Fallback mode spawns two inline Agent subagents in parallel when `prothesis:frame` is unavailable.
 
 ## Conventions
 

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel",
-  "version": "1.33.1",
+  "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
+  "version": "1.34.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/review-ensemble/SKILL.md
+++ b/epistemic-cooperative/skills/review-ensemble/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: review-ensemble
+description: |
+  This skill should be used when the user asks to "ensemble review", "multi-model review", "cross-model review", "review-ensemble", "review from different angles", "thorough code review", "comprehensive review", or wants multiple independent reviewers to analyze changes in parallel. Also trigger when the user wants code reviewed by both Claude and another model, asks for "cross-model" or "multi-perspective" analysis of code changes, or says "review this PR from multiple viewpoints". Orchestrates /frame (Claude multi-perspective review with agent-aware mapping) + Codex (cross-model independent review), then aggregates into a unified verdict.
+skills:
+  - prothesis:frame
+---
+
+# Review Ensemble
+
+Invoke directly with `/review-ensemble` when the user wants cross-model code review by composing /frame (Claude multi-perspective) with Codex (independent model), then aggregating findings at the cross-model boundary.
+
+**Architecture**:
+```
+review-ensemble
+├── /frame Mode 2 (Claude: perspective selection + AgentMap? + investigation + Lens L)
+├── Codex CLI (cross-model: independent review, parallel)
+└── Cross-model aggregation (Lens L + Codex findings → unified verdict)
+```
+
+**Why this composition**: /frame owns Claude-side orchestration — it selects perspectives, maps them to specialized agents, and synthesizes findings into a Lens. Adding Codex provides an independent model family's view. When two independent model families converge on the same issue, that signal is stronger than any single model's confidence score.
+
+## Phase 1: Scope Detection
+
+1. If PR number provided as argument: `gh pr view {NUMBER} --json number,title,headRefName,changedFiles`
+2. If no argument: `gh pr view --json number,title,headRefName,changedFiles 2>/dev/null`
+3. PR exists: scope = PR diff (`gh pr diff {NUMBER}`)
+4. No PR: scope = working tree (`git diff HEAD`)
+5. No changes: ask the user what to review
+
+Record scope type, PR number, changed files list, and the **full diff content** (needed for Codex prompt in Phase 2).
+
+Also capture diff statistics for context:
+```bash
+gh pr diff {NUMBER} --stat   # or: git diff HEAD --stat
+```
+
+## Phase 2: Parallel Launch
+
+Launch Codex in background FIRST, then invoke /frame (interactive). This maximizes parallelism — Codex runs independently while /frame engages the user for perspective selection.
+
+### Step 1: Launch Codex Reviewers (background)
+
+Check `which codex 2>/dev/null`. If Codex CLI is not found, skip to Step 2 and note in Phase 5 output that this was a single-model review.
+
+Generate a unique suffix for temp files: `SUFFIX=$(openssl rand -hex 4)`
+
+Write review prompt to `/tmp/ensemble_codex_review_${SUFFIX}.txt`, embedding the actual diff so Codex knows exactly what changed:
+
+```
+Review the following code changes for correctness, security, and edge cases.
+
+Scope: {PR #{number} — {title} on branch {branch} | working tree changes}
+Diff statistics: {diff_stat_output}
+
+--- Begin Diff ---
+{full_diff_content}
+--- End Diff ---
+
+Focus: logic errors, security vulnerabilities, missing error handling, edge cases, API contract violations.
+
+Report each finding as:
+- [{severity}] {file}:{line_range} — {description}
+
+Severity: critical | high | medium | low | suggestion
+Report only high-confidence findings. Ground all claims in the actual diff — do not speculate about code you have not seen.
+End with: VERDICT: approve | needs-attention
+```
+
+Locate the codex-run.sh wrapper first, fall back to direct exec if unavailable.
+
+Run via `Bash(run_in_background: true, timeout: 300000)`:
+```bash
+CODEX_RUN=$(find ~/.claude/plugins -path "*/codex-plus/scripts/codex-run.sh" -print -quit 2>/dev/null)
+if [ -n "$CODEX_RUN" ]; then
+  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_review_${SUFFIX}.txt
+else
+  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
+fi
+```
+
+**Optional: codex-adversarial** — If the user requests adversarial review or the change is large/architectural, also launch an adversarial prompt in background with a separate suffix:
+
+```
+You are a skeptical reviewer. Challenge the implementation approach and design choices in the following diff.
+
+Scope: {PR #{number} — {title} | working tree changes}
+
+--- Begin Diff ---
+{full_diff_content}
+--- End Diff ---
+
+Question: Is this the right approach? What assumptions does it depend on? Where could this fail under real-world conditions? What second-order effects might occur?
+
+Focus: design flaws, assumption failures, approach alternatives, second-order effects on downstream consumers and deployment.
+
+Severity: critical | high | medium | low | suggestion
+Report only high-confidence findings. Ground all claims in the actual diff — do not speculate about code you have not seen.
+
+Report each finding as:
+- [{severity}] {file}:{line_range} — {description}
+
+End with: VERDICT: approve | needs-attention
+```
+
+Execute with `Bash(run_in_background: true, timeout: 300000)`:
+```bash
+CODEX_RUN=$(find ~/.claude/plugins -path "*/codex-plus/scripts/codex-run.sh" -print -quit 2>/dev/null)
+if [ -n "$CODEX_RUN" ]; then
+  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_review_${SUFFIX}.txt
+else
+  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
+fi
+```
+
+### Step 2: Invoke /frame Mode 2 (foreground, interactive)
+
+Check if the `prothesis:frame` skill is available. If not available (epistemic-protocols plugin not installed), fall back to the **manual review mode** described in the Fallback section below.
+
+If available:
+```
+Skill("prothesis:frame", args: "Assemble a code review team for these changes. Scope: {scope_description}. Changed files: {file_list}. [select_all_perspectives]")
+```
+
+/frame will:
+1. **Phase 0**: Mission Brief (elidable — explicit argument provided)
+2. **Phase 1**: Context gathering (codebase exploration)
+3. **Phase 2**: Perspective selection (elidable — select_all_perspectives: auto-select all proposed lenses)
+4. **Phase 3**: AgentMap? → map perspectives to available agents → team investigation
+5. **Phase 4**: Cross-dialogue + synthesis → **Lens L** (convergence, divergence, assessment)
+
+The Lens L output contains:
+- **Convergence**: Where Claude perspectives agree — robust findings
+- **Divergence**: Where perspectives disagree — different values or evidence
+- **Assessment**: Integrated analysis with attribution to contributing perspectives
+
+## Phase 3: Collection
+
+After /frame completes (Lens L in context), the background Codex task will send a completion notification automatically. When the notification arrives:
+
+1. Read the Codex output from the completed background task
+2. Parse Codex findings: `[severity] file:line — description` format + VERDICT
+3. Record both Lens L and Codex findings for aggregation
+
+If the Codex background task has not completed yet when /frame finishes, wait for the notification — do not poll or sleep.
+
+## Phase 4: Cross-Model Aggregation
+
+Combine /frame's Lens L (Claude multi-perspective synthesis) with Codex findings (independent model review).
+
+### Cross-Model Agreements
+
+Identify findings that appear in BOTH /frame's Lens L AND Codex output:
+- Same file + overlapping concern = cross-model agreement
+- Different wording about the same logical concern counts — match by semantic overlap, not exact text
+- Cross-model agreements have the **highest confidence** — two independent model families converged on the same issue
+
+### Unified Verdict
+
+- ANY `critical` finding from either source → `needs-attention`
+- Cross-model agreement on `high` severity → `needs-attention`
+- Both /frame assessment AND Codex verdict say `needs-attention` → `needs-attention`
+- Otherwise → `approve`
+
+**Single-source mode**: When only one source produced output (Codex unavailable or /frame failed), any `high` or `critical` finding from the available source → `needs-attention`. Cross-model agreement rules apply only when both sources are present.
+
+## Phase 5: Output
+
+```markdown
+## Review Ensemble Results
+
+### Verdict: {approve | needs-attention}
+Scope: {PR #N | working tree} | Changed files: {N}
+
+### Cross-Model Agreements ({N})
+{Issues found by BOTH /frame (Claude) and Codex — highest confidence}
+
+### /frame Lens (Claude Multi-Perspective)
+**Convergence**: {robust findings across Claude perspectives}
+**Divergence**: {where perspectives disagree}
+**Assessment**: {integrated analysis}
+Perspectives: {list of perspectives used}
+
+### Codex Review
+{Codex findings list}
+Verdict: {codex verdict}
+
+### Summary
+- /frame: {N} perspectives, Lens with {convergence/divergence summary}
+- Codex: {N} findings ({severity breakdown})
+- Cross-model agreements: {N}
+```
+
+## Fallback: Manual Review Mode
+
+When /frame (prothesis:frame skill) is not available, fall back to direct agent spawning for Claude-side review:
+
+1. Spawn two Agent subagents with inline review prompts (no external plugin dependency):
+   - **Code Review Agent**: `Agent(prompt: "Review the following code changes for bugs, logic errors, security vulnerabilities, and code quality. Scope: {scope}. Changed files: {file_list}. Diff: {diff}. Report each finding as: - [{severity}] {file}:{line_range} — {description}. End with: VERDICT: approve | needs-attention", run_in_background: true)`
+   - **Simplification Agent**: `Agent(prompt: "Review the following code changes for clarity, consistency, and maintainability. Scope: {scope}. Changed files: {file_list}. Diff: {diff}. Report each finding as: - [{severity}] {file}:{line_range} — {description}. End with: VERDICT: approve | needs-attention", run_in_background: true)`
+2. Launch both in parallel with Codex (all run_in_background: true)
+3. Collect results and aggregate as in Phase 4, treating each agent's findings as a separate reviewer instead of Lens L sections
+
+This mode loses /frame's perspective selection and Lens synthesis but preserves the cross-model value of Codex + Claude comparison.
+
+## Error Handling
+
+| Condition | Action |
+|-----------|--------|
+| /frame skill not available | Fall back to manual review mode (see Fallback section) |
+| /frame timeout or failure | Present partial results from Codex only |
+| Codex CLI not found | Run /frame only, note single-model limitation in output |
+| Codex timeout (>300s) | Present /frame Lens only, note Codex timeout |
+| No changes found | Report and stop at Phase 1 |
+| Both sources approve, no findings | "All reviewers approve — no issues found" |
+
+## Rules
+
+- /frame owns Claude-side review — do not duplicate with separate Claude Agent spawns (unless in fallback mode)
+- Codex runs independently — it does not see /frame's output and vice versa
+- Cross-model agreement is the primary confidence signal
+- Launch Codex BEFORE /frame to maximize parallelism
+- Always embed the actual diff in the Codex prompt — file names alone are insufficient for meaningful review
+- If Codex is unavailable, /frame alone still provides multi-perspective value via Lens L

--- a/epistemic-cooperative/skills/review-ensemble/SKILL.md
+++ b/epistemic-cooperative/skills/review-ensemble/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review-ensemble
-description: |
-  This skill should be used when the user asks to "ensemble review", "multi-model review", "cross-model review", "review-ensemble", "review from different angles", "thorough code review", "comprehensive review", or wants multiple independent reviewers to analyze changes in parallel. Also trigger when the user wants code reviewed by both Claude and another model, asks for "cross-model" or "multi-perspective" analysis of code changes, or says "review this PR from multiple viewpoints". Orchestrates /frame (Claude multi-perspective review with agent-aware mapping) + Codex (cross-model independent review), then aggregates into a unified verdict.
+description: Cross-model code review composition — orchestrates /frame (Claude multi-perspective) + Codex (independent model) in parallel, then aggregates into a unified verdict. User-invoked via /review-ensemble.
 skills:
   - prothesis:frame
 ---

--- a/epistemic-cooperative/skills/review-ensemble/SKILL.md
+++ b/epistemic-cooperative/skills/review-ensemble/SKILL.md
@@ -66,16 +66,9 @@ Report only high-confidence findings. Ground all claims in the actual diff — d
 End with: VERDICT: approve | needs-attention
 ```
 
-Locate the codex-run.sh wrapper first, fall back to direct exec if unavailable.
-
 Run via `Bash(run_in_background: true, timeout: 300000)`:
 ```bash
-CODEX_RUN=$(find ~/.claude/plugins -path "*/codex-plus/scripts/codex-run.sh" -print -quit 2>/dev/null)
-if [ -n "$CODEX_RUN" ]; then
-  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_review_${SUFFIX}.txt
-else
-  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
-fi
+codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
 ```
 
 **Optional: codex-adversarial** — If the user requests adversarial review or the change is large/architectural, also launch an adversarial prompt in background using a distinct temp file `/tmp/ensemble_codex_adversarial_${SUFFIX}.txt` (same `SUFFIX`, different filename) so the adversarial runner does not overwrite or re-read the standard review prompt:
@@ -104,12 +97,7 @@ End with: VERDICT: approve | needs-attention
 
 Execute with `Bash(run_in_background: true, timeout: 300000)`:
 ```bash
-CODEX_RUN=$(find ~/.claude/plugins -path "*/codex-plus/scripts/codex-run.sh" -print -quit 2>/dev/null)
-if [ -n "$CODEX_RUN" ]; then
-  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
-else
-  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
-fi
+codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
 ```
 
 ### Step 2: Invoke /frame Mode 2 (foreground, interactive)

--- a/epistemic-cooperative/skills/review-ensemble/SKILL.md
+++ b/epistemic-cooperative/skills/review-ensemble/SKILL.md
@@ -79,7 +79,7 @@ else
 fi
 ```
 
-**Optional: codex-adversarial** — If the user requests adversarial review or the change is large/architectural, also launch an adversarial prompt in background with a separate suffix:
+**Optional: codex-adversarial** — If the user requests adversarial review or the change is large/architectural, also launch an adversarial prompt in background using a distinct temp file `/tmp/ensemble_codex_adversarial_${SUFFIX}.txt` (same `SUFFIX`, different filename) so the adversarial runner does not overwrite or re-read the standard review prompt:
 
 ```
 You are a skeptical reviewer. Challenge the implementation approach and design choices in the following diff.
@@ -107,9 +107,9 @@ Execute with `Bash(run_in_background: true, timeout: 300000)`:
 ```bash
 CODEX_RUN=$(find ~/.claude/plugins -path "*/codex-plus/scripts/codex-run.sh" -print -quit 2>/dev/null)
 if [ -n "$CODEX_RUN" ]; then
-  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_review_${SUFFIX}.txt
+  "$CODEX_RUN" -s read-only -r high /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
 else
-  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
+  codex exec --skip-git-repo-check -m gpt-5.4 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
 fi
 ```
 
@@ -141,6 +141,10 @@ After /frame completes (Lens L in context), the background Codex task will send 
 1. Read the Codex output from the completed background task
 2. Parse Codex findings: `[severity] file:line — description` format + VERDICT
 3. Record both Lens L and Codex findings for aggregation
+4. Clean up the temp prompt files after reading (prevents `/tmp` accumulation across invocations):
+   ```bash
+   rm -f /tmp/ensemble_codex_review_${SUFFIX}.txt /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
+   ```
 
 If the Codex background task has not completed yet when /frame finishes, wait for the notification — do not poll or sleep.
 

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -40,6 +40,7 @@ const PLUGINS = [
   { dir: 'epistemic-cooperative', skill: 'curses' },
   { dir: 'epistemic-cooperative', skill: 'write' },
   { dir: 'epistemic-cooperative', skill: 'artifact-review' },
+  { dir: 'epistemic-cooperative', skill: 'review-ensemble' },
   { dir: 'anamnesis', skill: 'recollect' },
 ];
 

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -206,7 +206,7 @@ describe('transformSkillMd', () => {
 describe('runtime contract view', () => {
   it('builds a packaged runtime view for every skill', () => {
     const views = buildRuntimeContractViews();
-    assert.equal(views.length, 21);
+    assert.equal(views.length, 22);
     for (const view of views) {
       assert.equal(view.skillEntryCount, 1, `${view.plugin}:${view.skill} should have one Skill.md entry`);
       assert.ok(view.transformedSkillMd, `${view.plugin}:${view.skill} should expose transformed Skill.md`);
@@ -482,7 +482,7 @@ describe('generate-changelog.js CLI', () => {
 // ============================================================
 
 describe('package.js CLI', () => {
-  it('packages all 21 skills plus bundle in dry-run', () => {
+  it('packages all 22 skills plus bundle in dry-run', () => {
     const output = execFileSync(process.execPath, [path.join(__dirname, 'package.js'), '--dry-run'], {
       encoding: 'utf8',
     });
@@ -495,7 +495,7 @@ describe('package.js CLI', () => {
     // surfacing the cause — this filter catches that specific failure mode.
     const anamnesisWarnings = result.warnings.filter(w => /anamnesis|recollect/.test(w));
     assert.deepEqual(anamnesisWarnings, [], 'no anamnesis/recollect packaging warnings');
-    assert.equal(result.results.length, 22);
+    assert.equal(result.results.length, 23);
     assert.deepEqual(
       result.results.map(entry => entry.zip).sort(),
       [
@@ -519,6 +519,7 @@ describe('package.js CLI', () => {
         'onboard.zip',
         'recollect.zip',
         'report.zip',
+        'review-ensemble.zip',
         'sophia.zip',
         'write.zip',
       ].sort(),


### PR DESCRIPTION
## Summary

- cc-plugin/review-ensemble standalone 플러그인을 `epistemic-cooperative` 하위 스킬로 편입
- SKILL.md 본문 변경 없음; Layer 1 invocation cue(`/review-ensemble`) 한 줄만 추가하여 `artifact-self-containment` 정적 검사 통과
- `prothesis:frame` 합성 의존성은 동일 마켓플레이스에서 해소되어 fallback 모드는 방어적 dead-code로 유지

## Changes

| 파일 | 변경 |
|------|------|
| `epistemic-cooperative/skills/review-ensemble/SKILL.md` | 신규 (cc-plugin 본문 + Layer 1 cue) |
| `epistemic-cooperative/.claude-plugin/plugin.json` | `1.33.1 → 1.34.0`, description에 `/review-ensemble` 추가 |
| `scripts/package.js` | PLUGINS 배열에 `epistemic-cooperative:review-ensemble` 등록 |
| `CLAUDE.md` | Architecture skills 리스트 / Plugins Utility skills 줄 / Delegation Constraint 신규 항목 |

## Verify

- `node .claude/skills/verify/scripts/static-checks.js .` → fail 0, warn 0

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` 재실행 → fail/warn 0 유지 확인
- [x] `node scripts/package.js --dry-run` 실행 → review-ensemble ZIP 빌드 결과 확인
- [ ] CI claude-code-review 워크플로 통과 확인
- [ ] 머지 후 plugin reload 세션에서 `/review-ensemble` 슬래시 명령 호출 가능 확인
- [ ] cc-plugin 측 `git commit` (`git rm` 스테이지된 review-ensemble/) + push 별도 수행

🤖 Generated with [Claude Code](https://claude.com/claude-code)
