### PR TITLE
fix(anamnesis): hypomnesis 인덱스에 cwd 기록 — `claude --resume` 완전 복원

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -121,10 +121,7 @@ function parseSession(transcriptPath) {
   let outputTokensSum = 0;
   let lastTurnHadFreshInput = false;
   let sawAnyAssistantUsage = false;
-  // Latest cwd observed in JSONL — required for `claude --resume <session-id>`
-  // since Claude Code resolves the project slug from invocation cwd. Resumes
-  // can in principle change cwd; the final value reflects the directory the
-  // user must be in to resume cleanly.
+  // Latest cwd wins — Claude Code resolves the project slug from invocation cwd at resume time.
   let cwd = "";
 
   const protocolMap = {

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -121,6 +121,11 @@ function parseSession(transcriptPath) {
   let outputTokensSum = 0;
   let lastTurnHadFreshInput = false;
   let sawAnyAssistantUsage = false;
+  // Latest cwd observed in JSONL — required for `claude --resume <session-id>`
+  // since Claude Code resolves the project slug from invocation cwd. Resumes
+  // can in principle change cwd; the final value reflects the directory the
+  // user must be in to resume cleanly.
+  let cwd = "";
 
   const protocolMap = {
     "/frame": "frame", "/gap": "gap", "/clarify": "clarify",
@@ -138,7 +143,7 @@ function parseSession(transcriptPath) {
     logErr(`failed to read transcript ${transcriptPath}: ${e.message}`);
     return {
       userMsgs, allTexts, timestamps, protocols: [],
-      tokenEstimate: 0,
+      tokenEstimate: 0, cwd: "",
     };
   }
   let totalChars = 0;
@@ -151,6 +156,7 @@ function parseSession(transcriptPath) {
     const ts = entry.timestamp ?? "";
     if (ts) timestamps.push(ts);
     const etype = entry.type ?? "";
+    if (typeof entry.cwd === "string" && entry.cwd) cwd = entry.cwd;
 
     if (etype === "user" && userMsgs.length < MAX_USER_MSGS) {
       const text = textFromContent(entry.message?.content ?? "");
@@ -199,6 +205,7 @@ function parseSession(transcriptPath) {
     tokenEstimate,
     lastTurnHadFreshInput,
     sawAnyAssistantUsage,
+    cwd,
   };
 }
 
@@ -344,10 +351,11 @@ function validateNarrative(data) {
 
 // --- File Builders ---
 
-function buildClueMd(sessionId, date, startedAt, lastTurnAt, data, crossRefs) {
+function buildClueMd(sessionId, date, startedAt, lastTurnAt, cwd, data, crossRefs) {
   const lines = [
     "---",
     `session_id: ${sessionId}`,
+    `cwd: "${esc(cwd)}"`,
     `date: ${date}`,
     `started_at: ${startedAt}`,
     `last_turn_at: ${lastTurnAt}`,
@@ -395,10 +403,11 @@ function buildVectorMd(sessionId, date, data) {
   return lines.join("\n") + "\n";
 }
 
-function buildNarrativeMd(sessionId, date, startedAt, lastTurnAt, topics, protocols, data) {
+function buildNarrativeMd(sessionId, date, startedAt, lastTurnAt, cwd, topics, protocols, data) {
   return [
     "---",
     `session_id: ${sessionId}`,
+    `cwd: "${esc(cwd)}"`,
     `started_at: ${startedAt}`,
     `last_turn_at: ${lastTurnAt}`,
     `date: ${date}`,
@@ -771,7 +780,7 @@ function main() {
 
   const {
     userMsgs, allTexts, timestamps, protocols, tokenEstimate,
-    lastTurnHadFreshInput, sawAnyAssistantUsage,
+    lastTurnHadFreshInput, sawAnyAssistantUsage, cwd: sessionCwd,
   } = parseSession(transcriptPath);
   if (userMsgs.length === 0) return;
 
@@ -823,7 +832,7 @@ function main() {
     const clueRaw = callHaiku(buildCluePrompt(userMsgs));
     clueData = parseHaikuOutput(clueRaw);
     if (validateClue(clueData)) {
-      files["clue.md"] = buildClueMd(sessionId, date, startedAt, lastTurnAt, clueData, crossRefs);
+      files["clue.md"] = buildClueMd(sessionId, date, startedAt, lastTurnAt, sessionCwd, clueData, crossRefs);
     } else {
       logErr(`clue validation failed: invalid schema`);
     }
@@ -851,7 +860,7 @@ function main() {
     if (validateNarrative(narrativeData)) {
       const topics = clueData?.topics ?? [];
       files["narrative.md"] = buildNarrativeMd(
-        sessionId, date, startedAt, lastTurnAt,
+        sessionId, date, startedAt, lastTurnAt, sessionCwd,
         topics, protocols, narrativeData,
       );
     } else {

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -396,7 +396,8 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Origin**: What prompted the discussion — the question or situation that started it
 - **Direction**: How the discussion developed — what path was taken, what was explored
 - **Outcome**: What was decided, produced, or concluded
-- **Session**: Full session ID and originating `cwd` for `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`, `cwd: /home/user/project`). Narrative uses short reference; both fields together form the complete resumable handle — Claude Code resolves the project slug from invocation cwd, so the session ID alone is insufficient when the user is in a different directory.
+- **Session**: Full session ID for `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`). Narrative uses short reference; this field provides the resumable identifier.
+- **Resume**: Copy-paste-ready invocation pairing the originating cwd with the session ID — `cd <cwd> && claude --resume <session_id>`. Claude Code resolves the project slug from invocation cwd, so both components are required; emit only the literal command, no narrative wrapper. Omit this field only when the originating cwd is absent from the index (pre-0.4.18 entries) and surface the omission to the user.
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Progress**: `[attempt N/3, M candidates in scope]`
 
@@ -418,7 +419,7 @@ Design principles for Phase 2 presentation — narrative over summary, concrete 
 
 After user response:
 
-1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID and originating cwd for `--resume` verification — both are required to reconstruct the resumable handle), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), resumption hint if applicable. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
+1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), and a literal `cd <cwd> && claude --resume <session_id>` line built from the index entry's `cwd` and `session_id` frontmatter (the project slug derives from invocation cwd, so the command is the resumable handle). This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
 
 2. **Refine**: Candidate not recognized but recall direction acknowledged. Initiate Socratic probing for recall deepening:
 

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -396,7 +396,7 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Origin**: What prompted the discussion — the question or situation that started it
 - **Direction**: How the discussion developed — what path was taken, what was explored
 - **Outcome**: What was decided, produced, or concluded
-- **Session**: Full session ID for `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`). Narrative uses short reference; this field provides the resumable identifier.
+- **Session**: Full session ID and originating `cwd` for `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`, `cwd: /home/user/project`). Narrative uses short reference; both fields together form the complete resumable handle — Claude Code resolves the project slug from invocation cwd, so the session ID alone is insufficient when the user is in a different directory.
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Progress**: `[attempt N/3, M candidates in scope]`
 
@@ -418,7 +418,7 @@ Design principles for Phase 2 presentation — narrative over summary, concrete 
 
 After user response:
 
-1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), resumption hint if applicable. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
+1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID and originating cwd for `--resume` verification — both are required to reconstruct the resumable handle), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), resumption hint if applicable. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
 
 2. **Refine**: Candidate not recognized but recall direction acknowledged. Initiate Socratic probing for recall deepening:
 

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -56,6 +56,7 @@ MarkerProfile    = { coinage: Set(Token), actor: Set(Entity),
 Store            = SSOT ⊕ INDEX               -- see ── STORE TOPOLOGY ── block
 Scan             = (Store, Track, RecallTrace) → List(Candidate)
 Candidate        = { session_id: Optional(SessionId),
+                     cwd: Optional(String),
                      topic: String,
                      keywords: Set(String),
                      fingerprint: Prose,
@@ -124,6 +125,7 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 --   INDEX_substitute ↦ ~/.claude/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl    (substitute channel capture from SubagentStop)
 --   memory           ↦ ~/.claude/projects/{slug}/memory/                                 (user-curated insights)
 --   slug-partitioned: prevents cwd-scattered INDEX; cross-cwd /recollect reaches one canonical location
+-- Candidate source binding: `Candidate.session_id` ← INDEX entry frontmatter `session_id`; `Candidate.cwd` ← INDEX entry frontmatter `cwd` (Optional — absent for entries written before cwd capture was implemented)
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
 Phase 1 Scan_entropy  (observe)  → Read, Grep (literal match over SSOT ∪ INDEX)
@@ -397,7 +399,7 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Direction**: How the discussion developed — what path was taken, what was explored
 - **Outcome**: What was decided, produced, or concluded
 - **Session**: Full session ID for `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`). Narrative uses short reference; this field provides the resumable identifier.
-- **Resume**: Copy-paste-ready invocation pairing the originating cwd with the session ID — `cd <cwd> && claude --resume <session_id>`. Claude Code resolves the project slug from invocation cwd, so both components are required; emit only the literal command, no narrative wrapper. Omit this field only when the originating cwd is absent from the index (pre-0.4.18 entries) and surface the omission to the user.
+- **Resume**: Copy-paste-ready invocation pairing the originating cwd with the session ID — `cd <cwd> && claude --resume <session_id>`. Claude Code resolves the project slug from invocation cwd, so both components are required; emit only the literal command, no narrative wrapper. Omit this field only when `Candidate.cwd` is absent or empty, and surface the omission to the user.
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Progress**: `[attempt N/3, M candidates in scope]`
 
@@ -419,7 +421,7 @@ Design principles for Phase 2 presentation — narrative over summary, concrete 
 
 After user response:
 
-1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), and a literal `cd <cwd> && claude --resume <session_id>` line built from the index entry's `cwd` and `session_id` frontmatter (the project slug derives from invocation cwd, so the command is the resumable handle). This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
+1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), and — when `Candidate.cwd` is present and non-empty — a literal `cd <cwd> && claude --resume <session_id>` line built from `Candidate.cwd` and `Candidate.session_id` (the project slug derives from invocation cwd, so the command is the resumable handle); when `Candidate.cwd` is absent or empty, omit the line and note the omission in the prose. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition.
 
 2. **Refine**: Candidate not recognized but recall direction acknowledged. Initiate Socratic probing for recall deepening:
 


### PR DESCRIPTION
Claude Code 의 프로젝트 슬러그는 invocation cwd 에서 파생되므로
session_id 만으로는 `claude --resume` 이 다른 디렉터리에서 실패한다.
JSONL 항목 최상단의 `cwd` 필드를 parseSession 에서 캡처해
clue.md / narrative.md 프런트매터에 기록, /recollect 의
narrative presentation 과 ClueVector_prose 에서 session_id 와
함께 노출하여 재개 핸들이 완결되도록 한다.