### PR TITLE
docs(all): @yolohyo 기여 인정 — Artifact-review UX 설계

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ For the architecture and principles behind the protocols themselves, read [CLAUD
 
 ## Acknowledgments
 
+- [@yolohyo](https://github.com/yolohyo) — Comment-lifecycle UX design contribution for artifact-review (delete affordance · pending highlight · sidebar list)
 - [@zzsza](https://github.com/zzsza) — Quiz-based participatory UX design contribution for Onboard
 
 ## License

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ For the architecture and principles behind the protocols themselves, read [CLAUD
 
 ## Acknowledgments
 
-- [@yolohyo](https://github.com/yolohyo) — Comment-lifecycle UX design contribution for artifact-review (delete affordance · pending highlight · sidebar list)
+- [@yolohyo](https://github.com/yolohyo) — Comment-lifecycle UX design contribution for artifact-review
 - [@zzsza](https://github.com/zzsza) — Quiz-based participatory UX design contribution for Onboard
 
 ## License

--- a/README_ko.md
+++ b/README_ko.md
@@ -155,6 +155,7 @@ scripts/sync-agents-symlinks.sh
 
 ## 감사의 말
 
+- [@yolohyo](https://github.com/yolohyo) — Artifact-review 코멘트 라이프사이클 UX 설계 기여 (delete affordance · pending highlight · 사이드바 리스트)
 - [@zzsza](https://github.com/zzsza) — Onboard 퀴즈 기반 참여형 UX 설계 기여
 
 ## 라이선스

--- a/README_ko.md
+++ b/README_ko.md
@@ -155,7 +155,7 @@ scripts/sync-agents-symlinks.sh
 
 ## 감사의 말
 
-- [@yolohyo](https://github.com/yolohyo) — Artifact-review 코멘트 라이프사이클 UX 설계 기여 (delete affordance · pending highlight · 사이드바 리스트)
+- [@yolohyo](https://github.com/yolohyo) — Artifact-review 코멘트 라이프사이클 UX 설계 기여
 - [@zzsza](https://github.com/zzsza) — Onboard 퀴즈 기반 참여형 UX 설계 기여
 
 ## 라이선스


### PR DESCRIPTION
## Summary

[@yolohyo](https://github.com/yolohyo) 님께서 `epistemic-cooperative:artifact-review` 의 코멘트 라이프사이클 UX 디자인에 기여해 주셨습니다.

구체적으로 다음 affordance를 제안하셨습니다:
- **Delete affordance** — 저장된 코멘트 삭제 (item 2)
- **Pending highlight 유지** — 코멘트 작성 중 시각적 연속성 (item 3)
- **사이드바 리스트** — 전체 코멘트 조회 + 본문 mark 포커싱 (item 4)
- **Highlight 중첩** — 다중 mark 데이터 모델 (item 1, 후속 작업)

이 피드백은 PR #324 (items 2·3·4 구현) 와 walk-and-wrap 도입 (item 1 시각적 부분 해결) 의 출발점이 되었습니다.

## Test plan

- [x] README.md `## Acknowledgments` 섹션에 알파벳 순으로 추가 (yolohyo before zzsza)
- [x] README_ko.md `## 감사의 말` 섹션에 동일하게 추가
- [x] @zzsza 기여 인정 PR (#158) 의 패턴 (`docs/acknowledgments` 브랜치 + `docs(all):` commit) 동일 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)