### PR TITLE
feat: Gate 옵션 implication 2층 authoring rule 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
-  "version": "1.34.4",
+  "version": "1.34.5",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation",
-  "version": "1.34.3",
+  "version": "1.34.4",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -70,6 +70,18 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 1. **Option** — implication
 ──────────────────────────────────────────
 
+The implication after each option — the text following the em-dash — is authored in two cognitive layers:
+
+1. A short summary that makes the option's axis value immediately recognizable at a glance
+2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution)
+
+Applied at stakes=High decision gates where option selection requires user judgment. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — pure paraphrase of the summary is cost without value.
+
+Rendered shape:
+
+1. **Option** — summary (axis value)
+   → rationale (one of: temporal, branch, side-effect)
+
 **Convergence** — emit dimension status between dividers, using ✓ for defined and ○ for pending:
 
 · Convergence ────────────────────────────

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -75,7 +75,7 @@ The implication after each option — the text following the em-dash — is auth
 1. A short summary that makes the option's axis value immediately recognizable at a glance
 2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution)
 
-Applied at stakes=High decision gates where option selection requires user judgment. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — pure paraphrase of the summary is cost without value.
+Applied at `always_gated` gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects its consequence.
 
 Rendered shape:
 


### PR DESCRIPTION
## Summary

- Epistemic Ink Output Style Gate 섹션에 option implication 2층 authoring rule 추가
- Recognition summary (axis value 즉각 인식) + rationale (temporal / branch / side-effect 중 1+) 구성
- Stakes=High 판단 gate에 적용; matrix · taxonomy · convergence trace는 summary만

## Background

세션 관찰과 hypomnesis 증거(N=7 cross-protocol: `/release`, `/anamnesis:recollect`, `/katalepsis`, `/clarify`, `/inquire`, code review, insights-synthesis)에서 "지나친 symbol화 → 역추적 deficit" 패턴 확인. 사용자의 `/btw` 습관은 이 결손에 대한 side-channel workaround 행동으로 해석됨.

Hermeneia + Syneidesis hybrid 감사를 통해 design/authoring 구분 — 구조 추가가 아닌 authoring discipline 층에서 해소(hybrid: compressed label + narrative future-scenario). 두 축이 orthogonal하므로 tradeoff 없이 병기 가능.

## Changes

- `epistemic-cooperative/styles/epistemic-ink.md` Gate 섹션에 implication authoring rule + placeholder shape 추가
- `epistemic-cooperative/.claude-plugin/plugin.json` 1.34.3 → 1.34.4

**Co-change scope (evidence-grounded narrow)**: SKILL.md 11개 모두 기존 "Context-Question Separation" 규칙 및 Hermeneia 옵션 템플릿이 2층 form을 자연 수용 → 편집 불필요. 다른 protocol plugin.json bump 불필요.

## Test plan

- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 정적 검사 통과 (현재: pass 78 / fail 0 / warn 0)
- [ ] 다음 stakes=High 판단 gate에서 2층 form이 자연스럽게 적용되는지 dogfooding (2-3 턴 관찰)
- [ ] `/btw` 호출 빈도 변화 관찰 — 6-10 gate 누적 후 효용 검증 (다음 세션)
- [ ] Fresh reader 관점에서 `epistemic-cooperative/styles/epistemic-ink.md` 열어 rule 이해 가능한지 검토
- [ ] 다른 protocol의 gate 렌더링에 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
