### PR TITLE
fix(ci): #302 directioncheck step GITHUB_OUTPUT EOF 파싱 실패 수정

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -110,7 +110,7 @@ jobs:
           if [ -z "$REVIEW_TEXT" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            printf '%s' "$REVIEW_TEXT" > .review-text.txt
+            printf '%s\n' "$REVIEW_TEXT" > .review-text.txt
             echo "review_text<<REVIEW_TEXT_EOF" >> "$GITHUB_OUTPUT"
             echo "$REVIEW_TEXT" >> "$GITHUB_OUTPUT"
             echo "REVIEW_TEXT_EOF" >> "$GITHUB_OUTPUT"
@@ -125,6 +125,7 @@ jobs:
             {
               echo "review_text<<REVIEW_TEXT_EOF"
               cat .review-text.txt 2>/dev/null || true
+              echo ""
               echo "REVIEW_TEXT_EOF"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -154,6 +155,7 @@ jobs:
           {
             echo "review_text<<REVIEW_TEXT_EOF"
             cat .review-text.txt
+            echo ""
             echo "REVIEW_TEXT_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-epistemic-review.yml
+++ b/.github/workflows/claude-epistemic-review.yml
@@ -154,7 +154,7 @@ jobs:
           if [ -z "$REVIEW_TEXT" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            printf '%s' "$REVIEW_TEXT" > .review-text.txt
+            printf '%s\n' "$REVIEW_TEXT" > .review-text.txt
             echo "review_text<<REVIEW_TEXT_EOF" >> "$GITHUB_OUTPUT"
             echo "$REVIEW_TEXT" >> "$GITHUB_OUTPUT"
             echo "REVIEW_TEXT_EOF" >> "$GITHUB_OUTPUT"
@@ -169,6 +169,7 @@ jobs:
             {
               echo "review_text<<REVIEW_TEXT_EOF"
               cat .review-text.txt 2>/dev/null || true
+              echo ""
               echo "REVIEW_TEXT_EOF"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -198,6 +199,7 @@ jobs:
           {
             echo "review_text<<REVIEW_TEXT_EOF"
             cat .review-text.txt
+            echo ""
             echo "REVIEW_TEXT_EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

PR #317로 도입된 `Cross-check review for direction errors` step (M3)이 양 workflow에서 silent failure — `"Invalid value. Matching delimiter not found 'REVIEW_TEXT_EOF'"`. PR #318의 두 CI 런 모두 이 step에서 실패.

## 원인

`Extract review text` step이 `.review-text.txt`를 `printf '%s'` (trailing newline 없음)로 작성. `directioncheck` step에서 다음과 같이 heredoc-style로 GITHUB_OUTPUT에 작성:

```bash
{
  echo "review_text<<REVIEW_TEXT_EOF"
  cat .review-text.txt          # 파일 끝 newline 없음
  echo "REVIEW_TEXT_EOF"        # 직전 라인에 붙어버림
} >> "$GITHUB_OUTPUT"
```

EOF 마커가 직전 컨텐츠 마지막 라인에 붙어 자기 줄에 있지 않게 되어 GitHub Actions multi-line output parser가 종료 마커를 못 찾음.

원본 `Extract` step은 `echo "$REVIEW_TEXT" >> $GITHUB_OUTPUT` (echo가 newline 추가)로 작동했지만, 새 `directioncheck`는 `cat`으로 파일에서 읽어 newline이 사라짐.

## Fix

- `Extract review text`: `printf '%s'` → `printf '%s\n'` — `.review-text.txt` 끝 newline 보장
- `directioncheck`: GITHUB_OUTPUT 작성 직전 `echo ""` 추가 — 방어선 (회귀 보호)

두 workflow 동일 적용.

## 검증 실패 런

- Run 25204087796 (epistemic-review) on PR #318
- Run 25204087798 (claude-review) on PR #318

머지 후 차기 PR opened 시 directioncheck step이 정상 통과하면 fix 검증 완료.

## Test plan

- [ ] 머지 후 차기 PR opened 시 두 workflow가 directioncheck step 통과
- [ ] M3 cross-check가 실제로 동작 — A 마킹 파일이 review에서 "deleted"로 언급될 경우 warning prepend되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016d8bZLkwyEZnReP83MRdJf)_