### PR TITLE
fix(anamnesis): hypomnesis-write SKIP_REASONS에서 "clear" 제거

### DIFF
--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -53,7 +53,10 @@ const ENTROPY_MAX_OUTPUT = 40;
 // Observed reason values in ~/.claude/logs/hooks.log (33 days, 1408 records):
 // other, prompt_input_exit, resume, clear. "compact" never observed — PreCompact
 // does not trigger SessionEnd; the two events are temporally independent.
-const SKIP_REASONS = new Set(["clear"]);
+// "clear" was previously skipped without documented rationale, but /clear fires
+// SessionEnd with intact payload; MIN_SESSION_BYTES + COOLDOWN_MS already cover
+// the noise/duplicate cases an exclusion would address.
+const SKIP_REASONS = new Set([]);
 const KNOWN_EVENTS = new Set(["SessionEnd", "PreCompact"]);
 
 // SessionEnd gate: cooldown against narrative.md mtime. Skip if last index


### PR DESCRIPTION
## Summary

- `SKIP_REASONS = Set(["clear"])`이 `79867b1`(mjs 재설계)에서 문서화된 근거 없이 도입되어 `/clear`로 종료되는 모든 세션이 hypomnesis INDEX에서 영구 결손됨
- `Set([])`으로 변경하고, rationale 주석을 보강해 향후 reviewer가 동일 의문을 다시 마주하지 않도록 함

## Motivation

`/clear`는 `SessionEnd`를 정상 payload(`session_id` + `transcript_path`, `reason="clear"`)로 fire하므로 SSOT JSONL은 보존됩니다. INDEX 결손은 *write 경로의 자기 차단*이지 lifecycle 결함이 아닙니다.

exclusion이 필요했을 가능성을 모두 점검:

| 가설 | 반증 |
|---|---|
| 사용자가 버린 세션 = 기억 가치 없음 | 실증 사례(f1db6667 probe skill 생성)가 직접 반박 |
| 짧은 clear 세션 노이즈 방지 | `MIN_SESSION_BYTES = 1024` 가드가 이미 처리 |
| PreCompact↔SessionEnd 중복 쓰기 | `COOLDOWN_MS = 300_000` 가드(line 59–63 주석에 설계 명시)가 이미 처리 |

→ exclusion이 다루려던 모든 케이스는 다른 가드가 커버하고 있었음. SKIP_REASONS는 redundant defensive default였습니다.

## Evidence

`~/.claude/logs/hooks.log` 발췌:

```
2026-04-25 07:12:53 SessionEnd  session_id=f1db6667-...  reason=clear   (probe skill 작업 세션)
2026-04-25 07:12:53 SessionStart session_id=3816da0f-... source=clear
```

→ SessionEnd가 정상 fire됐으나 hypomnesis 디렉토리 미생성. JSONL(`~/.claude/projects/-Users-choi-Downloads-github-private-epistemic-protocols/f1db6667-...jsonl`)은 보존됨. `/recollect` 시 INDEX salience track에서 reachable하지 않아 사용자가 직전 작업을 떠올리지 못한 사례.

## Diff shape

```diff
-const SKIP_REASONS = new Set(["clear"]);
+// "clear" was previously skipped without documented rationale, but /clear fires
+// SessionEnd with intact payload; MIN_SESSION_BYTES + COOLDOWN_MS already cover
+// the noise/duplicate cases an exclusion would address.
+const SKIP_REASONS = new Set([]);
```

constant + guard 자체는 유지 — 향후 정당화된 reason 추가 여지를 남기되, 빈 set일 때의 의미를 주석으로 고정.

## Risks

- **Duplicate write potential**: `/clear` 직전 `PreCompact`가 fire된 경우 cooldown(300s) 미경과 시 `SessionEnd` write가 skip됨 — 기존 idempotent 동작에 부합. 300s 경과 후 발생하면 두 번 write되지만 overwrite는 무해(같은 JSONL → 갱신된 INDEX).
- **Backfill 미포함**: 기존 `/clear`로 누락된 세션은 본 PR로 자동 복원되지 않음. 수동 invoke 또는 별도 backfill PR이 필요. orphan SessionEnd 세션(`5cc9439f` 같은 케이스, SessionEnd 자체 부재)은 이 PR scope 외 — 별도 트랙.

## Test plan

- [ ] `claude` 다음 세션에서 `/clear` 종료 후, `~/.claude/projects/{slug}/hypomnesis/{session-id}/`에 `narrative.md`/`clue.md` 생성 확인
- [ ] PreCompact 직후 `/clear` 시 cooldown 가드가 두 번째 write를 정상 차단하는지 확인
- [ ] 기존 `prompt_input_exit` 종료 경로에 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
