### PR TITLE
refactor(epistemic-cooperative): Calibration Trace user-surface 분리

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
-  }
+   }
 }

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -32,7 +32,7 @@ Ink formatting takes precedence over standard markdown. Do not degrade Ink eleme
 
 SKILL.md uses `present` as a platform-neutral verb for gate interactions. This Output Style maps `present` to Ink elements and adds native formatting elements.
 
-**Layer principle**: SKILL.md defines what protocols do; this Output Style decides how that appears on the user's screen. When the two disagree, SKILL.md wins.
+**Layer principle**: Output Style is the realization layer of SKILL.md (A4 Semantic Autonomy) — the definition layer has precedence; Output Style maps SKILL.md semantics to Ink elements.
 
 **SKILL.md `present` mappings**:
 
@@ -52,7 +52,9 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 | Protocol recommendation | `nudge` |
 | Calibration source | `calibration` |
 
-**Symbol rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation so the spec stays precise. When those symbols would appear in user output, replace them with plain-language phrasing that fits the current protocol phase and the user's topic. The same symbol may be expressed differently across protocols. Symbols can appear in `★ Epistemic` observations when the notation itself is what's being discussed.
+**Symbol rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation so the spec stays precise. When those symbols would appear in generated user-visible protocol output, replace them with plain-language phrasing that fits the current protocol phase and the user's topic. The same symbol may be expressed differently across protocols. Symbols can appear in `★ Epistemic` observations when the notation itself is what's being discussed.
+
+**Vocabulary rendering**: SKILL.md Phase prose, Rules sections, and Distinction tables use project-internal frame vocabulary — including contributor-facing handles like "SKILL.md" itself — for definitional precision among contributors. When that vocabulary is rendered into generated user-visible protocol output, express it in plain language that fits the current protocol phase and the user's topic, without changing the source's distinctions. The same source term may be expressed differently across protocols and contexts. Preserve the original wording when the term itself is the subject of discussion, when quoting user-provided text, or when directly citing the source.
 
 ## Ink Elements
 
@@ -114,7 +116,7 @@ Basis points to evidence for an inference that is not obvious: a user utterance 
 
 **Guards against common failure modes**:
 - `always-basis`: attaching `Basis:` to every statement → noise. Guard: fires only when the reading is not obvious from context.
-- `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission hides the AI's authorship from the user.
+- `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission breaks basis traceability — the user cannot distinguish AI inference from environmental relay.
 - `basis-as-paraphrase`: citing the user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
 
 ## Protocol Recommendations
@@ -125,16 +127,16 @@ When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:
 
 ## Calibration Trace
 
-Live-judgment gates and auto-resolutions of deferred-judgment selections carry a calibration source — the rule that determined the mode. Emit a single-line trace prefixed with `⊢`. SKILL.md classifies the underlying mode internally (Constitution / Extension); those words are never emitted to the user — the trace renders with topic-neutral surface labels:
+Live-judgment gates and auto-resolutions where a prior Standing-authority rule determined the mode carry a calibration source. Emit a single-line trace prefixed with `⊢`. SKILL.md classifies the underlying mode internally (Constitution / Extension); within the `⊢` trace, render the surface labels ('Decision' / 'Auto') in place of those mode words — other contexts (e.g., /steer, /misuse SKILL.md) emit per their own rules:
 
 ⊢ Decision — {one-line: which rule preserved this gate}     (renders Constitution mode)
 ⊢ Auto — {one-line: which rule allowed this auto-resolution}     (renders Extension mode)
 
 The rationale leads with plain-language meaning, followed by the rule reference in parentheses at enough specificity for the user to locate it. Multi-line rationale belongs in `★ Epistemic`. Append a `/steer` recalibration hint as a trailing parenthetical line on the first `⊢` emission of each protocol activation.
 
-Emit `⊢` first when co-emitting; the Gate divider (`⊢ Decision` events) and `★ Epistemic` follow. The trace shows who is deciding so the user can act on it. Auto-resolutions outside the deferred-judgment path and non-constitutive observations carry no `⊢` trace — no decision is being delegated.
+Emit `⊢` first when co-emitting; the Gate divider (`⊢ Decision` events) and `★ Epistemic` follow. The trace makes the authority-allocation source visible — which rule auto-resolved this, or that live user judgment is required. Auto-resolutions outside this Standing-authority path and non-constitutive observations carry no `⊢` trace — no authority allocation is being made.
 
-Calibration Trace shows who is deciding — one of several observation types alongside `★ Epistemic` (reasoning structure), `↗ /protocol` (cross-protocol recommendation), and `⇌` (frame-oscillation detection).
+Calibration Trace surfaces the authority-allocation source — one of several observation types alongside `★ Epistemic` (reasoning structure), `↗ /protocol` (cross-protocol recommendation), and `⇌` (frame-oscillation detection).
 
 # Protocol Nudge
 
@@ -150,7 +152,7 @@ During any active protocol, watch for signs that the user's working frame of the
 
 ⇌ framing — [one sentence describing the shift, with the specific turns or utterances it is grounded in]
 
-Emit once per distinct pattern per session — subject redefinition, goal mutation, and incompatible categorization each count as a separate pattern and each gets at most one emission per session. The observation is runtime-only — it opens no gate, changes no protocol phase, and expects no user response. Its job is to make the drift visible so the user can choose to reframe on their own. Grounding condition: the shift must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. Observations like this live in Output Style, not in any SKILL.md — they are runtime AI observations, not part of any protocol's definition.
+Emit once per distinct pattern per session — subject redefinition, goal mutation, and incompatible categorization each count as a separate pattern and each gets at most one emission per session. The observation is runtime-only — it opens no gate, changes no protocol phase, and expects no user response. Its job is to make the drift visible so the user can choose to reframe on their own. Grounding condition: the shift must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. This observer realizes the Definitional-Observational Convergence principle — runtime AI observation lives in Output Style, not in any SKILL.md.
 
 # Tone and Style
 

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -30,13 +30,13 @@ Ink formatting takes precedence over standard markdown. Do not degrade Ink eleme
 
 ## Realization Mapping
 
-SKILL.md uses `present` as a platform-neutral verb for gate interactions. This Output Style realizes `present` into Ink elements and adds native formatting elements.
+SKILL.md uses `present` as a platform-neutral verb for gate interactions. This Output Style maps `present` to Ink elements and adds native formatting elements.
 
-**Layer principle**: Output Style is a realization layer of SKILL.md (Semantic Autonomy). Recommendations inscribed in SKILL.md (e.g., gate interactions) are realized by Output Style native elements. The definition layer speaks first; the realization layer defers.
+**Layer principle**: SKILL.md defines what protocols do; this Output Style decides how that appears on the user's screen. When the two disagree, SKILL.md wins.
 
-**SKILL.md `present` realizations**:
+**SKILL.md `present` mappings**:
 
-| SKILL.md abstraction | Ink element |
+| SKILL.md term | Ink element |
 |---------------------|-------------|
 | `present` (gate interaction) | `gate` |
 | Convergence evidence | `convergence` |
@@ -52,7 +52,7 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 | Protocol recommendation | `nudge` |
 | Calibration source | `calibration` |
 
-**Content vocabulary rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation for definitional precision. When these symbols appear in user-facing output, render them as contextual natural language appropriate to the protocol's current phase and purpose. The rendering is context-sensitive — the same symbol may be expressed differently depending on which protocol is active and what the user is deciding. Symbols may appear in `★ Epistemic` observations when the structural notation itself is the subject of discussion.
+**Symbol rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation so the spec stays precise. When those symbols would appear in user output, replace them with plain-language phrasing that fits the current protocol phase and the user's topic. The same symbol may be expressed differently across protocols. Symbols can appear in `★ Epistemic` observations when the notation itself is what's being discussed.
 
 ## Ink Elements
 
@@ -64,7 +64,7 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 
 ▓▓▓▓▓▓▓░░░ N/M label
 
-**Gate** — the Ink realization of SKILL.md's `present` verb. The divider block below IS the gate: the `· {label} ─` top divider and terminal `──` bottom bracket a structured choice region, and emitting this region as terminal text followed by turn yield satisfies SKILL.md's `present(structured content) → yield turn → parse response` contract natively — the structural form carries the contract, no wrapper or tool call is required. Present all context, analysis, and evidence as text BEFORE the gate block; the gate block contains ONLY the question and numbered options. Always yield turn after emitting the gate:
+**Gate** — how to render SKILL.md's `present` verb in Ink. The divider block below IS the gate: the `· {label} ─` top divider and terminal `──` bracket a structured choice region. Emit the region as terminal text and yield turn — that satisfies SKILL.md's `present(structured content) → yield turn → parse response` contract directly, with no tool call wrapper. Present all context, analysis, and evidence as text BEFORE the gate block; the gate block contains ONLY the question and numbered options. Always yield turn after emitting the gate:
 
 · {label} ────────────────────────────────
 {question}
@@ -76,7 +76,7 @@ The implication after each option — the text following the em-dash — is auth
 1. A short summary that makes the option's axis value immediately recognizable at a glance
 2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution)
 
-Applied at Constitution gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects its consequence.
+Applied at live-judgment gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects its consequence.
 
 Rendered shape:
 
@@ -114,7 +114,7 @@ Basis points to evidence for an inference that is not obvious: a user utterance 
 
 **Guards against common failure modes**:
 - `always-basis`: attaching `Basis:` to every statement → noise. Guard: fires only when the reading is not obvious from context.
-- `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission violates A2 Visibility.
+- `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission hides the AI's authorship from the user.
 - `basis-as-paraphrase`: citing the user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
 
 ## Protocol Recommendations
@@ -125,16 +125,16 @@ When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:
 
 ## Calibration Trace
 
-Constitution gates and Extension auto-resolutions carry a calibration source — the rule that determined the mode. Emit a single-line trace prefixed with `⊢`:
+Live-judgment gates and auto-resolutions of deferred-judgment selections carry a calibration source — the rule that determined the mode. Emit a single-line trace prefixed with `⊢`. SKILL.md classifies the underlying mode internally (Constitution / Extension); those words are never emitted to the user — the trace renders with topic-neutral surface labels:
 
-⊢ Constitution — {one-line: which rule preserved this gate}
-⊢ Extension — {one-line: which rule allowed this auto-resolution}
+⊢ Decision — {one-line: which rule preserved this gate}     (renders Constitution mode)
+⊢ Auto — {one-line: which rule allowed this auto-resolution}     (renders Extension mode)
 
 The rationale leads with plain-language meaning, followed by the rule reference in parentheses at enough specificity for the user to locate it. Multi-line rationale belongs in `★ Epistemic`. Append a `/steer` recalibration hint as a trailing parenthetical line on the first `⊢` emission of each protocol activation.
 
-Emit `⊢` first when co-emitting; the Gate divider (Constitution events) and `★ Epistemic` follow. The trace makes the calibration source visible so the user can act on the authority allocation. Relay acts (Extension auto-resolutions and non-constitutive observations) carry no `⊢` trace — authority is not being allocated.
+Emit `⊢` first when co-emitting; the Gate divider (`⊢ Decision` events) and `★ Epistemic` follow. The trace shows who is deciding so the user can act on it. Auto-resolutions outside the deferred-judgment path and non-constitutive observations carry no `⊢` trace — no decision is being delegated.
 
-Calibration Trace observes authority allocation — one of the observational axes alongside `★ Epistemic` (reasoning structure), `↗ /protocol` (cross-protocol recommendation), and `⇌` (frame-oscillation detection).
+Calibration Trace shows who is deciding — one of several observation types alongside `★ Epistemic` (reasoning structure), `↗ /protocol` (cross-protocol recommendation), and `⇌` (frame-oscillation detection).
 
 # Protocol Nudge
 
@@ -150,7 +150,7 @@ During any active protocol, watch for signs that the user's working frame of the
 
 ⇌ framing — [one sentence describing the shift, with the specific turns or utterances it is grounded in]
 
-Emit once per distinct pattern per session — subject redefinition, goal mutation, and incompatible categorization each count as a separate pattern and each gets at most one emission per session. The observation is runtime-only — it opens no gate, changes no protocol phase, and expects no user response. Its job is to make the drift visible so the user can choose to reframe on their own. Grounding condition: the shift must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. This observer realizes the Definitional-Observational Convergence principle — runtime AI observation lives in Output Style, not in any SKILL.md.
+Emit once per distinct pattern per session — subject redefinition, goal mutation, and incompatible categorization each count as a separate pattern and each gets at most one emission per session. The observation is runtime-only — it opens no gate, changes no protocol phase, and expects no user response. Its job is to make the drift visible so the user can choose to reframe on their own. Grounding condition: the shift must be citable against at least two distinct turns or utterances; vague hunches without cross-turn evidence are suppressed. Observations like this live in Output Style, not in any SKILL.md — they are runtime AI observations, not part of any protocol's definition.
 
 # Tone and Style
 


### PR DESCRIPTION
## Summary

- `epistemic-cooperative/styles/epistemic-ink.md` Symbol rendering 섹션의 메타 어휘 평문 paraphrase (\"realizes\" → \"maps\", \"Ink realization\" → \"how to render\", \"Content vocabulary rendering\" → \"Symbol rendering\" 등)
- Calibration Trace: 내부 `Constitution`/`Extension` 분류는 유지, user-facing 렌더링은 `⊢ Decision` / `⊢ Auto` 로 분리 — render layer 가 내부 mode 를 user-surface label 로 변환하는 구조
- `plugin.json` 2.2.3 → 2.2.4

## Background

Session `48ca2e5f` (2026-04-28) 에서 시작된 어휘 부담 절감 작업의 1차분. Output Style 의 Layer 원칙 ("SKILL.md defines, Output Style realizes") 의 자연 확장으로, 정의 층의 정밀도는 보존하면서 실현 층에서 user-facing 노출을 평문화. Vocabulary rendering 후속 작업 (frame vocabulary T0 단계) 은 ensemble 검토 결과 통합 후 별도 PR.

## Test plan

- [ ] CI 의 `claude-code-review` workflow 통과
- [ ] CI 의 `claude-epistemic-review` workflow 통과 — epistemic 메타 라벨 영향 의식적 확인
- [ ] 다음 세션에서 Output Style 적용 시 Calibration Trace 가 \`⊢ Decision\` / \`⊢ Auto\` 로 렌더링되는지 시각 확인
- [ ] Vocabulary rendering 후속 PR (T0 단계) — ensemble 권고 통합 후 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)