### PR TITLE
chore(anamnesis): version 0.4.15 patch bump

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"


### PR DESCRIPTION
## Summary

PR #289(`fix(anamnesis): SKIP_REASONS에서 "clear" 제거`) 머지 시점에 누락된 version bump를 별도 PR로 분리. plugin marketplace의 update 메커니즘이 `version` 필드 변화로 캐시 갱신을 감지하므로, 콘텐츠 변경만 반영된 상태에서는 marketplace cache가 stale로 머무름.

## Changes

```diff
-  "version": "0.4.14",
+  "version": "0.4.15",
```

## Context

- 직전 PR #289(`0c272a3` 머지): hypomnesis-write SKIP_REASONS에서 `"clear"` 제거 — runtime 동작 변경 포함
- 본 PR: 동 변경에 대응하는 patch bump — 머지 시 marketplace cache가 0.4.15로 갱신되며 새 SessionEnd 동작이 사용자 환경에 반영

## Test plan

- [ ] 머지 후 `claude` plugin update 사이클에서 marketplace cache가 0.4.15로 갱신되는지 확인
- [ ] 갱신 후 `/clear` 종료 시 hypomnesis INDEX 디렉토리(`narrative.md` 등)가 생성되는지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
