### PR TITLE
feat(epistemic-cooperative): artifact-review UX 개선 — delete + pending highlight + sidebar list

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /artifact-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/artifact-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/artifact-review/scripts/serve.ts
@@ -106,7 +106,15 @@ interface FeedbackBody {
   context_before?: string;
   context_after?: string;
   comment: string;
+  id?: string; // optional on POST: present for edits (re-uses original id), absent for new entries
 }
+
+interface DeleteBody {
+  slug: string;
+  id: string;
+}
+
+const MAX_ID_LEN = 128;
 
 const server = Bun.serve({
   hostname: "127.0.0.1", // bind to loopback only — drafts and feedback are user-private
@@ -160,7 +168,19 @@ const server = Bun.serve({
       if ((body.context_after?.length ?? 0) > MAX_CONTEXT_LEN) return new Response(`context_after exceeds ${MAX_CONTEXT_LEN} chars`, { status: 413 });
       const draft = drafts.get(body.slug);
       if (!draft) return new Response("unknown slug", { status: 400 });
+      // Edit case: client supplies the original id so the new entry shares the dedup key
+      // (latest-timestamp wins). New case: server mints a UUID — guarantees uniqueness so
+      // two distinct annotations with identical (anchor, context) windows never collide.
+      let id: string;
+      if (isStr(body.id) && body.id.length > 0 && body.id.length <= MAX_ID_LEN) {
+        id = body.id;
+      } else if (body.id != null) {
+        return new Response(`id must be string ≤${MAX_ID_LEN} chars`, { status: 400 });
+      } else {
+        id = crypto.randomUUID();
+      }
       const entry = {
+        id,
         slug: body.slug,
         anchor: body.anchor,
         context_before: body.context_before ?? "",
@@ -177,45 +197,76 @@ const server = Bun.serve({
         console.error(`[feedback] FAILED to append ${feedbackPath}: ${msg}`);
         return new Response(`feedback write failed: ${msg}`, { status: 500 });
       }
-      console.error(`[feedback] ${body.slug} ← "${body.anchor.slice(0, 50)}${body.anchor.length > 50 ? "…" : ""}"`);
-      return Response.json({ ok: true, path: feedbackPath });
+      console.error(`[feedback] ${body.slug} id=${id.slice(0, 8)}… ← "${body.anchor.slice(0, 50)}${body.anchor.length > 50 ? "…" : ""}"`);
+      return Response.json({ ok: true, id, path: feedbackPath });
     }
 
     if (url.pathname === "/feedback" && req.method === "DELETE") {
-      // Tombstone strategy: append-only invariant preserved. The downstream JSONL
-      // consumer dedups on (anchor, context_before, context_after) by latest timestamp;
-      // a tombstone entry with `deleted: true` and an empty comment, written later than
-      // the original, naturally suppresses prior entries under that policy. This avoids
-      // file rewrite and stays consistent with the current "append + dedup" contract.
-      let body: Partial<FeedbackBody>;
+      // Tombstone strategy keyed by stable id. Existence check guards against ghost
+      // tombstones (DELETE for non-matching key would silently no-op under the prior
+      // tuple-based contract). Append-only invariant preserved.
+      let body: Partial<DeleteBody>;
       try {
-        body = (await req.json()) as Partial<FeedbackBody>;
+        body = (await req.json()) as Partial<DeleteBody>;
       } catch {
         return new Response("invalid JSON", { status: 400 });
       }
       const isStr = (v: unknown): v is string => typeof v === "string";
-      if (!isStr(body.slug) || !isStr(body.anchor)) {
-        return new Response("missing or non-string fields (slug, anchor)", { status: 400 });
+      if (!isStr(body.slug) || !isStr(body.id)) {
+        return new Response("missing or non-string fields (slug, id)", { status: 400 });
       }
-      if (body.context_before != null && !isStr(body.context_before)) return new Response("context_before must be string", { status: 400 });
-      if (body.context_after != null && !isStr(body.context_after)) return new Response("context_after must be string", { status: 400 });
-      if (body.anchor.length === 0) return new Response("anchor must be non-empty", { status: 400 });
+      if (body.id.length === 0) return new Response("id must be non-empty", { status: 400 });
       if (body.slug.length > MAX_SLUG_LEN) return new Response(`slug exceeds ${MAX_SLUG_LEN} chars`, { status: 413 });
-      if (body.anchor.length > MAX_ANCHOR_LEN) return new Response(`anchor exceeds ${MAX_ANCHOR_LEN} chars`, { status: 413 });
-      if ((body.context_before?.length ?? 0) > MAX_CONTEXT_LEN) return new Response(`context_before exceeds ${MAX_CONTEXT_LEN} chars`, { status: 413 });
-      if ((body.context_after?.length ?? 0) > MAX_CONTEXT_LEN) return new Response(`context_after exceeds ${MAX_CONTEXT_LEN} chars`, { status: 413 });
+      if (body.id.length > MAX_ID_LEN) return new Response(`id exceeds ${MAX_ID_LEN} chars`, { status: 413 });
       const draft = drafts.get(body.slug);
       if (!draft) return new Response("unknown slug", { status: 400 });
+      const feedbackPath = resolve(dirname(draft), `feedback-${body.slug}.jsonl`);
+
+      // Existence check: scan JSONL, find latest entry for this id, ensure it is a live
+      // (non-tombstoned) annotation. Linear scan acceptable — feedback files are per-draft,
+      // typically <1 MB.
+      let liveEntry: any = null;
+      try {
+        const content = await readFile(feedbackPath, "utf8");
+        let latest: any = null;
+        for (const line of content.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const e = JSON.parse(line);
+            if (e.id !== body.id) continue;
+            if (!latest || (typeof e.timestamp === "string" && (typeof latest.timestamp !== "string" || e.timestamp > latest.timestamp))) {
+              latest = e;
+            }
+          } catch {
+            // skip malformed lines — preserves resilience to manual edits
+          }
+        }
+        if (latest && !latest.deleted) liveEntry = latest;
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          const msg = (e as Error).message;
+          console.error(`[feedback] DELETE existence check failed for ${feedbackPath}: ${msg}`);
+          return new Response(`existence check failed: ${msg}`, { status: 500 });
+        }
+        // ENOENT — file does not exist, so target id cannot exist; fall through to 404
+      }
+      if (!liveEntry) {
+        return new Response(JSON.stringify({ ok: false, deleted: false, reason: "not found or already deleted" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+        });
+      }
+
       const tombstone = {
+        id: body.id,
         slug: body.slug,
-        anchor: body.anchor,
-        context_before: body.context_before ?? "",
-        context_after: body.context_after ?? "",
+        anchor: liveEntry.anchor,
+        context_before: liveEntry.context_before ?? "",
+        context_after: liveEntry.context_after ?? "",
         comment: "",
         deleted: true,
         timestamp: new Date().toISOString(),
       };
-      const feedbackPath = resolve(dirname(draft), `feedback-${body.slug}.jsonl`);
       try {
         await appendFile(feedbackPath, JSON.stringify(tombstone) + "\n", "utf8");
       } catch (e) {
@@ -223,8 +274,8 @@ const server = Bun.serve({
         console.error(`[feedback] FAILED to append tombstone ${feedbackPath}: ${msg}`);
         return new Response(`tombstone write failed: ${msg}`, { status: 500 });
       }
-      console.error(`[feedback] DELETE ${body.slug} ← "${body.anchor.slice(0, 50)}${body.anchor.length > 50 ? "…" : ""}"`);
-      return Response.json({ ok: true, path: feedbackPath, deleted: true });
+      console.error(`[feedback] DELETE ${body.slug} id=${body.id.slice(0, 8)}… ← "${(liveEntry.anchor ?? "").slice(0, 50)}${(liveEntry.anchor ?? "").length > 50 ? "…" : ""}"`);
+      return Response.json({ ok: true, id: body.id, deleted: true, path: feedbackPath });
     }
 
     if (url.pathname === "/ws") {

--- a/epistemic-cooperative/skills/artifact-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/artifact-review/scripts/serve.ts
@@ -181,6 +181,52 @@ const server = Bun.serve({
       return Response.json({ ok: true, path: feedbackPath });
     }
 
+    if (url.pathname === "/feedback" && req.method === "DELETE") {
+      // Tombstone strategy: append-only invariant preserved. The downstream JSONL
+      // consumer dedups on (anchor, context_before, context_after) by latest timestamp;
+      // a tombstone entry with `deleted: true` and an empty comment, written later than
+      // the original, naturally suppresses prior entries under that policy. This avoids
+      // file rewrite and stays consistent with the current "append + dedup" contract.
+      let body: Partial<FeedbackBody>;
+      try {
+        body = (await req.json()) as Partial<FeedbackBody>;
+      } catch {
+        return new Response("invalid JSON", { status: 400 });
+      }
+      const isStr = (v: unknown): v is string => typeof v === "string";
+      if (!isStr(body.slug) || !isStr(body.anchor)) {
+        return new Response("missing or non-string fields (slug, anchor)", { status: 400 });
+      }
+      if (body.context_before != null && !isStr(body.context_before)) return new Response("context_before must be string", { status: 400 });
+      if (body.context_after != null && !isStr(body.context_after)) return new Response("context_after must be string", { status: 400 });
+      if (body.anchor.length === 0) return new Response("anchor must be non-empty", { status: 400 });
+      if (body.slug.length > MAX_SLUG_LEN) return new Response(`slug exceeds ${MAX_SLUG_LEN} chars`, { status: 413 });
+      if (body.anchor.length > MAX_ANCHOR_LEN) return new Response(`anchor exceeds ${MAX_ANCHOR_LEN} chars`, { status: 413 });
+      if ((body.context_before?.length ?? 0) > MAX_CONTEXT_LEN) return new Response(`context_before exceeds ${MAX_CONTEXT_LEN} chars`, { status: 413 });
+      if ((body.context_after?.length ?? 0) > MAX_CONTEXT_LEN) return new Response(`context_after exceeds ${MAX_CONTEXT_LEN} chars`, { status: 413 });
+      const draft = drafts.get(body.slug);
+      if (!draft) return new Response("unknown slug", { status: 400 });
+      const tombstone = {
+        slug: body.slug,
+        anchor: body.anchor,
+        context_before: body.context_before ?? "",
+        context_after: body.context_after ?? "",
+        comment: "",
+        deleted: true,
+        timestamp: new Date().toISOString(),
+      };
+      const feedbackPath = resolve(dirname(draft), `feedback-${body.slug}.jsonl`);
+      try {
+        await appendFile(feedbackPath, JSON.stringify(tombstone) + "\n", "utf8");
+      } catch (e) {
+        const msg = (e as Error).message;
+        console.error(`[feedback] FAILED to append tombstone ${feedbackPath}: ${msg}`);
+        return new Response(`tombstone write failed: ${msg}`, { status: 500 });
+      }
+      console.error(`[feedback] DELETE ${body.slug} ← "${body.anchor.slice(0, 50)}${body.anchor.length > 50 ? "…" : ""}"`);
+      return Response.json({ ok: true, path: feedbackPath, deleted: true });
+    }
+
     if (url.pathname === "/ws") {
       if (srv.upgrade(req)) return;
       return new Response("upgrade failed", { status: 400 });

--- a/epistemic-cooperative/skills/artifact-review/templates/preview.html
+++ b/epistemic-cooperative/skills/artifact-review/templates/preview.html
@@ -9,18 +9,34 @@
     --accent: #2c7be5;
     --highlight: #fff3a3;
     --highlight-edge: #d4a017;
+    --highlight-pending: #e8f4ff;
+    --highlight-pending-edge: #2c7be5;
     --muted: #666;
     --bg: #fafafa;
+    --sidebar-width: 320px;
   }
   * { box-sizing: border-box; }
   body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Apple SD Gothic Neo", sans-serif;
-    max-width: 760px;
-    margin: 0 auto;
-    padding: 2.5em 1.5em 5em;
+    margin: 0;
+    padding: 0;
     line-height: 1.7;
     color: #222;
     background: white;
+  }
+
+  /* Layout — main content + right sidebar */
+  #layout {
+    display: flex;
+    min-height: 100vh;
+  }
+  #main {
+    flex: 1;
+    min-width: 0;
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 2.5em 1.5em 5em;
+    transition: max-width .2s ease, margin-right .2s ease;
   }
   header {
     border-bottom: 1px solid #eee;
@@ -68,18 +84,32 @@
   }
   #content th { background: #f7f7f7; }
 
-  /* Annotated text */
+  /* Annotated text — saved marks */
   .annotated {
     background: var(--highlight);
     border-bottom: 2px solid var(--highlight-edge);
     padding: 1px 0;
     cursor: help;
+    transition: box-shadow .25s ease;
   }
   .annotated::after {
     content: "💬";
     font-size: .65em;
     margin-left: 2px;
     vertical-align: super;
+  }
+
+  /* Pending mark — view-state only, while popup is open during compose */
+  .annotated-pending {
+    background: var(--highlight-pending);
+    border-bottom: 2px dashed var(--highlight-pending-edge);
+    padding: 1px 0;
+  }
+  .annotated-pending::after { content: ""; margin: 0; }
+
+  /* Click-to-focus pulse on body mark */
+  .annotated.pulse {
+    box-shadow: 0 0 0 4px rgba(44, 123, 229, .35);
   }
 
   /* Popup */
@@ -121,9 +151,18 @@
   #popup-actions {
     display: flex;
     gap: .5em;
-    justify-content: flex-end;
+    align-items: center;
     margin-top: .5em;
   }
+  #popup-cancel { margin-left: auto; }
+  #popup button.danger {
+    background: #c0392b;
+    color: white;
+    border-color: #c0392b;
+  }
+  #popup button.danger:hover { background: #e74c3c; border-color: #e74c3c; }
+  #popup-delete { display: none; }
+  #popup.edit-mode #popup-delete { display: inline-block; }
   #popup button {
     padding: .4em .9em;
     border: 1px solid #ccc;
@@ -143,6 +182,75 @@
     color: var(--muted);
     margin-top: .35em;
     text-align: right;
+  }
+
+  /* Sidebar — right panel listing all comments */
+  #sidebar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 2.4em; /* clear status bar */
+    width: var(--sidebar-width);
+    background: var(--bg);
+    border-left: 1px solid #eee;
+    transform: translateX(100%);
+    transition: transform .2s ease;
+    z-index: 400;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  body.sidebar-open #sidebar { transform: translateX(0); }
+  #sidebar-header {
+    padding: .75em 1em;
+    border-bottom: 1px solid #eee;
+    background: white;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: .9em;
+    color: var(--muted);
+  }
+  #sidebar-header strong { color: #222; }
+  #sidebar-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: .5em 0;
+  }
+  #sidebar-empty {
+    padding: 2em 1em;
+    color: var(--muted);
+    font-size: .85em;
+    text-align: center;
+    font-style: italic;
+  }
+  .sidebar-item {
+    padding: .65em 1em;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+    transition: background .12s ease;
+  }
+  .sidebar-item:hover { background: #f0f4f8; }
+  .sidebar-item-anchor {
+    font-size: .82em;
+    color: var(--muted);
+    border-left: 3px solid var(--highlight-edge);
+    padding-left: .55em;
+    margin-bottom: .35em;
+    line-height: 1.35;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+  .sidebar-item-comment {
+    font-size: .9em;
+    color: #222;
+    line-height: 1.4;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
   }
 
   /* Status bar */
@@ -165,6 +273,19 @@
     margin-right: .35em;
   }
   #status-conn.disconnected::before { color: #aaa; }
+  #status-count {
+    background: transparent;
+    border: none;
+    padding: .15em .55em;
+    margin: -.15em -.55em;
+    border-radius: 4px;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    transition: background .12s ease;
+  }
+  #status-count:hover { background: rgba(44, 123, 229, .1); color: #222; }
+  body.sidebar-open #status-count { background: rgba(44, 123, 229, .14); color: #222; }
   #status-count strong { color: #222; }
 
   /* Toast — confirms each submit silently append to disk, since popup close alone is ambiguous */
@@ -198,27 +319,54 @@
     #content th, #content td { border-color: #333; }
     #content th { background: #252525; }
     .annotated { background: #5a4a00; color: #fff; }
+    .annotated-pending { background: #1f3550; color: #fff; }
     #popup { background: #222; border-color: #444; }
     #popup-anchor-preview { background: #2a2a2a; color: #aaa; }
     #popup textarea { background: #2a2a2a; border-color: #444; color: #e0e0e0; }
     #popup button { background: #2a2a2a; border-color: #444; color: #e0e0e0; }
     #status { background: #1a1a1a; border-top-color: #333; }
     #status-count strong { color: #e0e0e0; }
+    #status-count:hover { background: rgba(255,255,255,.06); color: #e0e0e0; }
+    body.sidebar-open #status-count { background: rgba(255,255,255,.1); color: #e0e0e0; }
+    #sidebar { background: #1f1f1f; border-left-color: #333; }
+    #sidebar-header { background: #1a1a1a; border-bottom-color: #333; }
+    #sidebar-header strong { color: #e0e0e0; }
+    .sidebar-item { border-bottom-color: #333; }
+    .sidebar-item:hover { background: #2a2a2a; }
+    .sidebar-item-anchor { color: #aaa; }
+    .sidebar-item-comment { color: #e0e0e0; }
   }
+
 </style>
 </head>
 <body>
-<header>
-  <span><a href="/">← all drafts</a></span>
-  <span><strong>__TITLE_PLACEHOLDER__</strong></span>
-</header>
 
-<div id="content"></div>
+<div id="layout">
+  <div id="main">
+    <header>
+      <span><a href="/">← all drafts</a></span>
+      <span><strong>__TITLE_PLACEHOLDER__</strong></span>
+    </header>
+
+    <div id="content"></div>
+  </div>
+</div>
+
+<aside id="sidebar" aria-label="Comments panel">
+  <div id="sidebar-header">
+    <span><strong id="sidebar-count">0</strong> comments</span>
+    <span style="font-size:.78em;">click to focus</span>
+  </div>
+  <div id="sidebar-list">
+    <div id="sidebar-empty">No comments yet — select text to add one.</div>
+  </div>
+</aside>
 
 <div id="popup">
   <div id="popup-anchor-preview"></div>
   <textarea id="popup-textarea" placeholder="Comment on this selection…"></textarea>
   <div id="popup-actions">
+    <button id="popup-delete" class="danger" type="button" aria-label="Delete comment">Delete</button>
     <button id="popup-cancel">Cancel</button>
     <button id="popup-submit" class="primary">Submit</button>
   </div>
@@ -227,7 +375,9 @@
 
 <div id="status">
   <span id="status-conn">live</span>
-  <span id="status-count"><strong id="count">0</strong> comments this session</span>
+  <button id="status-count" type="button" aria-label="Toggle comment list">
+    <strong id="count">0</strong> comments
+  </button>
 </div>
 
 <div id="toast" role="status" aria-live="polite"></div>
@@ -250,10 +400,18 @@ const popupPreview = document.getElementById("popup-anchor-preview");
 const popupTextarea = document.getElementById("popup-textarea");
 const popupSubmit = document.getElementById("popup-submit");
 const popupCancel = document.getElementById("popup-cancel");
+const popupDelete = document.getElementById("popup-delete");
 const countEl = document.getElementById("count");
 
-let pending = null; // { range, anchor, context_before, context_after }
-let count = 0;
+// Sidebar state
+const sidebar = document.getElementById("sidebar");
+const sidebarList = document.getElementById("sidebar-list");
+const sidebarEmpty = document.getElementById("sidebar-empty");
+const sidebarCount = document.getElementById("sidebar-count");
+const statusCount = document.getElementById("status-count");
+
+let pending = null; // { range, anchor, context_before, context_after, editingMark, tempMark }
+let markIdCounter = 0; // monotonic id assigned per saved mark; bridges DOM <-> sidebar entry
 
 content.addEventListener("mouseup", () => {
   // Let the selection settle before reading it
@@ -262,6 +420,7 @@ content.addEventListener("mouseup", () => {
 
 function setPopupMode(isEdit) {
   popupSubmit.textContent = isEdit ? "Update" : "Submit";
+  popup.classList.toggle("edit-mode", !!isEdit);
 }
 
 function positionPopupNear(rect) {
@@ -269,6 +428,44 @@ function positionPopupNear(rect) {
   const left = Math.min(window.scrollX + rect.left, window.scrollX + window.innerWidth - popupWidth - 16);
   popup.style.top = (window.scrollY + rect.bottom + 8) + "px";
   popup.style.left = Math.max(16, left) + "px";
+}
+
+// Wrap pending range in a dashed "drafting" mark so the selection stays visible
+// while the user types in the popup. Returns the mark element on success, or null
+// when the range crosses element boundaries (surroundContents throws).
+function applyPendingMark(range) {
+  try {
+    const tempMark = document.createElement("mark");
+    tempMark.className = "annotated-pending";
+    range.surroundContents(tempMark);
+    return tempMark;
+  } catch (e) {
+    // Range crosses element boundaries — out of scope for the pending-mark feature.
+    // Save flow's surroundContents at line ~430 documents the same limitation.
+    return null;
+  }
+}
+
+// Unwrap a temp mark, restoring its children inline. Safe to call with null.
+function removePendingMark(tempMark) {
+  if (!tempMark || !tempMark.parentNode) return;
+  const parent = tempMark.parentNode;
+  while (tempMark.firstChild) parent.insertBefore(tempMark.firstChild, tempMark);
+  parent.removeChild(tempMark);
+  parent.normalize(); // merge adjacent text nodes — keeps DOM clean for next selection
+}
+
+// Promote a pending temp mark to a saved annotation in place — keeps the same
+// element instance and avoids a second surroundContents (which would fail again
+// on the same boundary-crossing range).
+function promotePendingMark(tempMark, anchor, context_before, context_after, comment) {
+  tempMark.className = "annotated";
+  tempMark.title = comment;
+  tempMark.dataset.anchor = anchor;
+  tempMark.dataset.contextBefore = context_before;
+  tempMark.dataset.contextAfter = context_after;
+  tempMark.dataset.comment = comment;
+  tempMark.dataset.markId = String(++markIdCounter);
 }
 
 function handleSelection() {
@@ -283,13 +480,27 @@ function handleSelection() {
   const context_before = idx >= 0 ? contentText.slice(Math.max(0, idx - 60), idx).replace(/\s+/g, " ").trim() : "";
   const context_after = idx >= 0 ? contentText.slice(idx + text.length, idx + text.length + 60).replace(/\s+/g, " ").trim() : "";
 
-  pending = { range: range.cloneRange(), anchor: text, context_before, context_after, editingMark: null };
+  // Apply temp mark first; positioning will use the mark's rect when wrap succeeds
+  const liveRange = range.cloneRange();
+  const tempMark = applyPendingMark(liveRange);
 
-  positionPopupNear(range.getBoundingClientRect());
+  pending = {
+    range: liveRange,
+    anchor: text,
+    context_before,
+    context_after,
+    editingMark: null,
+    tempMark, // null if surroundContents failed; save flow handles both
+  };
+
+  const anchorRect = tempMark ? tempMark.getBoundingClientRect() : range.getBoundingClientRect();
+  positionPopupNear(anchorRect);
   popupPreview.textContent = text.length > 200 ? text.slice(0, 200) + "…" : text;
   popupTextarea.value = "";
   setPopupMode(false);
   popup.classList.add("show");
+  // Drop the live selection so the dashed pending mark is the only visible cue
+  sel.removeAllRanges();
   popupTextarea.focus();
 }
 
@@ -303,6 +514,7 @@ function openEditPopup(markEl) {
     context_before: markEl.dataset.contextBefore || "",
     context_after: markEl.dataset.contextAfter || "",
     editingMark: markEl,
+    tempMark: null,
   };
   positionPopupNear(markEl.getBoundingClientRect());
   const anchorText = pending.anchor;
@@ -323,7 +535,12 @@ content.addEventListener("click", (e) => {
 });
 
 function dismissPopup() {
+  // Clean up the pending temp mark before clearing state
+  if (pending && pending.tempMark) {
+    removePendingMark(pending.tempMark);
+  }
   popup.classList.remove("show");
+  popup.classList.remove("edit-mode");
   pending = null;
   const sel = window.getSelection();
   if (sel) sel.removeAllRanges();
@@ -331,6 +548,7 @@ function dismissPopup() {
 
 popupCancel.addEventListener("click", dismissPopup);
 popupSubmit.addEventListener("click", submitFeedback);
+popupDelete.addEventListener("click", deleteFeedback);
 
 popupTextarea.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
@@ -343,7 +561,9 @@ popupTextarea.addEventListener("keydown", (e) => {
 });
 
 document.addEventListener("click", (e) => {
-  if (!popup.contains(e.target) && !content.contains(e.target)) dismissPopup();
+  if (!popup.contains(e.target) && !content.contains(e.target) && !sidebar.contains(e.target) && e.target !== statusCount && !statusCount.contains(e.target)) {
+    dismissPopup();
+  }
 });
 
 const toastEl = document.getElementById("toast");
@@ -381,8 +601,15 @@ async function submitFeedback() {
       captured.editingMark.dataset.comment = comment;
       captured.editingMark.title = comment;
       showToast("✓ updated");
+    } else if (captured.tempMark && captured.tempMark.parentNode) {
+      // Promote the dashed pending mark to a permanent annotation
+      promotePendingMark(captured.tempMark, captured.anchor, captured.context_before, captured.context_after, comment);
+      captured.tempMark = null; // do not unwrap on dismiss
+      showToast("✓ saved");
     } else {
-      // Visual mark — best effort; surroundContents fails if range crosses element boundaries
+      // Pending mark was not applied (range crossed element boundaries). Try the
+      // original surroundContents anyway as a last-ditch attempt — it will fail
+      // identically and the comment is then saved without a visual mark.
       try {
         const mark = document.createElement("mark");
         mark.className = "annotated";
@@ -391,20 +618,111 @@ async function submitFeedback() {
         mark.dataset.contextBefore = captured.context_before;
         mark.dataset.contextAfter = captured.context_after;
         mark.dataset.comment = comment;
+        mark.dataset.markId = String(++markIdCounter);
         captured.range.surroundContents(mark);
       } catch (e) {
         console.warn("range crosses element boundary; comment saved without visual mark (edit unavailable).", e);
       }
-      count++;
-      countEl.textContent = count;
-      showToast(`✓ saved (${count} total)`);
+      showToast("✓ saved");
     }
     dismissPopup();
+    renderSidebar();
   } catch (e) {
     // Preserve comment text on failure (5xx, network error) so the user can retry — don't dismiss.
     showToast(`✗ save failed: ${e.message} — comment preserved, press ⌘Enter to retry`, true);
   }
 }
+
+async function deleteFeedback() {
+  if (!pending || !pending.editingMark) return;
+  const captured = pending;
+  const mark = captured.editingMark;
+
+  try {
+    const resp = await fetch("/feedback", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        slug: SLUG,
+        anchor: captured.anchor,
+        context_before: captured.context_before,
+        context_after: captured.context_after,
+      }),
+    });
+    if (!resp.ok) throw new Error("server " + resp.status);
+
+    // Unwrap mark in place, restoring plain text
+    const parent = mark.parentNode;
+    if (parent) {
+      while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+      parent.removeChild(mark);
+      parent.normalize();
+    }
+    dismissPopup();
+    renderSidebar();
+    showToast("✓ deleted");
+  } catch (e) {
+    showToast(`✗ delete failed: ${e.message}`, true);
+  }
+}
+
+// ── Sidebar: list-of-comments view + click-to-focus ──
+
+function renderSidebar() {
+  const marks = content.querySelectorAll(".annotated");
+  const n = marks.length;
+  sidebarCount.textContent = String(n);
+  countEl.textContent = String(n);
+
+  // Clear list (preserve sidebarEmpty node by removing all children then conditionally re-adding)
+  while (sidebarList.firstChild) sidebarList.removeChild(sidebarList.firstChild);
+
+  if (n === 0) {
+    sidebarList.appendChild(sidebarEmpty);
+    return;
+  }
+
+  marks.forEach((mark) => {
+    if (!mark.dataset.markId) mark.dataset.markId = String(++markIdCounter);
+    const item = document.createElement("div");
+    item.className = "sidebar-item";
+    item.dataset.targetMarkId = mark.dataset.markId;
+
+    const anchorEl = document.createElement("div");
+    anchorEl.className = "sidebar-item-anchor";
+    const anchorText = mark.dataset.anchor || mark.textContent || "";
+    anchorEl.textContent = anchorText;
+
+    const commentEl = document.createElement("div");
+    commentEl.className = "sidebar-item-comment";
+    commentEl.textContent = mark.dataset.comment || "";
+
+    item.appendChild(anchorEl);
+    item.appendChild(commentEl);
+    item.addEventListener("click", () => focusMark(mark));
+    sidebarList.appendChild(item);
+  });
+}
+
+let pulseTimer = null;
+function focusMark(mark) {
+  if (!mark || !mark.isConnected) return;
+  mark.scrollIntoView({ behavior: "smooth", block: "center" });
+  // Clear any in-flight pulse so a fresh click always re-triggers the animation
+  document.querySelectorAll(".annotated.pulse").forEach((el) => el.classList.remove("pulse"));
+  if (pulseTimer) clearTimeout(pulseTimer);
+  // Force reflow before re-adding so the transition restarts
+  void mark.offsetWidth;
+  mark.classList.add("pulse");
+  pulseTimer = setTimeout(() => mark.classList.remove("pulse"), 800);
+}
+
+statusCount.addEventListener("click", () => {
+  document.body.classList.toggle("sidebar-open");
+});
+
+// Initial render — empty state on fresh load (no preloaded marks in template)
+renderSidebar();
 
 // WebSocket hot reload
 function connectWS() {

--- a/epistemic-cooperative/skills/artifact-review/templates/preview.html
+++ b/epistemic-cooperative/skills/artifact-review/templates/preview.html
@@ -36,7 +36,6 @@
     max-width: 760px;
     margin: 0 auto;
     padding: 2.5em 1.5em 5em;
-    transition: max-width .2s ease, margin-right .2s ease;
   }
   header {
     border-bottom: 1px solid #eee;
@@ -375,7 +374,7 @@
 
 <div id="status">
   <span id="status-conn">live</span>
-  <button id="status-count" type="button" aria-label="Toggle comment list">
+  <button id="status-count" type="button" aria-label="Toggle comment list" aria-controls="sidebar" aria-expanded="false">
     <strong id="count">0</strong> comments
   </button>
 </div>
@@ -410,8 +409,8 @@ const sidebarEmpty = document.getElementById("sidebar-empty");
 const sidebarCount = document.getElementById("sidebar-count");
 const statusCount = document.getElementById("status-count");
 
-let pending = null; // { range, anchor, context_before, context_after, editingMark, tempMark }
-let markIdCounter = 0; // monotonic id assigned per saved mark; bridges DOM <-> sidebar entry
+let pending = null; // { range, anchor, context_before, context_after, editingMark, tempMarks }
+let markIdCounter = 0; // monotonic id assigned per saved mark group; bridges DOM <-> sidebar entry
 
 content.addEventListener("mouseup", () => {
   // Let the selection settle before reading it
@@ -430,42 +429,98 @@ function positionPopupNear(rect) {
   popup.style.left = Math.max(16, left) + "px";
 }
 
-// Wrap pending range in a dashed "drafting" mark so the selection stays visible
-// while the user types in the popup. Returns the mark element on success, or null
-// when the range crosses element boundaries (surroundContents throws).
-function applyPendingMark(range) {
+// Wrap a range across element boundaries by walking its intersecting text nodes
+// and wrapping each fragment individually. Returns an array of <mark> elements
+// (one per text-node fragment). Used by both the pending (dashed) and save (yellow)
+// flows so element-crossing selections produce a visible mark instead of silently
+// failing at surroundContents.
+function wrapRangeInMarks(range, className) {
+  const startCont = range.startContainer;
+  const endCont = range.endContainer;
+  const startOffsetInitial = range.startOffset;
+  const endOffsetInitial = range.endOffset;
+
+  const ancestor = range.commonAncestorContainer;
+  const root = ancestor.nodeType === Node.TEXT_NODE ? ancestor.parentNode : ancestor;
+  if (!root) return [];
+
+  // Snapshot text nodes intersecting the range BEFORE any DOM mutation, so the
+  // walk is unaffected by subsequent splitText / wrap operations.
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes = [];
+  let n;
+  while ((n = walker.nextNode())) {
+    if (range.intersectsNode(n)) textNodes.push(n);
+  }
+
+  const marks = [];
+  for (const textNode of textNodes) {
+    let startOffset = 0;
+    let endOffset = textNode.length;
+    if (textNode === startCont) startOffset = startOffsetInitial;
+    if (textNode === endCont) endOffset = endOffsetInitial;
+    if (startOffset >= endOffset) continue;
+
+    let target = textNode;
+    if (startOffset > 0) {
+      target = target.splitText(startOffset);
+      endOffset -= startOffset;
+    }
+    if (endOffset < target.length) {
+      target.splitText(endOffset);
+    }
+
+    const mark = document.createElement("mark");
+    mark.className = className;
+    target.parentNode.insertBefore(mark, target);
+    mark.appendChild(target);
+    marks.push(mark);
+  }
+  return marks;
+}
+
+// Apply pending dashed marks for an in-progress selection. Returns array of marks
+// (possibly empty for degenerate ranges with no intersecting text nodes).
+function applyPendingMarks(range) {
   try {
-    const tempMark = document.createElement("mark");
-    tempMark.className = "annotated-pending";
-    range.surroundContents(tempMark);
-    return tempMark;
+    return wrapRangeInMarks(range, "annotated-pending");
   } catch (e) {
-    // Range crosses element boundaries — out of scope for the pending-mark feature.
-    // Save flow's surroundContents at line ~430 documents the same limitation.
-    return null;
+    if (e instanceof DOMException) {
+      // Genuine DOM constraint — popup-only flow remains usable
+      console.warn("[applyPendingMarks] DOM constraint:", e.name, e.message);
+      return [];
+    }
+    throw e; // unexpected — surface for investigation
   }
 }
 
-// Unwrap a temp mark, restoring its children inline. Safe to call with null.
-function removePendingMark(tempMark) {
-  if (!tempMark || !tempMark.parentNode) return;
-  const parent = tempMark.parentNode;
-  while (tempMark.firstChild) parent.insertBefore(tempMark.firstChild, tempMark);
-  parent.removeChild(tempMark);
-  parent.normalize(); // merge adjacent text nodes — keeps DOM clean for next selection
+// Unwrap pending marks, restoring inline text. Safe to call with empty/null array.
+function removePendingMarks(marks) {
+  if (!marks || marks.length === 0) return;
+  for (const mark of marks) {
+    if (!mark.parentNode) continue;
+    const parent = mark.parentNode;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+  }
+  // Single normalize at the end is cheaper than per-mark when marks share parents
+  content.normalize();
 }
 
-// Promote a pending temp mark to a saved annotation in place — keeps the same
-// element instance and avoids a second surroundContents (which would fail again
-// on the same boundary-crossing range).
-function promotePendingMark(tempMark, anchor, context_before, context_after, comment) {
-  tempMark.className = "annotated";
-  tempMark.title = comment;
-  tempMark.dataset.anchor = anchor;
-  tempMark.dataset.contextBefore = context_before;
-  tempMark.dataset.contextAfter = context_after;
-  tempMark.dataset.comment = comment;
-  tempMark.dataset.markId = String(++markIdCounter);
+// Promote pending marks to saved annotations — all marks in the array share the
+// same markId (logical comment identity for sidebar dedup) and server-issued id.
+function promotePendingMarks(marks, anchor, context_before, context_after, comment, id) {
+  const markId = String(++markIdCounter);
+  for (const mark of marks) {
+    mark.className = "annotated";
+    mark.title = comment;
+    mark.dataset.anchor = anchor;
+    mark.dataset.contextBefore = context_before;
+    mark.dataset.contextAfter = context_after;
+    mark.dataset.comment = comment;
+    mark.dataset.markId = markId;
+    mark.dataset.id = id;
+  }
 }
 
 function handleSelection() {
@@ -480,9 +535,9 @@ function handleSelection() {
   const context_before = idx >= 0 ? contentText.slice(Math.max(0, idx - 60), idx).replace(/\s+/g, " ").trim() : "";
   const context_after = idx >= 0 ? contentText.slice(idx + text.length, idx + text.length + 60).replace(/\s+/g, " ").trim() : "";
 
-  // Apply temp mark first; positioning will use the mark's rect when wrap succeeds
+  // Apply temp marks first; positioning uses the first mark's rect when wrap succeeds
   const liveRange = range.cloneRange();
-  const tempMark = applyPendingMark(liveRange);
+  const tempMarks = applyPendingMarks(liveRange);
 
   pending = {
     range: liveRange,
@@ -490,10 +545,10 @@ function handleSelection() {
     context_before,
     context_after,
     editingMark: null,
-    tempMark, // null if surroundContents failed; save flow handles both
+    tempMarks, // empty array for degenerate ranges; save flow handles both cases
   };
 
-  const anchorRect = tempMark ? tempMark.getBoundingClientRect() : range.getBoundingClientRect();
+  const anchorRect = tempMarks.length > 0 ? tempMarks[0].getBoundingClientRect() : range.getBoundingClientRect();
   positionPopupNear(anchorRect);
   popupPreview.textContent = text.length > 200 ? text.slice(0, 200) + "…" : text;
   popupTextarea.value = "";
@@ -514,7 +569,7 @@ function openEditPopup(markEl) {
     context_before: markEl.dataset.contextBefore || "",
     context_after: markEl.dataset.contextAfter || "",
     editingMark: markEl,
-    tempMark: null,
+    tempMarks: [],
   };
   positionPopupNear(markEl.getBoundingClientRect());
   const anchorText = pending.anchor;
@@ -535,9 +590,9 @@ content.addEventListener("click", (e) => {
 });
 
 function dismissPopup() {
-  // Clean up the pending temp mark before clearing state
-  if (pending && pending.tempMark) {
-    removePendingMark(pending.tempMark);
+  // Clean up pending temp marks before clearing state
+  if (pending && pending.tempMarks && pending.tempMarks.length > 0) {
+    removePendingMarks(pending.tempMarks);
   }
   popup.classList.remove("show");
   popup.classList.remove("edit-mode");
@@ -556,12 +611,13 @@ popupTextarea.addEventListener("keydown", (e) => {
     submitFeedback();
   } else if (e.key === "Escape") {
     e.preventDefault();
+    e.stopPropagation(); // prevent document-level Esc handler from also firing
     dismissPopup();
   }
 });
 
 document.addEventListener("click", (e) => {
-  if (!popup.contains(e.target) && !content.contains(e.target) && !sidebar.contains(e.target) && e.target !== statusCount && !statusCount.contains(e.target)) {
+  if (!popup.contains(e.target) && !content.contains(e.target) && !sidebar.contains(e.target) && !statusCount.contains(e.target)) {
     dismissPopup();
   }
 });
@@ -583,47 +639,50 @@ async function submitFeedback() {
 
   const captured = pending; // capture before dismiss
 
+  // Edit case: send the original id so the new entry shares the dedup key with the
+  // previous version. Create case: omit id so server mints a UUID.
+  const reqBody = {
+    slug: SLUG,
+    anchor: captured.anchor,
+    context_before: captured.context_before,
+    context_after: captured.context_after,
+    comment,
+  };
+  if (captured.editingMark && captured.editingMark.dataset.id) {
+    reqBody.id = captured.editingMark.dataset.id;
+  }
+
   try {
     const resp = await fetch("/feedback", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        slug: SLUG,
-        anchor: captured.anchor,
-        context_before: captured.context_before,
-        context_after: captured.context_after,
-        comment,
-      }),
+      body: JSON.stringify(reqBody),
     });
     if (!resp.ok) throw new Error("server " + resp.status);
+    const result = await resp.json();
+    const id = result.id;
 
     if (captured.editingMark) {
-      captured.editingMark.dataset.comment = comment;
-      captured.editingMark.title = comment;
+      // Update comment text on all marks in the same logical group
+      const markId = captured.editingMark.dataset.markId;
+      const marks = markId
+        ? content.querySelectorAll('.annotated[data-mark-id="' + markId + '"]')
+        : [captured.editingMark];
+      for (const mark of marks) {
+        mark.dataset.comment = comment;
+        mark.title = comment;
+        if (id) mark.dataset.id = id;
+      }
       showToast("✓ updated");
-    } else if (captured.tempMark && captured.tempMark.parentNode) {
-      // Promote the dashed pending mark to a permanent annotation
-      promotePendingMark(captured.tempMark, captured.anchor, captured.context_before, captured.context_after, comment);
-      captured.tempMark = null; // do not unwrap on dismiss
+    } else if (captured.tempMarks && captured.tempMarks.length > 0 && captured.tempMarks[0].parentNode) {
+      promotePendingMarks(captured.tempMarks, captured.anchor, captured.context_before, captured.context_after, comment, id);
+      captured.tempMarks = []; // do not unwrap on dismiss
       showToast("✓ saved");
     } else {
-      // Pending mark was not applied (range crossed element boundaries). Try the
-      // original surroundContents anyway as a last-ditch attempt — it will fail
-      // identically and the comment is then saved without a visual mark.
-      try {
-        const mark = document.createElement("mark");
-        mark.className = "annotated";
-        mark.title = comment;
-        mark.dataset.anchor = captured.anchor;
-        mark.dataset.contextBefore = captured.context_before;
-        mark.dataset.contextAfter = captured.context_after;
-        mark.dataset.comment = comment;
-        mark.dataset.markId = String(++markIdCounter);
-        captured.range.surroundContents(mark);
-      } catch (e) {
-        console.warn("range crosses element boundary; comment saved without visual mark (edit unavailable).", e);
-      }
-      showToast("✓ saved");
+      // Truly degenerate range — zero text nodes intersected. Comment is persisted
+      // server-side; no DOM mark was created so editing/deleting via UI is unavailable.
+      console.warn("[submitFeedback] no marks to promote; comment saved without visual mark.");
+      showToast("✓ saved (no visual mark)");
     }
     dismissPopup();
     renderSidebar();
@@ -634,43 +693,73 @@ async function submitFeedback() {
 }
 
 async function deleteFeedback() {
-  if (!pending || !pending.editingMark) return;
+  if (!pending || !pending.editingMark) {
+    showToast("✗ delete unavailable", true);
+    return;
+  }
   const captured = pending;
-  const mark = captured.editingMark;
+  const editedMark = captured.editingMark;
+  const id = editedMark.dataset.id;
+  const markId = editedMark.dataset.markId;
+
+  if (!id) {
+    showToast("✗ delete unavailable (no id — pre-update mark)", true);
+    return;
+  }
 
   try {
     const resp = await fetch("/feedback", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        slug: SLUG,
-        anchor: captured.anchor,
-        context_before: captured.context_before,
-        context_after: captured.context_after,
-      }),
+      body: JSON.stringify({ slug: SLUG, id }),
     });
-    if (!resp.ok) throw new Error("server " + resp.status);
+    if (!resp.ok) {
+      let reason = "HTTP " + resp.status;
+      try {
+        const errBody = await resp.json();
+        if (errBody && errBody.reason) reason = errBody.reason;
+      } catch {
+        // non-JSON body — keep HTTP status as reason
+      }
+      throw new Error(reason);
+    }
+    const result = await resp.json();
+    if (!result.deleted) {
+      throw new Error(result.reason || "server did not confirm deletion");
+    }
 
-    // Unwrap mark in place, restoring plain text
-    const parent = mark.parentNode;
-    if (parent) {
+    // Unwrap ALL marks sharing the same markId — preserves multi-mark groups
+    const marks = markId
+      ? content.querySelectorAll('.annotated[data-mark-id="' + markId + '"]')
+      : [editedMark];
+    for (const mark of marks) {
+      const parent = mark.parentNode;
+      if (!parent) continue;
       while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
       parent.removeChild(mark);
-      parent.normalize();
     }
+    content.normalize();
     dismissPopup();
     renderSidebar();
     showToast("✓ deleted");
   } catch (e) {
-    showToast(`✗ delete failed: ${e.message}`, true);
+    showToast("✗ delete failed: " + e.message, true);
   }
 }
 
 // ── Sidebar: list-of-comments view + click-to-focus ──
 
 function renderSidebar() {
-  const marks = content.querySelectorAll(".annotated");
-  const n = marks.length;
+  const allMarks = content.querySelectorAll(".annotated");
+  // Group by markId so multi-mark logical comments collapse to one sidebar row.
+  // First-seen mark per group is the canonical scroll/focus target.
+  const groups = new Map();
+  for (const mark of allMarks) {
+    if (!mark.dataset.markId) mark.dataset.markId = String(++markIdCounter);
+    if (!groups.has(mark.dataset.markId)) groups.set(mark.dataset.markId, mark);
+  }
+
+  const n = groups.size;
   sidebarCount.textContent = String(n);
   countEl.textContent = String(n);
 
@@ -682,11 +771,11 @@ function renderSidebar() {
     return;
   }
 
-  marks.forEach((mark) => {
-    if (!mark.dataset.markId) mark.dataset.markId = String(++markIdCounter);
+  for (const mark of groups.values()) {
     const item = document.createElement("div");
     item.className = "sidebar-item";
-    item.dataset.targetMarkId = mark.dataset.markId;
+    item.setAttribute("role", "button");
+    item.setAttribute("tabindex", "0");
 
     const anchorEl = document.createElement("div");
     anchorEl.className = "sidebar-item-anchor";
@@ -700,25 +789,58 @@ function renderSidebar() {
     item.appendChild(anchorEl);
     item.appendChild(commentEl);
     item.addEventListener("click", () => focusMark(mark));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        focusMark(mark);
+      }
+    });
     sidebarList.appendChild(item);
-  });
+  }
 }
 
 let pulseTimer = null;
 function focusMark(mark) {
   if (!mark || !mark.isConnected) return;
+  // Clean orphaned pending marks before refocusing — popup may be open with a draft
+  // that the user is abandoning by clicking a sidebar item
+  if (pending && pending.tempMarks && pending.tempMarks.length > 0) {
+    removePendingMarks(pending.tempMarks);
+    pending.tempMarks = [];
+  }
   mark.scrollIntoView({ behavior: "smooth", block: "center" });
   // Clear any in-flight pulse so a fresh click always re-triggers the animation
   document.querySelectorAll(".annotated.pulse").forEach((el) => el.classList.remove("pulse"));
   if (pulseTimer) clearTimeout(pulseTimer);
   // Force reflow before re-adding so the transition restarts
   void mark.offsetWidth;
-  mark.classList.add("pulse");
-  pulseTimer = setTimeout(() => mark.classList.remove("pulse"), 800);
+  // Pulse all marks in the same logical group (multi-mark comments span multiple elements)
+  const markId = mark.dataset.markId;
+  const groupMarks = markId
+    ? document.querySelectorAll('.annotated[data-mark-id="' + markId + '"]')
+    : [mark];
+  groupMarks.forEach((m) => m.classList.add("pulse"));
+  pulseTimer = setTimeout(() => {
+    groupMarks.forEach((m) => m.classList.remove("pulse"));
+  }, 800);
 }
 
 statusCount.addEventListener("click", () => {
-  document.body.classList.toggle("sidebar-open");
+  const opened = document.body.classList.toggle("sidebar-open");
+  statusCount.setAttribute("aria-expanded", opened ? "true" : "false");
+});
+
+// Document-level Esc: dismiss popup if open, otherwise close sidebar.
+// Popup textarea handler runs first and stopPropagation prevents this from firing
+// when the textarea has focus.
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "Escape") return;
+  if (popup.classList.contains("show")) {
+    dismissPopup();
+  } else if (document.body.classList.contains("sidebar-open")) {
+    document.body.classList.remove("sidebar-open");
+    statusCount.setAttribute("aria-expanded", "false");
+  }
 });
 
 // Initial render — empty state on fresh load (no preloaded marks in template)


### PR DESCRIPTION
## Summary
- 디자이너 [@yolohyo](https://github.com/yolohyo) UX 피드백 items 2·3·4 반영 (item 1 highlight 중첩은 후속 `/induce` 세션 분리)
- **Item 2**: JSONL tombstone delete 엔드포인트 + popup 좌측 빨강 Delete 버튼
- **Item 3**: 코멘트 작성 중 dashed blue pending highlight 유지 (in-place promotion으로 save 시 solid yellow 전이)
- **Item 4**: 우측 collapsible 사이드 패널 + 코멘트 리스트 + 클릭 시 본문 mark 포커싱 (box-shadow pulse)

## 주요 결정

- **Tombstone 전략**: append-only invariant 보존을 위해 line-rewrite가 아닌 `{deleted: true, comment: ""}` 항목 append. latest-timestamp-wins dedup 모델이 자연 처리. Downstream 소비자(revision loop)가 delete를 구조적으로 honor하려면 dedup 후 1줄 필터(`entries.filter(e => !e.deleted)`) 추가 필요 — writer 측은 완비
- **Toggle 진입점**: 별도 floating button을 만들지 않고 status bar의 "N comments" 영역 자체를 버튼화. 본문은 sidebar open 여부와 무관하게 viewport 가운데 정렬 유지 (sidebar는 fixed로 우측 overlay)
- **Delete 버튼 패턴**: `.danger` 클래스로 `.primary`와 동등한 specificity 매칭 (이전 base-색이 white로 cascade되던 specificity 버그 해소). base 빨강 + 호버 시 밝은 빨강
- **Pending highlight in-place promotion**: save 시 새 `surroundContents`를 호출하지 않고 기존 temp mark 요소의 className만 교체 — element-crossing 범위에서 두 번째 호출이 동일 실패하는 트랩 회피
- **카운트 통합**: bottom status-count = sidebar count = 현재 마크 수 (이전의 "session adds vs current marks" 차이 제거)

## Item 1 후속 처리

Highlight 중첩 (range-crossing `surroundContents` 한계, `preview.html`에 기록된 documented limitation)은 데이터 모델 결정이 필요한 영역. Pending mark / save / delete 모두 element-crossing 범위에서 graceful fallback (no visual mark, popup만 정상 동작) 유지. 후속 `/induce` 세션에서 추상화 도출 후 별도 PR로 분리.

## Test plan

- [x] 사이드바 토글 (status bar "N comments" 클릭) — 본문 가운데 정렬 유지
- [x] 텍스트 selection → dashed blue highlight 즉시 + 입력 중 유지 → save 시 solid yellow 전환 + 사이드바 항목 추가
- [x] 사이드바 항목 클릭 → 본문 mark scrollIntoView + ~0.8s pulse
- [x] 저장된 mark 클릭 → popup edit 모드 (Submit→"Update", 좌측에 base 빨강 Delete 버튼 노출)
- [x] Delete 클릭 → mark unwrap + 카운트 감소 + 사이드바 항목 제거 + JSONL tombstone 항목 기록
- [x] Range-crossing selection → graceful (popup만 열림, dashed highlight 없음)
- [x] Esc/Cancel → pending highlight 제거 + 평문 복귀
- [x] Cmd+R reload → 스크롤 복원 + 사이드바 collapsed로 시작 + 기존 코멘트 유지
- [x] 정적 검사 (`node .claude/skills/verify/scripts/static-checks.js .`) zero failures, zero warnings

## 변경 파일

- `epistemic-cooperative/skills/artifact-review/scripts/serve.ts` (+46): DELETE 엔드포인트
- `epistemic-cooperative/skills/artifact-review/templates/preview.html` (+~390): pending mark + sidebar + delete affordance + status-count toggle 통합
- `epistemic-cooperative/.claude-plugin/plugin.json`: version 2.5.3 → 2.6.0 (minor — backward-compatible 신규 기능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

