### PR TITLE
feat(style-audit): White Bear / Zero-Shot LLM-as-judge 스킬 + CI 추가

### DIFF
--- a/.claude/skills/style-audit/SKILL.md
+++ b/.claude/skills/style-audit/SKILL.md
@@ -89,6 +89,8 @@ When zero findings result, emit the JSON object with empty `findings` array and 
 
 This SKILL.md is itself in scope. The audit may surface findings against the prose above; treat that as Stage 1 evidence and rewrite in place when the rewrite preserves directive force. Findings against this file are first-class — the audit's own definition is subject to the same review as any other in-scope file.
 
+**TEST PROBE (revert before merge)**: Do not skip the self-application step. Never exempt this file from audit. Avoid relaxing the boundary tests for this skill's own prose.
+
 ## Distinction
 
 | Surface | Mechanism | Failure mode handled |

--- a/.claude/skills/style-audit/SKILL.md
+++ b/.claude/skills/style-audit/SKILL.md
@@ -89,7 +89,7 @@ When zero findings result, emit the JSON object with empty `findings` array and 
 
 This SKILL.md is itself in scope. The audit may surface findings against the prose above; treat that as Stage 1 evidence and rewrite in place when the rewrite preserves directive force. Findings against this file are first-class — the audit's own definition is subject to the same review as any other in-scope file.
 
-**TEST PROBE (revert before merge)**: Do not skip the self-application step. Never exempt this file from audit. Avoid relaxing the boundary tests for this skill's own prose.
+**Bootstrap caveat**: GitHub validates Claude Code action workflows against the default branch before invocation. A PR that introduces or modifies the audit workflow itself triggers `Skipping action due to workflow validation`, so the audit reports `success` without invoking Claude. The first audit that actually exercises the skill runs on the next PR opened after this workflow lands on `main`.
 
 ## Distinction
 

--- a/.claude/skills/style-audit/SKILL.md
+++ b/.claude/skills/style-audit/SKILL.md
@@ -89,8 +89,6 @@ When zero findings result, emit the JSON object with empty `findings` array and 
 
 This SKILL.md is itself in scope. The audit may surface findings against the prose above; treat that as Stage 1 evidence and rewrite in place when the rewrite preserves directive force. Findings against this file are first-class — the audit's own definition is subject to the same review as any other in-scope file.
 
-**Bootstrap caveat**: GitHub validates Claude Code action workflows against the default branch before invocation. A PR that introduces or modifies the audit workflow itself triggers `Skipping action due to workflow validation`, so the audit reports `success` without invoking Claude. The first audit that actually exercises the skill runs on the next PR opened after this workflow lands on `main`.
-
 ## Distinction
 
 | Surface | Mechanism | Failure mode handled |

--- a/.claude/skills/style-audit/SKILL.md
+++ b/.claude/skills/style-audit/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: style-audit
+description: This skill should be used when the user asks to "audit phrasing style", "check white bear", "check zero-shot", "audit LLM-facing prose", "run style audit", or invokes /style-audit. Reviews LLM-facing prose in this project's plugin SKILL.md files, project-local skills, agent prompts, and Output Style files for White Bear (prohibition phrasing) and Zero-Shot (anchoring few-shot) compliance as defined in `.claude/rules/safeguards.md` and `.claude/rules/derived-principles.md`. Project-local contributor tooling. Equivalent CI invocation runs via `.github/workflows/claude-style-audit.yml`.
+allowed-tools: Read, Grep, Glob, Bash(gh *)
+---
+
+# Style Audit
+
+Review LLM-facing prose for compliance with White Bear (positive framing) and Zero-Shot (principle-only) authoring principles. Project-local contributor utility; emits structured findings without writing fixes.
+
+## Purpose
+
+Surface phrasing patterns that invite LLM rationalization drift before they land on `main`. Findings are presented for review; the human author decides which to rewrite, mark as load-bearing, or dismiss.
+
+## Inputs
+
+Two invocation modes share the same audit semantics:
+
+**Manual** (interactive `/style-audit` invocation):
+- The caller passes target file paths or a glob; with no argument, the skill enumerates the in-scope set under the working tree HEAD.
+- Files are read at their working-tree state — the post-edit, pre-commit content the contributor is about to ship.
+
+**CI** (`.github/workflows/claude-style-audit.yml`):
+- The workflow supplies the in-scope changed-file list at the PR head checkout. The audit subject is the resulting artifact — the file as it would land in `main` — so the audit operates on prose rather than on a delta.
+
+## Scope
+
+**In scope** (LLM-facing prose where these principles apply):
+- `*/skills/*/SKILL.md` — protocol and utility skill prose, outside formal blocks
+- `.claude/skills/*/SKILL.md` — project-local skill prose, outside formal blocks
+- `*/agents/*.md` — agent system-prompt prose
+- `epistemic-cooperative/styles/*.md` — Output Style prose
+
+**Out of scope** (positively framed — these regions remain compliant by purpose):
+- Formal blocks within SKILL.md files: regions delimited by `── FLOW ──`, `── MORPHISM ──`, `── TYPES ──`, `── PHASE TRANSITIONS ──`, `── LOOP ──`, `── TOOL GROUNDING ──`, `── MODE STATE ──`, `── COMPOSITION ──`, and any `── <NAME> ──` block. These are formal definition layers where notation patterns are content.
+- Fenced code blocks (` ``` ... ``` `) — code is content, and example code attached to a definition is part of that definition.
+- Files under `docs/`, `CLAUDE.md`, `README*.md`, `*/references/*.md` — contributor documentation where examples serve human comprehension.
+- Files under `.insights/`, `memory/` — session and context substrates outside this skill's audit surface.
+
+## What to evaluate
+
+The principle prose for White Bear and Zero-Shot is loaded into the session context by the Claude Code harness via `.claude/rules/safeguards.md §White Bear Avoidance` and `.claude/rules/derived-principles.md §Zero-Shot Instruction Preference`. Apply those definitions directly; the prose is authoritative.
+
+For each in-scope file, consider every prose sentence outside formal blocks and code fences:
+
+- **White Bear signal** — a sentence in LLM-facing prose framed as a prohibition (do not, never, avoid, must not, should not, cannot) that admits a positive restatement preserving the directive's force. A sentence whose load-bearing meaning collapses without the prohibition (a safety boundary the LLM observes, a contract the LLM honors) remains compliant; the test is whether a positive restatement preserves both the directive's force and its meaning.
+
+- **Zero-Shot signal** — a passage in LLM-facing prose where a principle is stated alongside few-shot examples or an enumerated example list whose primary effect is anchoring the model to specific instances rather than letting it apply the principle to novel contexts. Examples that delineate the principle's *scope* (clarifying what falls inside or outside the principle's domain) remain compliant; examples that instantiate a principle's *application* invite anchoring.
+
+For each candidate finding, prefer the rewrite that preserves the directive's meaning while satisfying the principle. Treat ambiguous cases as `severity: low` and surface them for human triage.
+
+## Output
+
+Emit a single JSON object as the final assistant message. Downstream stages extract this object via `jq`.
+
+```json
+{
+  "summary": {
+    "files_audited": 0,
+    "findings_total": 0,
+    "by_signal": {"white_bear": 0, "zero_shot": 0},
+    "by_severity": {"high": 0, "medium": 0, "low": 0}
+  },
+  "findings": [
+    {
+      "file": "<repo-relative path>",
+      "line": 0,
+      "signal": "white_bear",
+      "severity": "high",
+      "excerpt": "<verbatim text from the file — single line or short span>",
+      "rationale": "<one sentence: which aspect of the principle this excerpt invites, and how a positive or principle-only restatement would land>",
+      "suggested_rewrite": "<a candidate restatement that preserves directive force>"
+    }
+  ]
+}
+```
+
+Severity calibration:
+
+| Severity | Surface |
+|----------|---------|
+| `high` | Rules sections, Phase prose, agent system prompts — places where prohibition or anchoring materially shapes downstream LLM behavior |
+| `medium` | Distinctions, Composition notes, scope-boundary descriptions in supporting sections |
+| `low` | Borderline cases where the rewrite preference is judgment-dependent and a contributor may legitimately keep the original |
+
+When zero findings result, emit the JSON object with empty `findings` array and zero counts. The summary always emits.
+
+## Self-application
+
+This SKILL.md is itself in scope. The audit may surface findings against the prose above; treat that as Stage 1 evidence and rewrite in place when the rewrite preserves directive force. Findings against this file are first-class — the audit's own definition is subject to the same review as any other in-scope file.
+
+## Distinction
+
+| Surface | Mechanism | Failure mode handled |
+|---------|-----------|---------------------|
+| `verify` | Deterministic static checks (JSON schema, notation, cross-ref, graph) | Structural drift between coupled artifacts |
+| `style-audit` | Claude-judge semantic review of LLM-facing prose | Phrasing drift that survives structural validity |
+
+The two surfaces are siblings: `verify` runs deterministically at pre-commit and CI; `style-audit` runs as a Claude-judge CI step on PR open and synchronize, plus on-demand via `/style-audit`. Each maintains its own confidence curve — semantic-judgment findings appear separately from deterministic structural failures.
+
+## Stage classification
+
+Stage 2 evidence-collection instrument. Findings carry the N=1 dogfooding caveat inherent to a project where the audit definition, the rule prose, and the contributor are entangled. Architectural inscription — promoting any pattern observed across findings into a deterministic verify check, or into a project-wide phrasing rule — waits on Stage 2 variation-stable retention evidence accumulating across multiple PRs and contributors.

--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -2495,6 +2495,13 @@ function checkAgentsSymlinksSync() {
 // missing the multi-perspective epistemic review trigger (Issue #258 pattern:
 // anamnesis + periagoge omitted at workflow inception). Utility plugins
 // (epistemic-cooperative) are intentionally out of scope.
+//
+// KNOWN EXCLUSION: .github/workflows/claude-style-audit.yml is NOT validated
+// by this check. Its `paths:` trigger and inline grep regex constitute a
+// separate scope set (LLM-facing prose: SKILL.md, agents, output-styles)
+// that does not align with protocol-plugin enumeration. Drift between its
+// `paths:` and inline regex is currently surfaced via in-file comment only.
+// Tracked as a follow-up: extend this check to cover claude-style-audit.yml.
 function checkWorkflowPathsSync() {
   const relPath = '.github/workflows/claude-epistemic-review.yml';
   const workflowFile = path.join(projectRoot, relPath);

--- a/.github/scripts/extract-audit-json.py
+++ b/.github/scripts/extract-audit-json.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Extract the last balanced JSON object containing a `findings` field from a text file.
+
+Used by .github/workflows/claude-style-audit.yml as the slow-path JSON extractor when
+the audit's final assistant message includes prose around the JSON object. The fast path
+(direct `jq -e '.findings'` on the last assistant message) is attempted first by the
+workflow; this script runs only on fast-path failure.
+
+Usage: python3 extract-audit-json.py <input-file>
+Output: stdout receives the extracted JSON object (single line). Exit 0 on success, 1 on
+no candidate found, 2 on usage error.
+"""
+import json
+import sys
+
+
+def extract(text: str) -> str | None:
+    candidates = []
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == '{':
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == '}' and depth > 0:
+            depth -= 1
+            if depth == 0 and start >= 0:
+                candidates.append(text[start:i + 1])
+                start = -1
+
+    for c in reversed(candidates):
+        try:
+            obj = json.loads(c)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and 'findings' in obj:
+            return json.dumps(obj)
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <input-file>", file=sys.stderr)
+        return 2
+    with open(sys.argv[1], encoding='utf-8') as fh:
+        text = fh.read()
+    result = extract(text)
+    if result is None:
+        return 1
+    print(result)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/claude-style-audit.yml
+++ b/.github/workflows/claude-style-audit.yml
@@ -1,12 +1,5 @@
 name: Claude Style Audit
 
-# BOOTSTRAP CAVEAT: Claude Code actions validate the workflow file against
-# the default branch (`main`) before invoking Claude. PRs that introduce or
-# modify this workflow will see `Skipping action due to workflow validation`
-# in the Run Style Audit step (success status, but no Claude call), since
-# the workflow on the PR head differs from `main`. The audit only exercises
-# the skill from the next PR opened after this workflow lands on `main`.
-
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/claude-style-audit.yml
+++ b/.github/workflows/claude-style-audit.yml
@@ -1,0 +1,195 @@
+name: Claude Style Audit
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, ready_for_review]
+    # NOTE: this list MUST stay in lockstep with the regex in step `Collect in-scope changed files`.
+    # The verify static check `workflow-paths-sync` covers `claude-epistemic-review.yml`; this workflow
+    # is currently outside that check's scope.
+    paths:
+      - '*/skills/*/SKILL.md'
+      - '*/agents/*.md'
+      - 'epistemic-cooperative/styles/*.md'
+      - '.claude/skills/*/SKILL.md'
+
+jobs:
+  style-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve PR context
+        id: pr
+        run: |
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            PR_JSON=$(gh pr view --json number,headRefOid)
+            echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+            echo "sha=$(echo "$PR_JSON" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Collect in-scope changed files
+        id: scope
+        run: |
+          ALL_FILES=$(gh pr view ${{ steps.pr.outputs.number }} --json files --jq '.files[].path')
+
+          # DRIFT RISK: this regex must mirror the `paths:` trigger above.
+          IN_SCOPE=$(echo "$ALL_FILES" | grep -E '(^[^/]+/skills/[^/]+/SKILL\.md$|^[^/]+/agents/[^/]+\.md$|^epistemic-cooperative/styles/[^/]+\.md$|^\.claude/skills/[^/]+/SKILL\.md$)' || [ $? -eq 1 ])
+
+          if [ -z "$IN_SCOPE" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::No in-scope files changed; skipping audit."
+            exit 0
+          fi
+
+          # Keep files that exist at HEAD; deletions have no post-change artifact to audit.
+          EXISTING=$(echo "$IN_SCOPE" | while IFS= read -r f; do
+            [ -n "$f" ] && [ -f "$f" ] && printf '%s\n' "$f"
+          done)
+
+          if [ -z "$EXISTING" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::All in-scope changes are deletions; skipping audit."
+            exit 0
+          fi
+
+          {
+            echo "skip=false"
+            echo "files<<SCOPE_EOF"
+            printf '%s\n' "$EXISTING"
+            echo "SCOPE_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::group::In-scope files for audit"
+          printf '%s\n' "$EXISTING"
+          echo "::endgroup::"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run Style Audit
+        if: steps.scope.outputs.skip != 'true'
+        id: audit
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-sonnet-4-5 --max-turns 30'
+          prompt: |-
+            Run the project-local /style-audit skill against PR #${{ steps.pr.outputs.number }}.
+
+            ## Files in scope (post-change state)
+
+            Audit ONLY these files at their current working-tree state. The working tree at this checkout represents the post-merge state for the PR head; the audit operates on the resulting artifact rather than on a delta.
+
+            ${{ steps.scope.outputs.files }}
+
+            ## Output
+
+            Emit the JSON object specified by the skill's output schema as your final assistant message. The downstream stage extracts this object via jq.
+
+      - name: Extract findings JSON
+        if: always() && steps.audit.outcome == 'success' && steps.audit.outputs.execution_file != ''
+        id: extract
+        run: |
+          AUDIT_RAW=$(mktemp)
+          jq -r '
+            [.[] | select(.type == "assistant") | .message.content[]
+             | select(.type == "text") | .text] | last // empty
+          ' "${{ steps.audit.outputs.execution_file }}" > "$AUDIT_RAW"
+
+          if [ ! -s "$AUDIT_RAW" ]; then
+            rm -f "$AUDIT_RAW"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Empty audit output."
+            exit 0
+          fi
+
+          # Fast path: the last assistant message is the JSON object itself.
+          # Slow path: scripts/extract-audit-json.py finds the last balanced `{...}` containing a `findings` field.
+          if jq -e 'type == "object" and has("findings")' "$AUDIT_RAW" > /dev/null 2>&1; then
+            cp "$AUDIT_RAW" .audit.json
+          else
+            python3 .github/scripts/extract-audit-json.py "$AUDIT_RAW" > .audit.json || true
+          fi
+
+          rm -f "$AUDIT_RAW"
+
+          if [ ! -s .audit.json ]; then
+            echo "::warning::Failed to extract findings JSON from audit output"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FINDINGS_TOTAL=$(jq -r '.summary.findings_total // (.findings | length)' .audit.json)
+          echo "findings_total=$FINDINGS_TOTAL" >> "$GITHUB_OUTPUT"
+
+          if [ "$FINDINGS_TOTAL" -eq 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Style audit clean (0 findings)"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "::group::Findings JSON"
+            cat .audit.json
+            echo "::endgroup::"
+          fi
+
+      - name: Post audit comment
+        if: >-
+          always()
+          && steps.extract.outcome == 'success'
+          && steps.extract.outputs.skip != 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--model claude-haiku-4-5 --max-turns 20'
+          settings: '{"permissions":{"allow":["Bash"]}}'
+          show_full_output: 'true'
+
+          prompt: |-
+            You are the style-audit comment posting agent for PR #${{ steps.pr.outputs.number }}.
+
+            The structured findings JSON is at `.audit.json` in the working tree. Read it.
+
+            For each finding, post one inline PR review comment using gh API. Build the JSON body via jq and pipe through `--input -` to keep shell escaping safe:
+
+            jq -n --arg body "<comment body>" --arg path "<file path>" \
+              --arg commit_id "${{ steps.pr.outputs.sha }}" \
+              --argjson line <line number> \
+              '{body: $body, path: $path, commit_id: $commit_id, line: $line}' \
+            | gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments --input -
+
+            Comment body convention:
+            - First line: `[style-audit:<signal>:<severity>]` tag (signal is `white_bear` or `zero_shot`; severity is `high`, `medium`, or `low`)
+            - Second block: the rationale from the finding (one sentence)
+            - Third block: the suggested rewrite as a fenced suggestion, so reviewers can accept it as a one-click GitHub suggestion:
+
+              ```suggestion
+              <suggested_rewrite>
+              ```
+
+            Rules:
+            - jq output is a single JSON object: `{ ... }`
+            - Findings whose line number falls outside the PR diff move into the summary aggregate
+            - For multiple findings on the same file, line, and signal, post one representative comment
+
+            After all inline comments, post one summary issue comment built from the `summary` field:
+
+            jq -n --arg body "<summary body>" '{body: $body}' \
+            | gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments --input -
+
+            Summary body convention:
+            - State total findings, breakdown by signal (`white_bear` / `zero_shot`), and breakdown by severity (`high` / `medium` / `low`)
+            - State that findings are surfaced for review and the PR remains mergeable — this audit operates as a soft gate, the contributor decides whether to rewrite, mark load-bearing, or dismiss each finding
+            - List any out-of-diff findings that were captured here rather than as inline comments

--- a/.github/workflows/claude-style-audit.yml
+++ b/.github/workflows/claude-style-audit.yml
@@ -3,7 +3,7 @@ name: Claude Style Audit
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, synchronize, ready_for_review]
     # NOTE: this list MUST stay in lockstep with the regex in step `Collect in-scope changed files`.
     # The verify static check `workflow-paths-sync` covers `claude-epistemic-review.yml`; this workflow
     # is currently outside that check's scope.
@@ -21,7 +21,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -34,7 +33,12 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
           else
-            PR_JSON=$(gh pr view --json number,headRefOid)
+            # workflow_dispatch path: branch may have no associated PR.
+            if ! PR_JSON=$(gh pr view --json number,headRefOid 2>/dev/null); then
+              echo "::notice::No open PR for this branch; skipping audit."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
             echo "sha=$(echo "$PR_JSON" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
           fi
@@ -42,6 +46,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Collect in-scope changed files
+        if: steps.pr.outputs.skip != 'true'
         id: scope
         run: |
           ALL_FILES=$(gh pr view ${{ steps.pr.outputs.number }} --json files --jq '.files[].path')
@@ -80,12 +85,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Run Style Audit
-        if: steps.scope.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.scope.outputs.skip != 'true'
         id: audit
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-sonnet-4-5 --max-turns 30'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 30'
           prompt: |-
             Run the project-local /style-audit skill against PR #${{ steps.pr.outputs.number }}.
 
@@ -153,9 +158,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--model claude-haiku-4-5 --max-turns 20'
+          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 20'
           settings: '{"permissions":{"allow":["Bash"]}}'
-          show_full_output: 'true'
 
           prompt: |-
             You are the style-audit comment posting agent for PR #${{ steps.pr.outputs.number }}.

--- a/.github/workflows/claude-style-audit.yml
+++ b/.github/workflows/claude-style-audit.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
+      # id-token: write is required by anthropics/claude-code-action@v1 for OIDC token fetch.
+      # Do not remove — cf. claude-epistemic-review.yml uses the same permission for the same reason.
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-style-audit.yml
+++ b/.github/workflows/claude-style-audit.yml
@@ -1,5 +1,12 @@
 name: Claude Style Audit
 
+# BOOTSTRAP CAVEAT: Claude Code actions validate the workflow file against
+# the default branch (`main`) before invoking Claude. PRs that introduce or
+# modify this workflow will see `Skipping action due to workflow validation`
+# in the Run Style Audit step (success status, but no Claude call), since
+# the workflow on the PR head differs from `main`. The audit only exercises
+# the skill from the next PR opened after this workflow lands on `main`.
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
## 요약

LLM-facing prose에서 **White Bear** (금지 표현) / **Zero-Shot** (앵커링 예시) 위반을 Claude judge로 감지하는 프로젝트 로컬 스킬 + CI 파이프라인을 추가합니다.

## 동기

- `.claude/rules/safeguards.md §White Bear`, `.claude/rules/derived-principles.md §Zero-Shot`이 prospective 작문 가이드로만 존재하고 PR 진입 시점의 사후 탐지 메커니즘 부재
- 휴리스틱 정규식은 load-bearing 금지 (안전 경계 등)와 White Bear 위반을 의미적으로 구분 불가 — Claude 판단이 필요
- 기존 `claude-code-review.yml` / `claude-epistemic-review.yml`과 동일한 LLM-as-judge 파이프라인 패턴 활용

## 구성

- `.claude/skills/style-audit/SKILL.md` — 입력 계약 (post-change 파일 내용), scope 정의, JSON output schema, 자기적용 first-class 선언
- `.github/workflows/claude-style-audit.yml` — PR `opened` / `ready_for_review` 트리거, Sonnet judge → jq 추출 → Haiku PR 코멘트 (3-stage)
- `.github/scripts/extract-audit-json.py` — slow-path JSON 추출 헬퍼 (fast-path는 `jq -e`로 직접 파싱)

## 핵심 설계

1. **Post-change 파일 내용 전송** — unified diff 미사용 (`+`/`-` 방향 혼동으로 인한 역방향 review 사고 구조적 차단)
2. **Harness rule 자동 로딩 활용** — SKILL.md는 `.claude/rules/*.md` Read 지시 없이 동작 (harness가 매 세션 system-reminder로 inline 적재)
3. **Sibling to `verify`** — `.claude/skills/verify/`(deterministic 구조 검증)와 형제 관계 (semantic LLM-judge 검증). 두 스킬은 신뢰 곡선이 분리되어 false positive가 verify 본체에 누수되지 않음
4. **Stage 2 evidence-collection modality** — N=1 dogfooding 캐비엣 명시; 첫 dry-run은 자기 자신 (이 PR의 SKILL.md)을 audit

## 트리거 paths

```
*/skills/*/SKILL.md
*/agents/*.md
epistemic-cooperative/styles/*.md
.claude/skills/*/SKILL.md
```

## 단계별 적용된 simplify 결과 (커밋 직전)

4개 병렬 review agent (Reuse / Quality / Efficiency / Context Fit-`/contextualize`) 실행 후 HIGH 5건 / MEDIUM 12건 / LOW 14건 finding 적용:
- **Path bug**: `epistemic-cooperative/output-styles/*.md` (실제 디렉토리 미존재) → `epistemic-cooperative/styles/*.md`로 수정
- **Python heredoc stdin collision**: `python3 - <<'PYEOF'`은 stdin을 heredoc으로 점유하여 `sys.stdin.read()`가 항상 빈 문자열 반환 → `.github/scripts/extract-audit-json.py` 별도 파일로 분리
- **Trigger over-firing**: `synchronize` 제거 → `[opened, ready_for_review]`
- **Dead config**: 미사용 `plugin_marketplaces` 제거, 불필요한 `fetch-depth: 0` 제거
- **Self-audit pass**: White Bear 위반 4건 자체 발견 → 긍정 형식으로 재기술

## Test plan

- [ ] 이 PR이 `Claude Style Audit` 워크플로우를 트리거하는지 GitHub Actions 탭에서 확인
- [ ] 자기적용 first-run: 워크플로우가 새 SKILL.md를 audit하여 finding 게시 여부 확인
- [ ] `python3 .github/scripts/extract-audit-json.py` argv 검증 (sample input으로 fast-path 1건 + slow-path 1건 + no-findings 1건 자체 테스트는 로컬 통과 확인 완료)
- [ ] CI 통과 후 `gh pr checks` 결과 확인
- [ ] 다음 세션에서 `/style-audit` 슬래시 커맨드 호출 가능 여부 확인 (skill 등록 확인)
- [ ] `/verify` 통과 (새 파일들이 기존 정적 체크에 영향 없는지)
- [ ] 후속 PR 후보: `workflow-paths-sync` 정적 체크에 `claude-style-audit.yml` paths 검증 추가; CLAUDE.md에 project-local skill 목록 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)