### PR TITLE
feat(verify): workflow-paths-sync 체크에 claude-style-audit.yml 추가

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -2490,19 +2490,38 @@ function checkAgentsSymlinksSync() {
 // ============================================================
 // Check 19: Workflow Paths Sync
 // ============================================================
-// Verifies .github/workflows/claude-epistemic-review.yml `paths` includes
-// every protocol plugin directory. Prevents new protocols from silently
-// missing the multi-perspective epistemic review trigger (Issue #258 pattern:
-// anamnesis + periagoge omitted at workflow inception). Utility plugins
-// (epistemic-cooperative) are intentionally out of scope.
+// Verifies that PR-triggered Claude-judge workflows declare the right `paths:`
+// triggers so new content is not silently missed.
 //
-// KNOWN EXCLUSION: .github/workflows/claude-style-audit.yml is NOT validated
-// by this check. Its `paths:` trigger and inline grep regex constitute a
-// separate scope set (LLM-facing prose: SKILL.md, agents, output-styles)
-// that does not align with protocol-plugin enumeration. Drift between its
-// `paths:` and inline regex is currently surfaced via in-file comment only.
-// Tracked as a follow-up: extend this check to cover claude-style-audit.yml.
+// Two workflows are validated:
+//
+// - .github/workflows/claude-epistemic-review.yml: `paths:` must enumerate
+//   every protocol plugin directory (Issue #258 pattern: anamnesis + periagoge
+//   omitted at workflow inception). Utility plugins (epistemic-cooperative)
+//   are intentionally out of scope.
+//
+// - .github/workflows/claude-style-audit.yml: `paths:` must declare the four
+//   LLM-facing prose scopes, AND the inline grep regex in `Collect in-scope
+//   changed files` must mirror those globs (drift prevention between the
+//   trigger filter and the runtime filter).
 function checkWorkflowPathsSync() {
+  checkEpistemicReviewPaths();
+  checkStyleAuditPaths();
+}
+
+function parsePathsBlock(content) {
+  const pathsBlockMatch = content.match(/^\s+paths:\s*\n((?:\s+-\s+'[^']+'\s*\n)+)/m);
+  if (!pathsBlockMatch) return null;
+  const declared = new Set();
+  const pathLineRe = /-\s+'([^']+)'/g;
+  let m;
+  while ((m = pathLineRe.exec(pathsBlockMatch[1])) !== null) {
+    declared.add(m[1]);
+  }
+  return declared;
+}
+
+function checkEpistemicReviewPaths() {
   const relPath = '.github/workflows/claude-epistemic-review.yml';
   const workflowFile = path.join(projectRoot, relPath);
 
@@ -2516,21 +2535,14 @@ function checkWorkflowPathsSync() {
   }
 
   const content = fs.readFileSync(workflowFile, 'utf8');
-  const pathsBlockMatch = content.match(/^\s+paths:\s*\n((?:\s+-\s+'[^']+'\s*\n)+)/m);
-  if (!pathsBlockMatch) {
+  const declaredPaths = parsePathsBlock(content);
+  if (!declaredPaths) {
     results.fail.push({
       check: 'workflow-paths-sync',
       file: relPath,
       message: 'on.pull_request.paths block not found or unparseable',
     });
     return;
-  }
-
-  const declaredPaths = new Set();
-  const pathLineRe = /-\s+'([^']+)'/g;
-  let m;
-  while ((m = pathLineRe.exec(pathsBlockMatch[1])) !== null) {
-    declaredPaths.add(m[1]);
   }
 
   const expected = PROTOCOL_FILES.map(p => p.split('/')[0]);
@@ -2550,6 +2562,97 @@ function checkWorkflowPathsSync() {
         message: `Missing protocol path — add "- '${name}/**'" under on.pull_request.paths so ${name} PRs trigger epistemic review`,
       });
     }
+  }
+}
+
+// Canonical scope set for style-audit. Each entry pairs the YAML glob with
+// the regex alternative that must appear in the `Collect in-scope changed
+// files` step's grep -E pattern.
+const STYLE_AUDIT_SCOPE = [
+  {
+    glob: '*/skills/*/SKILL.md',
+    regexFragment: '^[^/]+/skills/[^/]+/SKILL\\.md$',
+  },
+  {
+    glob: '*/agents/*.md',
+    regexFragment: '^[^/]+/agents/[^/]+\\.md$',
+  },
+  {
+    glob: 'epistemic-cooperative/styles/*.md',
+    regexFragment: '^epistemic-cooperative/styles/[^/]+\\.md$',
+  },
+  {
+    glob: '.claude/skills/*/SKILL.md',
+    regexFragment: '^\\.claude/skills/[^/]+/SKILL\\.md$',
+  },
+];
+
+function checkStyleAuditPaths() {
+  const relPath = '.github/workflows/claude-style-audit.yml';
+  const workflowFile = path.join(projectRoot, relPath);
+
+  if (!fs.existsSync(workflowFile)) {
+    results.fail.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: 'Missing — claude-style-audit.yml not found',
+    });
+    return;
+  }
+
+  const content = fs.readFileSync(workflowFile, 'utf8');
+
+  const declaredPaths = parsePathsBlock(content);
+  if (!declaredPaths) {
+    results.fail.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: 'on.pull_request.paths block not found or unparseable',
+    });
+    return;
+  }
+
+  const inlineGrepMatch = content.match(/grep -E '\(([^']+)\)'/);
+  if (!inlineGrepMatch) {
+    results.fail.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: 'Inline grep regex not found in `Collect in-scope changed files` step — required to keep runtime filter in lockstep with paths: trigger',
+    });
+    return;
+  }
+  const regexBody = inlineGrepMatch[1];
+
+  const missingPaths = STYLE_AUDIT_SCOPE
+    .filter(({ glob }) => !declaredPaths.has(glob))
+    .map(({ glob }) => glob);
+
+  const missingRegex = STYLE_AUDIT_SCOPE
+    .filter(({ regexFragment }) => !regexBody.includes(regexFragment))
+    .map(({ regexFragment }) => regexFragment);
+
+  if (missingPaths.length === 0 && missingRegex.length === 0) {
+    results.pass.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: `All ${STYLE_AUDIT_SCOPE.length} scope patterns mirrored in paths: trigger and inline regex`,
+    });
+    return;
+  }
+
+  for (const glob of missingPaths) {
+    results.fail.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: `Missing scope pattern in paths: trigger — add "- '${glob}'" so style-audit fires for that scope`,
+    });
+  }
+  for (const fragment of missingRegex) {
+    results.fail.push({
+      check: 'workflow-paths-sync',
+      file: relPath,
+      message: `Inline grep regex missing alternative "${fragment}" — keep the runtime filter in lockstep with the paths: trigger`,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- 디자이너 UX 피드백 items 2·3·4 반영 (item 1 highlight 중첩은 후속 `/induce` 세션 분리)
- **Item 2**: JSONL tombstone delete 엔드포인트 + popup 좌측 빨강 Delete 버튼
- **Item 3**: 코멘트 작성 중 dashed blue pending highlight 유지 (in-place promotion으로 save 시 solid yellow 전이)
- **Item 4**: 우측 collapsible 사이드 패널 + 코멘트 리스트 + 클릭 시 본문 mark 포커싱 (box-shadow pulse)

## 주요 결정

- **Tombstone 전략**: append-only invariant 보존을 위해 line-rewrite가 아닌 `{deleted: true, comment: ""}` 항목 append. latest-timestamp-wins dedup 모델이 자연 처리. Downstream 소비자(revision loop)가 delete를 구조적으로 honor하려면 dedup 후 1줄 필터(`entries.filter(e => !e.deleted)`) 추가 필요 — writer 측은 완비
- **Toggle 진입점**: 별도 floating button을 만들지 않고 status bar의 "N comments" 영역 자체를 버튼화. 본문은 sidebar open 여부와 무관하게 viewport 가운데 정렬 유지 (sidebar는 fixed로 우측 overlay)
- **Delete 버튼 패턴**: `.danger` 클래스로 `.primary`와 동등한 specificity 매칭 (이전 base-색이 white로 cascade되던 specificity 버그 해소). base 빨강 + 호버 시 밝은 빨강
- **Pending highlight in-place promotion**: save 시 새 `surroundContents`를 호출하지 않고 기존 temp mark 요소의 className만 교체 — element-crossing 범위에서 두 번째 호출이 동일 실패하는 트랩 회피
- **카운트 통합**: bottom status-count = sidebar count = 현재 마크 수 (이전의 "session adds vs current marks" 차이 제거)

## Item 1 후속 처리

Highlight 중첩 (range-crossing `surroundContents` 한계, `preview.html`에 기록된 documented limitation)은 데이터 모델 결정이 필요한 영역. Pending mark / save / delete 모두 element-crossing 범위에서 graceful fallback (no visual mark, popup만 정상 동작) 유지. 후속 `/induce` 세션에서 추상화 도출 후 별도 PR로 분리.

## Test plan

- [x] 사이드바 토글 (status bar "N comments" 클릭) — 본문 가운데 정렬 유지
- [x] 텍스트 selection → dashed blue highlight 즉시 + 입력 중 유지 → save 시 solid yellow 전환 + 사이드바 항목 추가
- [x] 사이드바 항목 클릭 → 본문 mark scrollIntoView + ~0.8s pulse
- [x] 저장된 mark 클릭 → popup edit 모드 (Submit→"Update", 좌측에 base 빨강 Delete 버튼 노출)
- [x] Delete 클릭 → mark unwrap + 카운트 감소 + 사이드바 항목 제거 + JSONL tombstone 항목 기록
- [x] Range-crossing selection → graceful (popup만 열림, dashed highlight 없음)
- [x] Esc/Cancel → pending highlight 제거 + 평문 복귀
- [x] Cmd+R reload → 스크롤 복원 + 사이드바 collapsed로 시작 + 기존 코멘트 유지
- [x] 정적 검사 (`node .claude/skills/verify/scripts/static-checks.js .`) zero failures, zero warnings

## 변경 파일

- `epistemic-cooperative/skills/artifact-review/scripts/serve.ts` (+46): DELETE 엔드포인트
- `epistemic-cooperative/skills/artifact-review/templates/preview.html` (+~390): pending mark + sidebar + delete affordance + status-count toggle 통합
- `epistemic-cooperative/.claude-plugin/plugin.json`: version 2.5.3 → 2.6.0 (minor — backward-compatible 신규 기능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
