### PR TITLE
fix(anamnesis): hypomnesis store chmod 0o755 — ripgrep traversal 보장

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -702,6 +702,7 @@ function writeStore(targetDir, files) {
   fs.mkdirSync(parent, { recursive: true });
 
   if (fs.existsSync(targetDir)) {
+    fs.chmodSync(targetDir, 0o755);
     for (const [name, content] of Object.entries(files)) {
       const dest = path.join(targetDir, name);
       try {
@@ -715,12 +716,17 @@ function writeStore(targetDir, files) {
       }
     }
   } else {
+    // mkdtempSync defaults to 0o700, which makes ripgrep traversal silently
+    // empty the INDEX — /recollect then falls back to SSOT-only via
+    // degraded_scan. Chmod to 0o755 after rename so the INDEX stays
+    // readable as a sibling of the slug-level JSONL.
     const tmp = fs.mkdtempSync(path.join(parent, ".hyp-"));
     try {
       for (const [name, content] of Object.entries(files)) {
         fs.writeFileSync(path.join(tmp, name), content, "utf8");
       }
       fs.renameSync(tmp, targetDir);
+      fs.chmodSync(targetDir, 0o755);
     } catch (e) {
       fs.rmSync(tmp, { recursive: true, force: true });
       throw e;


### PR DESCRIPTION
## Summary
- `mkdtempSync` 기본 모드(`0o700`) 때문에 `~/.claude/projects/{slug}/hypomnesis/{session-id}/` INDEX 디렉토리가 700으로 굳어져 ripgrep 회수가 침묵으로 비어보이고, `/recollect`가 `degraded_scan` 분기로 SSOT JSONL 직접 스캔에 우회되던 문제 수정 (`anamnesis/skills/recollect/SKILL.md:197`)
- `writeStore` 두 분기(신규 생성 / 기존 디렉토리 재작성) 모두 `fs.chmodSync(targetDir, 0o755)` 추가, 의도 주석 1줄
- `anamnesis` plugin 0.4.21 → 0.4.22

## Background
세션 JSONL(SSOT)은 Claude Code가 의도적으로 `0o600`으로 보호 — INDEX는 그 sibling으로서 동등한 회수 가시성을 가져야 함. `mkdtempSync` 보안 기본값과 ripgrep 인덱스 가시성 의도가 권한 모델에서 충돌했고, `degraded_scan`은 fallback이지 default 경로가 아니어야 함.

기존 700 디렉토리 171개는 로컬에서 `find ~/.claude/projects/*/hypomnesis -type d -perm 700 -exec chmod 755 {} +` 로 backfill 완료 — 이 PR은 코드 회귀만 다룸.

## Test plan
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 통과 확인
- [ ] CI workflow 통과
- [ ] 새 세션 종료 후 생성된 `~/.claude/projects/*/hypomnesis/{session-id}/` 권한이 755인지 확인
- [ ] `/recollect` 실행 시 INDEX 가속 경로(MarkerProfile/Coinage)가 정상 동작하고 `degraded_scan`이 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)