### PR TITLE
docs(CLAUDE.md): project-local skill 목록 명시 — verify / style-audit / audit-delta / release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,11 @@ In this repository, that machinery is realized as a Claude Code plugin marketpla
 ```
 epistemic-protocols/
 ├── .claude-plugin/marketplace.json    # Marketplace manifest
-├── .claude/skills/verify/             # Project-level verification skill
+├── .claude/skills/                    # Project-local skills (contributor tooling, not packaged)
+│   ├── verify/        (/verify)       # 20-check static verification (deterministic)
+│   ├── style-audit/   (/style-audit)  # White Bear / Zero-Shot LLM-as-judge phrasing audit (CI at PR time)
+│   ├── audit-delta/   (/audit-delta)  # Periodic audit progress tracker (issues + commit activity)
+│   └── release/       (/release)      # CalVer tag + narrative release
 │
 │   # Each protocol plugin: .claude-plugin/plugin.json + skills/<verb>/SKILL.md
 ├── prothesis/       (/frame)          # multi-perspective investigation
@@ -66,7 +70,11 @@ epistemic-protocols/
 | Epharmoge | `/contextualize` | ApplicationDecontextualized → ContextualizedExecution |
 | Anamnesis | `/recollect` | RecallAmbiguous → RecalledContext |
 
-**Utility skills**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/probe`, `/dashboard`, `/compose`, `/introspect`, `/sophia`, `/curses`, `/write`, `/comment-review`, `/review-ensemble`, `/steer`, `/misuse`, `/crystallize`, `/rehydrate`), Verify (`/verify`). Triggers, flows, and detailed descriptions in each plugin's SKILL.md.
+**Utility skills**:
+- **Plugin (distributed via marketplace)**: Epistemic Cooperative (`/catalog`, `/report`, `/onboard`, `/probe`, `/dashboard`, `/compose`, `/introspect`, `/sophia`, `/curses`, `/write`, `/comment-review`, `/review-ensemble`, `/steer`, `/misuse`, `/crystallize`, `/rehydrate`).
+- **Project-local** (`.claude/skills/`, contributor tooling, not packaged): `/verify` (deterministic 20-check static verification, pre-commit + on-demand), `/style-audit` (semantic LLM-as-judge phrasing audit at PR time, sibling to verify), `/audit-delta` (periodic audit progress tracker), `/release` (CalVer tag + narrative release).
+
+Triggers, flows, and detailed descriptions in each plugin's SKILL.md or `.claude/skills/<name>/SKILL.md`.
 
 **Probe utility (deficit recognition fit review)**: `/probe` (epistemic-cooperative) surfaces multiple candidate deficit hypotheses with reverse-evidence conditions when the user is uncertain which protocol fits the present situation. Probe is a utility skill, not a 13th core protocol — it is intentionally absent from `graph.json`. Coexistence over Mirroring applies: `/probe` may enrich scans with prior `misfit.md` records via opt-in cross-session read (default scope is current session; cross-session recall requires explicit user confirmation) and routes the user's recognized choice to the selected core protocol; the relationship is prose-level, not a graph.json edge. Probe stands in structural homology with Anamnesis (RECOGNIZE operation family — past context recognition vs present-situation deficit recognition) but the homology is descriptive, not enforced as advisory edges. Stage 2 evidence-collection modality: probe is released as a usage-evidence instrument; **architectural inscription** (new core protocol, new `graph.json` edge, category-level promotion) is deferred until Stage 2 variation-stable retention evidence accumulates. **Type-level realization** of an already-inscribed `── COMPOSITION ──` product within an existing protocol's operational scope is evidence-collection modality internal iteration and does not require Stage 2 deferral framing — the distinction prevents the false-positive gating pattern recorded in issue #295. Verification framework limitations (drop-in feasibility vs endpoint well-defined-ness — two-axis distinction) tracked in [docs/probe-verification-framework.md](docs/probe-verification-framework.md) — N=1 instance L4a (PR #288), Stage 2 corroboration pending.
 


### PR DESCRIPTION
## 요약

CLAUDE.md의 architecture 다이어그램과 "Utility skills" 섹션이 verify만 단독 언급하고 `audit-delta`, `style-audit`, `release`는 누락된 상태였습니다. PR #329 (`/style-audit` 도입)을 반영하면서 `.claude/skills/` 하위 4개 project-local skill을 모두 명시합니다.

## 동기

PR #329 머지 시점에 `style-audit`이 신설되었지만 CLAUDE.md는 갱신되지 않았습니다. 또한 기존부터 누락된 `audit-delta`(주기적 audit progress tracker)와 `release`(CalVer release skill)도 함께 명시 — contributor가 CLAUDE.md만 읽고도 project-local skill 카탈로그를 즉시 파악할 수 있도록.

## 변경 내용

### Architecture 다이어그램 (line 16)

**이전**: 단일 라인 — `├── .claude/skills/verify/             # Project-level verification skill`

**이후**: 4-skill 블록
```
├── .claude/skills/                    # Project-local skills (contributor tooling, not packaged)
│   ├── verify/        (/verify)       # 20-check static verification (deterministic)
│   ├── style-audit/   (/style-audit)  # White Bear / Zero-Shot LLM-as-judge phrasing audit (CI at PR time)
│   ├── audit-delta/   (/audit-delta)  # Periodic audit progress tracker (issues + commit activity)
│   └── release/       (/release)      # CalVer tag + narrative release
```

### Utility skills 섹션 (line 69)

**이전**: 단일 평문 라인 — Epistemic Cooperative 와 Verify 를 한 줄에 나열

**이후**: 두 그룹으로 split
- **Plugin (distributed via marketplace)**: Epistemic Cooperative 16개 슬래시 명령
- **Project-local** (`.claude/skills/`, contributor tooling, not packaged): `/verify`, `/style-audit`, `/audit-delta`, `/release` — 각각 한 줄 역할 설명

이 split은 packaging 경계를 명시 — plugin skill은 marketplace install로 외부 사용자에게 도달하지만, project-local skill은 이 repo의 contributor만 사용.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 103 pass / 0 fail / 0 warn

## Test plan

- [ ] PR이 `Claude Style Audit` 워크플로우를 트리거 — CLAUDE.md는 in-scope path가 아니므로 트리거 안 됨이 정상 (skip notice). 별도 audit이 작동하는지는 다른 PR에서 검증 (#330, #331)
- [ ] `gh pr checks` 통과
- [ ] 후속: contributor가 새 project-local skill 추가 시 CLAUDE.md 동기화 누락 방지 정적 체크 (선택; rule of three 도달 시 고려)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
