### PR TITLE
feat(epistemic-cooperative): HFT Reference Shells에 Task Anchors 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize with browser inline-comment channel, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/crystallize/SKILL.md
+++ b/epistemic-cooperative/skills/crystallize/SKILL.md
@@ -106,17 +106,18 @@ Collect anchors to auxiliary substrates. Four subsections:
 1. **Session Anchors** — `previous_session_id` (current session ID), current `branch`, optional `pr_number` (from `gh pr view --json number 2>/dev/null`)
 2. **File Anchors** — file paths the work touched. Source: `git diff --name-only <predecessor-baseline>..HEAD` if predecessor frontmatter `git_head` is available, else `git diff --name-only main..HEAD`
 3. **External References** — URLs to external materials cited in the session (videos, articles, prior memos)
-4. **Task Anchors** — `~/.claude/tasks/<previous_session_id>/` (the per-session task substrate path). Mechanically derivable from `previous_session_id`; inscribe the path so cross-session anchor task discovery reaches it via `/inquire` or `/recollect`
+4. **Task Anchors** — `~/.claude/tasks/<previous_session_id>/` per stage (the per-session task substrate path), mechanically derivable from `previous_session_id`. Multi-stage HFT accumulates one path per inherited stage per the Reference Shells refresh policy (update in place, stale anchors retained). Inscribed for cross-session anchor task discovery via `/inquire` or `/recollect`
 
 No-data invariant: Reference Shell entries are paths or URLs only. Do not inline content from any anchored substrate. Inlining auto-memory, hypomnesis, or task substrate content into HFT body collapses topology separation.
 
-Default behavior: auto-collect when all three subsections are mechanically determinable (current session ID is known, `git diff` returns paths, URLs come from session context). Auto-collected anchors flow into Phase 5 final approval where they are reviewed alongside the rest of the HFT draft. Surface a Cognitive Partnership Move (Constitution) with options Accept · Modify(anchor, direction) · Reject · Free response only when an anchor source is ambiguous (e.g., multiple plausible PRs to cite, or the user has explicitly requested manual review). The default and the Constitution path together honor the elidable annotation in ELIDABLE CHECKPOINTS — Phase 5 Qc remains the binding gate.
+Default behavior: auto-collect when all four subsections are mechanically determinable (current session ID is known, `git diff` returns paths, URLs come from session context, task path derives from session ID). Auto-collected anchors flow into Phase 5 final approval where they are reviewed alongside the rest of the HFT draft. Surface a Cognitive Partnership Move (Constitution) with options Accept · Modify(anchor, direction) · Reject · Free response only when an anchor source is ambiguous (e.g., multiple plausible PRs to cite, or the user has explicitly requested manual review). The default and the Constitution path together honor the elidable annotation in ELIDABLE CHECKPOINTS — Phase 5 Qc remains the binding gate.
 
 ### Phase 5: Excluded Layer + Frontmatter Confirmation
 
 Default Excluded entries (always present unless rationale changes):
 - `auto-memory MEMORY.md body` — separate topology
 - `hypomnesis sub-index body` — separate topology
+- `per-session task substrate body` — separate topology
 - `tactical execution traces` — regenerable from Surface Text + Wirkungsgeschichte
 
 Frontmatter assembly:

--- a/epistemic-cooperative/skills/crystallize/SKILL.md
+++ b/epistemic-cooperative/skills/crystallize/SKILL.md
@@ -101,13 +101,14 @@ Present the delta via Cognitive Partnership Move (Constitution). User options: A
 
 ### Phase 4: Reference Shell Enumeration
 
-Collect anchors to auxiliary substrates. Three subsections:
+Collect anchors to auxiliary substrates. Four subsections:
 
 1. **Session Anchors** — `previous_session_id` (current session ID), current `branch`, optional `pr_number` (from `gh pr view --json number 2>/dev/null`)
 2. **File Anchors** — file paths the work touched. Source: `git diff --name-only <predecessor-baseline>..HEAD` if predecessor frontmatter `git_head` is available, else `git diff --name-only main..HEAD`
 3. **External References** — URLs to external materials cited in the session (videos, articles, prior memos)
+4. **Task Anchors** — `~/.claude/tasks/<previous_session_id>/` (the per-session task substrate path). Mechanically derivable from `previous_session_id`; inscribe the path so cross-session anchor task discovery reaches it via `/inquire` or `/recollect`
 
-No-data invariant: Reference Shell entries are paths or URLs only. Do not inline content from any anchored substrate. Inlining auto-memory or hypomnesis content into HFT body collapses topology separation.
+No-data invariant: Reference Shell entries are paths or URLs only. Do not inline content from any anchored substrate. Inlining auto-memory, hypomnesis, or task substrate content into HFT body collapses topology separation.
 
 Default behavior: auto-collect when all three subsections are mechanically determinable (current session ID is known, `git diff` returns paths, URLs come from session context). Auto-collected anchors flow into Phase 5 final approval where they are reviewed alongside the rest of the HFT draft. Surface a Cognitive Partnership Move (Constitution) with options Accept · Modify(anchor, direction) · Reject · Free response only when an anchor source is ambiguous (e.g., multiple plausible PRs to cite, or the user has explicitly requested manual review). The default and the Constitution path together honor the elidable annotation in ELIDABLE CHECKPOINTS — Phase 5 Qc remains the binding gate.
 
@@ -184,7 +185,8 @@ P_prev         = Optional(InscribedHFT)            -- predecessor file content +
 S              = SurfaceText { design_concept: String, ubiquitous_language: List<(term, meaning)>, sache: String }
 W              = Wirkungsgeschichte { trajectory: List<Entry>, rejected: List<Entry>, priors: List<Entry> }
 W_delta        ⊂ Wirkungsgeschichte                 -- proper subset: current-stage entries only (each list ⊂ corresponding W list)
-R              = ReferenceShells { session: List<KV>, files: List<Path>, urls: List<URL> }
+R              = ReferenceShells { session: List<KV>, files: List<Path>, urls: List<URL>, tasks: List<Path> }
+                 -- tasks: per-session task substrate paths (~/.claude/tasks/<session_id>/); mechanically derivable from session_id
 Excluded       = List<(substrate, rationale)>
 Frontmatter    = { hft_format_version, stage, generated_at, git_head, inherits_from, stage_classification, n1_dogfooding_caveat }
 HFT_draft      = { frontmatter, S, W_full, R, Excluded }

--- a/epistemic-cooperative/skills/crystallize/references/hft-format.md
+++ b/epistemic-cooperative/skills/crystallize/references/hft-format.md
@@ -61,7 +61,7 @@ An HFT file has exactly four layers, identified by H2 headings and ordered as be
 
 - `auto-memory MEMORY.md body` — separate topology; reachable via its own auto-load mechanism
 - `hypomnesis sub-index body` — separate topology; reachable via `/recollect` or `/inquire`
-- `~/.claude/tasks/<session_id>/ body` — separate topology; path inscribed as Task Anchor in Reference Shells, reachable via `/inquire` or `/recollect`
+- `per-session task substrate body` — separate topology; path inscribed as Task Anchor in Reference Shells, reachable via `/inquire` or `/recollect`
 - `tactical execution traces` — regenerable by fresh session from Surface Text + Wirkungsgeschichte
 
 Project-specific exclusions extend this list.

--- a/epistemic-cooperative/skills/crystallize/references/hft-format.md
+++ b/epistemic-cooperative/skills/crystallize/references/hft-format.md
@@ -49,8 +49,9 @@ An HFT file has exactly four layers, identified by H2 headings and ordered as be
 1. `### Session Anchors` — `previous_session_id`, `branch`, optional `pr_number`. One key per line.
 2. `### File Anchors` — file paths the work touched or depends on. One path per line.
 3. `### External References` — URLs to external materials (videos, articles, prior memos). One URL per line.
+4. `### Task Anchors` — paths to per-session task substrates (`~/.claude/tasks/<session_id>/`). One path per line. The path inscription enables cross-session anchor task discovery via `/inquire` or `/recollect` (TaskList scope covers the current session only).
 
-**No-data invariant**: Reference Shells must contain only identifiers and paths, never copied content. Inlining the referenced data into HFT body violates the topology-separation invariant (auto-memory and hypomnesis are operationally distinct substrates and must stay distinct).
+**No-data invariant**: Reference Shells must contain only identifiers and paths, never copied content. Inlining the referenced data into HFT body violates the topology-separation invariant (auto-memory, hypomnesis, and per-session task substrates are operationally distinct and must stay distinct).
 
 ### Layer 4: Excluded (Topology Declaration)
 
@@ -60,6 +61,7 @@ An HFT file has exactly four layers, identified by H2 headings and ordered as be
 
 - `auto-memory MEMORY.md body` — separate topology; reachable via its own auto-load mechanism
 - `hypomnesis sub-index body` — separate topology; reachable via `/recollect` or `/inquire`
+- `~/.claude/tasks/<session_id>/ body` — separate topology; path inscribed as Task Anchor in Reference Shells, reachable via `/inquire` or `/recollect`
 - `tactical execution traces` — regenerable by fresh session from Surface Text + Wirkungsgeschichte
 
 Project-specific exclusions extend this list.
@@ -103,7 +105,7 @@ A writer protocol inscribes layers in the following order, because each layer de
 2. Inscribe `### Design Concept` and `### Ubiquitous Language` — fresh per stage
 3. Inscribe `### Sache` — the live subject for the new stage
 4. Append new entries to `### Formation Trajectory`, `### Rejected Alternatives`, `### External Priors` — preserves prior content
-5. Update `### Session Anchors`, `### File Anchors`, `### External References`
+5. Update `### Session Anchors`, `### File Anchors`, `### External References`, `### Task Anchors`
 6. Refresh `### Excluded` only if topology choice changed
 7. Write frontmatter with current `git_head` and `generated_at`
 

--- a/epistemic-cooperative/skills/rehydrate/SKILL.md
+++ b/epistemic-cooperative/skills/rehydrate/SKILL.md
@@ -153,7 +153,7 @@ Rehydration Convergence Trace
 - Generated: <date>, baseline git_head: <SHA>, drift: <none / N commits ahead>
 - Surface Text: 1-pass read; Sache = "<restated>"
 - Wirkungsgeschichte: <N trajectory entries, N rejected alternatives, N external priors> recognized
-- Reference Shells: <N session, N file, N external> available (not auto-loaded)
+- Reference Shells: <N session, N file, N external, N task> available (not auto-loaded)
 - Anchor tasks: <N pending, N in-progress, N completed>
 - Resumption: <chosen path from Phase 5>
 - Stage 1 caveat: this HFT is Stage 1 conjecture; format may evolve.

--- a/epistemic-cooperative/skills/rehydrate/SKILL.md
+++ b/epistemic-cooperative/skills/rehydrate/SKILL.md
@@ -119,13 +119,14 @@ Reference Shells (available; not auto-loaded):
 - Session Anchors: previous_session_id=<id>, branch=<name>, pr_number=<N>
 - File Anchors: <N paths>
 - External References: <N URLs>
+- Task Anchors: <N session task paths> (e.g., ~/.claude/tasks/<previous_session_id>/)
 ```
 
-This separation enforces topology distinction: auto-memory and hypomnesis remain operationally distinct; the user explicitly invokes /inquire or /recollect when those substrates are needed.
+This separation enforces topology distinction: auto-memory, hypomnesis, and per-session task substrates remain operationally distinct; the user explicitly invokes /inquire or /recollect when those substrates are needed.
 
 ### Phase 5: Anchor Task Identification
 
-Filter `TaskList` for tasks with `metadata.source == "crystallize-hft"` and `metadata.stage == <stage_id from frontmatter>`. These are the anchor tasks emitted by the originating `/crystallize` invocation.
+Filter `TaskList` for tasks with `metadata.source == "crystallize-hft"` and `metadata.stage == <stage_id from frontmatter>`. These are the anchor tasks emitted by the originating `/crystallize` invocation in the *current* session scope. Cross-session anchor tasks (originating session differs from current session) live under the Task Anchors path surfaced in Phase 4 — the user reaches them via `/inquire` or `/recollect` against `~/.claude/tasks/<previous_session_id>/`.
 
 Present the anchor task set:
 
@@ -204,7 +205,8 @@ HFT_path       = Path
 Frontmatter    = { hft_format_version, stage, generated_at, git_head, inherits_from, stage_classification, n1_dogfooding_caveat }
 SurfaceText    = { design_concept: String, ubiquitous_language: List<(term, meaning)>, sache: String }
 Wirkungsgeschichte = { trajectory: List<Entry>, rejected: List<Entry>, priors: List<Entry> }
-ReferenceShells = { session: List<KV>, files: List<Path>, urls: List<URL> }
+ReferenceShells = { session: List<KV>, files: List<Path>, urls: List<URL>, tasks: List<Path> }
+                 -- tasks: per-session task substrate paths (~/.claude/tasks/<session_id>/); surfaced as anchor, not auto-fetched
 T              = AnchorTaskSet
                  = { t : Task | t.metadata.source = "crystallize-hft" ∧ t.metadata.stage = stage_id }
                  -- predicate filters TaskList; stage_id sourced from frontmatter


### PR DESCRIPTION
## Summary

- precedent session `00ec221a-...`에서 `/inquire`로 발견된 substrate cross-reference gap을 **Frame 1 (Topology-first, minimal posture)**로 보완. `/probe → /inquire → /goal` chain을 거쳐 수렴.
- `~/.claude/tasks/<session_id>/`를 HFT Reference Shells layer의 **4번째 canonical subsection** (`### Task Anchors`)으로 inscribe. `crystallize` Phase 4 enumeration 동기화 + `rehydrate` Phase 5에 cross-session scope clarification 추가. **Algorithm 변경 없음** — path 명시 + `/inquire`/`/recollect` runtime delegation으로 substrate-coupling 회피.
- `/simplify zero shot and avoid white bear problem` 적용: hft-format.md trailing White Bear clause 제거 + Layer 3 out-of-place empty-section block 제거 + rehydrate Phase 5 redundant negation 정리.

## Changes

| File | Change |
|---|---|
| `epistemic-cooperative/skills/crystallize/references/hft-format.md` | Layer 3에 `### Task Anchors` 4번째 canonical subsection + Layer 4 Excluded entry + Inscription Order #5 sync |
| `epistemic-cooperative/skills/crystallize/SKILL.md` | Phase 4 enumeration 4번째 항목 + TYPES `R` 확장 (`tasks: List<Path>`) |
| `epistemic-cooperative/skills/rehydrate/SKILL.md` | Phase 4 anchor surface + Phase 5 cross-session scope clarification + TYPES `ReferenceShells` 확장 |
| `epistemic-cooperative/.claude-plugin/plugin.json` | 2.1.1 → 2.2.0 (minor: feature addition) |

## Out-of-scope (deferred)

**U3 metadata.source mismatch**: `~/.claude/tasks/`의 crystallize-emitted task 중 `"source": "crystallize"` 69건 vs `"source": "crystallize-hft"` 8건. 현재 `rehydrate` Phase 5 strict-match filter는 anchor task의 약 89%를 miss 중 — 별도 PR/turn에서 canonicalization 결정 (`"crystallize"` 채택 / `"crystallize-hft"` 채택 + 마이그레이션 / disjoint match).

## Test plan

- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 실행 — 0 fail / 0 warn 확인
- [ ] `node --test scripts/package.test.js` 실행 — 48 tests pass 확인
- [ ] CI `claude-epistemic-review` workflow pass 확인
- [ ] 다음 세션에서 `/crystallize` 호출 시 Phase 4가 Task Anchors subsection을 자동 enumerate하는지 dogfood 확인
- [ ] `/rehydrate` 호출 시 Phase 4 surface에 `Task Anchors:` 라인이 포함되고 Phase 5가 current-session vs cross-session scope를 분리해 안내하는지 확인
- [ ] PR 머지 후 feature branch (`feat/hft-tasks-anchor`) cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
