### PR TITLE
feat(anamnesis): MarkerProfile 추출 정규식 → Haiku 마이그레이션

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -41,8 +41,13 @@ const MAX_ALL_CHARS = 80_000;
 const HAIKU_TIMEOUT = 120_000;
 
 // v0.4.0 two-track extension budgets.
-// Soft cap on deterministic extract/detect/coinage; the haiku calls above are
-// bounded separately by HAIKU_TIMEOUT and are unaffected by this budget.
+// Soft cap on deterministic extract/coinage; the haiku calls (clue, vector,
+// narrative, markers) are bounded separately by HAIKU_TIMEOUT and are
+// unaffected by this budget.
+//
+// v0.4.24: MarkerProfile salience markers (actor/temporal/emotional/cognitive/
+// singularity) migrated from regex to Haiku LLM extraction; coinage remains
+// deterministic (Zipf-statistical, defined in SKILL.md ── SALIENCE MARKERS ──).
 const TWO_TRACK_BUDGET_MS = 5_000;
 const COINAGE_MIN_REMAINING_MS = 500;
 const COINAGE_PRECISION_THRESHOLD = 0.5;
@@ -281,6 +286,39 @@ Session content:
 ${sample}`;
 }
 
+function buildMarkerPrompt(allTexts, startedAt) {
+  const sample = allTexts.join("\n---\n").slice(0, 30_000);
+  const dateAnchor = (startedAt && startedAt.length >= 10)
+    ? startedAt.slice(0, 10)
+    : new Date().toISOString().slice(0, 10);
+
+  return `You are a session indexer. Extract salience markers as ABSOLUTE/CONCRETE entities only.
+
+Output EXACTLY valid JSON, nothing else:
+{
+  "actor":      [{"name": "...", "role": "...", "phrase_in_text": "..."}],
+  "temporal":   [{"iso": "YYYY-MM-DD", "phrase_in_text": "...", "kind": "date|datetime|range"}],
+  "emotional":  [{"verbatim": "...", "polarity": "positive|negative|emphatic"}],
+  "cognitive":  [{"verbatim": "...", "function": "contrast|cause|conclusion|qualification"}],
+  "singularity":[{"verbatim": "..."}]
+}
+
+Rules:
+- actor: humans, roles, named external systems only. SKIP @team-agent handles such as @architectural-layer-analyst from /frame protocol output, and bare code identifiers.
+- temporal: keep only entries that resolve to an ABSOLUTE timestamp. Normalize relative phrases (yesterday, 어제, last week) to ISO using session start date ${dateAnchor} as anchor; if normalization is ambiguous, omit the entry. Drop fractions and ranges (1/2, 2-3) and future-intent tokens such as "next session" or "next phase".
+- emotional: verbatim quotes that carry stance markers (emphasis, strong agreement or disagreement, surprise).
+- cognitive: verbatim quotes featuring discourse connectives that signal reasoning shifts (however, therefore, 따라서, 하지만, etc.).
+- singularity: memorable user statements (decisions, strong opinions, distinctive coinage).
+- Each category: maximum ${MARKER_CAT_LIMIT} items. Empty arrays are valid and preferred over noise.
+- All values stay in the language they were originally written in.
+- Each item must have a verifiable anchor in the session text.
+
+Session start date (for temporal normalization): ${dateAnchor}
+
+Session content:
+${sample}`;
+}
+
 // --- Haiku Invocation ---
 
 function callHaiku(prompt) {
@@ -344,6 +382,14 @@ function validateNarrative(data) {
     typeof data.direction === "string" &&
     typeof data.outcome === "string"
   );
+}
+
+function validateMarkers(data) {
+  if (!data || typeof data !== "object") return false;
+  for (const key of ["actor", "temporal", "emotional", "cognitive", "singularity"]) {
+    if (!Array.isArray(data[key])) return false;
+  }
+  return true;
 }
 
 // --- File Builders ---
@@ -499,49 +545,16 @@ function extractEntropyRefs(allTexts) {
     .slice(0, ENTROPY_MAX_OUTPUT);
 }
 
-// detect: Session → MarkerProfile — salience-track profile
-// Laws: monotonicity/locality hold exactly; idempotence holds up to output truncation.
-const MARKER_PATTERNS = {
-  actor: /@[\w-]{2,40}\b/g,
-  temporal: /\b(\d{4}-\d{2}-\d{2}|\d{1,2}[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?|yesterday|today|tomorrow|last\s+\w+|next\s+\w+|어제|오늘|내일|이번주|지난주|다음주|주말)\b/gi,
-  emotional: /(?:!{2,}|\?{2,}|\bwow\b|\bexactly\b|\bperfect\b|완벽|맞습니다|최고|중요합니다?)/gi,
-  cognitive: /\b(?:however|therefore|because|hence|thus|nonetheless|moreover)\b|따라서|그래서|왜냐하면|그러나|하지만|결국/gi,
-};
-const COINAGE_PATTERN = /\b(?:[a-z]+(?:[A-Z][a-z]+)+|[A-Z][a-z]+(?:[A-Z][a-z]+){1,3})\b/g;
-
-function detectMarkers(userMsgs, allTexts) {
-  const profile = {
-    coinage: new Set(),
-    actor: new Set(),
-    temporal: new Set(),
-    emotional: new Set(),
-    cognitive: new Set(),
-    singularity: new Set(),
-  };
-  for (const text of allTexts) {
-    for (const match of text.matchAll(COINAGE_PATTERN)) {
-      if (profile.coinage.size >= MARKER_CAT_LIMIT) break;
-      profile.coinage.add(match[0]);
-    }
-    for (const [category, pattern] of Object.entries(MARKER_PATTERNS)) {
-      if (profile[category].size >= MARKER_CAT_LIMIT) continue;
-      for (const match of text.matchAll(pattern)) {
-        if (profile[category].size >= MARKER_CAT_LIMIT) break;
-        profile[category].add(match[0]);
-      }
-    }
-  }
-  for (const msg of userMsgs.slice(0, 30)) {
-    if (profile.singularity.size >= 10) break;
-    const text = cleanText(msg.text).trim();
-    if (text.length >= 80 && text.length <= 500 && /[!?]|\*\*/.test(text)) {
-      profile.singularity.add(text.slice(0, 200));
-    }
-  }
-  return Object.fromEntries(
-    Object.entries(profile).map(([k, v]) => [k, [...v]])
-  );
-}
+// MarkerProfile salience extraction — migrated from regex (v0.4.0) to Haiku
+// LLM extraction (v0.4.24). The 5 semantic categories (actor / temporal /
+// emotional / cognitive / singularity) are extracted by buildMarkerPrompt +
+// callHaiku; the 6th category (coinage) remains deterministic via
+// computeCoinage below — the SKILL.md coinage(s, corpus, θ) formula is the
+// authoritative definition and must remain byte-aligned with this function.
+//
+// Per SKILL.md ── SALIENCE MARKERS ── (v0.4.24): semantic invariants
+// (traceability, boundedness, stability) replace prior exact laws
+// (monotonicity, locality, idempotence) for Haiku-extracted categories.
 
 // coinage: Session × Corpus × θ → CoinageSet
 // salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
@@ -628,29 +641,56 @@ function buildEntropyMd(sessionId, date, refs) {
   return lines.join("\n") + "\n";
 }
 
-function buildMarkersMd(sessionId, date, profile) {
-  const counts = Object.fromEntries(
-    Object.entries(profile).map(([k, v]) => [k, v.length])
-  );
+// buildMarkersMd: assembles markers.md combining Haiku-extracted semantic
+// categories (actor/temporal/emotional/cognitive/singularity) with the
+// deterministic coinage statistics. extractionMethod is recorded in
+// frontmatter for cross-version observability (no ranking influence).
+function buildMarkersMd(sessionId, date, haikuMarkers, coinageResult, extractionMethod) {
+  const coinageItems = coinageResult?.coinage ?? [];
+  const counts = {
+    coinage: coinageItems.length,
+    actor: haikuMarkers.actor.length,
+    temporal: haikuMarkers.temporal.length,
+    emotional: haikuMarkers.emotional.length,
+    cognitive: haikuMarkers.cognitive.length,
+    singularity: haikuMarkers.singularity.length,
+  };
   const lines = [
     "---",
     `session_id: ${sessionId}`,
     `date: ${date}`,
-    `marker_categories: [${Object.keys(profile).join(", ")}]`,
+    `marker_categories: [coinage, actor, temporal, emotional, cognitive, singularity]`,
     `marker_counts: ${JSON.stringify(counts)}`,
+    `extraction_method: ${extractionMethod}`,
     "---",
     "",
     "## MarkerProfile",
     "",
+    `### coinage (${coinageItems.length})`,
   ];
-  for (const [category, items] of Object.entries(profile)) {
-    lines.push(`### ${category} (${items.length})`);
+  if (coinageItems.length === 0) {
+    lines.push("_none_");
+  } else {
+    for (const c of coinageItems) {
+      lines.push(`- \`${escMd(c.token)}\` (precision ${c.precision.toFixed(3)}, session ${c.sessionOcc} / corpus ${c.corpusOcc})`);
+    }
+  }
+  lines.push("");
+
+  const renderers = {
+    actor: (items) => items.map((i) => `- ${escMd(i.name ?? "")} (role: ${escMd(i.role ?? "")}, phrase: \`${escMd(i.phrase_in_text ?? "")}\`)`),
+    temporal: (items) => items.map((i) => `- ${escMd(i.iso ?? "")} (phrase: \`${escMd(i.phrase_in_text ?? "")}\`, kind: ${escMd(i.kind ?? "")})`),
+    emotional: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")} (polarity: ${escMd(i.polarity ?? "")})`),
+    cognitive: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")} (function: ${escMd(i.function ?? "")})`),
+    singularity: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")}`),
+  };
+  for (const cat of ["actor", "temporal", "emotional", "cognitive", "singularity"]) {
+    const items = haikuMarkers[cat];
+    lines.push(`### ${cat} (${items.length})`);
     if (items.length === 0) {
       lines.push("_none_");
     } else {
-      for (const item of items) {
-        lines.push(`- ${escMd(item)}`);
-      }
+      lines.push(...renderers[cat](items));
     }
     lines.push("");
   }
@@ -875,17 +915,36 @@ function main() {
 
   // Post-extraction low-info discard: silent skip when all 3 haiku extractions
   // produced empty payloads — enables retry via next SessionEnd once cooldown
-  // expires. Two-track extensions (entropy/markers/coinage) are also skipped
-  // since ghost sessions lack the semantic content they depend on.
+  // expires. Two-track extensions (entropy/coinage) and the Haiku marker call
+  // are also skipped since ghost sessions lack the semantic content they
+  // depend on.
   if (isLowInfo(clueData, vectorData, narrativeData)) {
     logErr(`low-info discard: all 3 extractions produced empty payloads — skipping write, retry eligible at next SessionEnd`);
     return;
   }
 
-  // --- v0.4.0 Two-Track Extension ---
-  // Deterministic extract/detect run first; coinage runs if budget allows.
-  // Soft cap: TWO_TRACK_BUDGET_MS. On exhaustion, coinage is skipped while
-  // markers + entropy refs remain intact (Anamnesis R1 fallback).
+  // --- Haiku Marker Extraction (v0.4.24) ---
+  // 4th Haiku call — extracts 5 semantic salience categories
+  // (actor/temporal/emotional/cognitive/singularity). Bound by HAIKU_TIMEOUT
+  // separately, NOT by TWO_TRACK_BUDGET_MS. Fail-open: marker absence does not
+  // abort the write.
+  let markerData = null;
+  try {
+    const markerRaw = callHaiku(buildMarkerPrompt(allTexts, startedAt));
+    markerData = parseHaikuOutput(markerRaw);
+    if (!validateMarkers(markerData)) {
+      logErr(`marker validation failed: invalid schema`);
+      markerData = null;
+    }
+  } catch (e) {
+    logErr(`marker extraction failed: ${e.message}`);
+    markerData = null;
+  }
+
+  // --- Deterministic Two-Track Extension ---
+  // Entropy refs are O(n) over text; coinage is corpus-comparative under
+  // TWO_TRACK_BUDGET_MS soft cap. On exhaustion, coinage is skipped while
+  // entropy refs remain intact (Anamnesis R1 fallback).
   const twoTrackStart = Date.now();
 
   try {
@@ -895,28 +954,34 @@ function main() {
     logErr(`entropy extraction failed: ${e.message}`);
   }
 
-  try {
-    const profile = detectMarkers(userMsgs, allTexts);
-    files["markers.md"] = buildMarkersMd(sessionId, date, profile);
-  } catch (e) {
-    logErr(`marker detection failed: ${e.message}`);
-  }
-
+  let coinageResult = null;
   try {
     const elapsed = Date.now() - twoTrackStart;
     const remaining = TWO_TRACK_BUDGET_MS - elapsed;
+    let skipped = false;
+    let skipReason = null;
     if (remaining < COINAGE_MIN_REMAINING_MS) {
-      files["coinage.md"] = buildCoinageMd(
-        sessionId, date, null, true,
-        `budget ${TWO_TRACK_BUDGET_MS}ms exhausted after ${elapsed}ms`,
-      );
+      skipped = true;
+      skipReason = `budget ${TWO_TRACK_BUDGET_MS}ms exhausted after ${elapsed}ms`;
     } else {
       const corpusRoot = path.join(slugDir, "hypomnesis");
-      const result = computeCoinage(userMsgs, allTexts, corpusRoot, sessionId, remaining);
-      files["coinage.md"] = buildCoinageMd(sessionId, date, result, false, null);
+      coinageResult = computeCoinage(userMsgs, allTexts, corpusRoot, sessionId, remaining);
     }
+    files["coinage.md"] = buildCoinageMd(sessionId, date, coinageResult, skipped, skipReason);
   } catch (e) {
     logErr(`coinage extraction failed: ${e.message}`);
+  }
+
+  // markers.md combines Haiku semantic categories + deterministic coinage
+  // statistics. Built after both inputs settle.
+  if (markerData) {
+    try {
+      files["markers.md"] = buildMarkersMd(
+        sessionId, date, markerData, coinageResult, "haiku-marker-v1",
+      );
+    } catch (e) {
+      logErr(`markers assembly failed: ${e.message}`);
+    }
   }
 
   if (Object.keys(files).length > 0) {

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -32,6 +32,10 @@ function logErr(msg) {
   try { process.stderr.write(`[hypomnesis-write] ${msg}\n`); } catch {}
 }
 
+function toDateString(iso) {
+  return (iso && iso.length >= 10) ? iso.slice(0, 10) : new Date().toISOString().slice(0, 10);
+}
+
 // --- SIGHUP guard ---
 try { process.on("SIGHUP", () => {}); } catch {}
 
@@ -55,6 +59,7 @@ const COINAGE_MIN_SESSION_OCC = 2;
 const COINAGE_MAX_OUTPUT = 30;
 const MARKER_CAT_LIMIT = 30;
 const ENTROPY_MAX_OUTPUT = 40;
+const MARKER_EXTRACTION_METHOD = "haiku-marker-v1";
 // Observed reason values in ~/.claude/logs/hooks.log (33 days, 1408 records):
 // other, prompt_input_exit, resume, clear. "compact" never observed — PreCompact
 // does not trigger SessionEnd; the two events are temporally independent.
@@ -288,11 +293,9 @@ ${sample}`;
 
 function buildMarkerPrompt(allTexts, startedAt) {
   const sample = allTexts.join("\n---\n").slice(0, 30_000);
-  const dateAnchor = (startedAt && startedAt.length >= 10)
-    ? startedAt.slice(0, 10)
-    : new Date().toISOString().slice(0, 10);
+  const dateAnchor = toDateString(startedAt);
 
-  return `You are a session indexer. Extract salience markers as ABSOLUTE/CONCRETE entities only.
+  return `You are a session indexer. Extract salience markers as concrete, anchored entities.
 
 Output EXACTLY valid JSON, nothing else:
 {
@@ -304,16 +307,15 @@ Output EXACTLY valid JSON, nothing else:
 }
 
 Rules:
-- actor: humans, roles, named external systems only. SKIP @team-agent handles such as @architectural-layer-analyst from /frame protocol output, and bare code identifiers.
-- temporal: keep only entries that resolve to an ABSOLUTE timestamp. Normalize relative phrases (yesterday, 어제, last week) to ISO using session start date ${dateAnchor} as anchor; if normalization is ambiguous, omit the entry. Drop fractions and ranges (1/2, 2-3) and future-intent tokens such as "next session" or "next phase".
-- emotional: verbatim quotes that carry stance markers (emphasis, strong agreement or disagreement, surprise).
-- cognitive: verbatim quotes featuring discourse connectives that signal reasoning shifts (however, therefore, 따라서, 하지만, etc.).
-- singularity: memorable user statements (decisions, strong opinions, distinctive coinage).
-- Each category: maximum ${MARKER_CAT_LIMIT} items. Empty arrays are valid and preferred over noise.
+- actor: named human individuals, role descriptors, and external advisor systems whose attribution persists across sessions.
+- temporal: each entry must resolve to an absolute calendar reference. Convert relative time expressions to ISO date by anchoring against ${dateAnchor}. The kind field declares the resolved precision.
+- emotional: verbatim quotes whose pragmatic function is stance signaling — emphasis, evaluative reaction, or affective intensity. The polarity field declares the resolved valence.
+- cognitive: verbatim quotes featuring discourse connectives whose pragmatic function is signaling reasoning transitions — causal, adversative, or conclusive relations within argument structure. The function field declares the relation type.
+- singularity: memorable user statements distinctive enough to anchor session recall — decisive judgments, strong stances, or distinctive coinage that summarizes the session's character.
+- Each category: maximum ${MARKER_CAT_LIMIT} items. Empty arrays are valid; entries must be verifiable in the session text.
 - All values stay in the language they were originally written in.
-- Each item must have a verifiable anchor in the session text.
 
-Session start date (for temporal normalization): ${dateAnchor}
+Session start date (for temporal anchoring): ${dateAnchor}
 
 Session content:
 ${sample}`;
@@ -862,7 +864,7 @@ function main() {
 
   const startedAt = timestamps[0] ?? "";
   const lastTurnAt = timestamps.at(-1) ?? "";
-  const date = startedAt.slice(0, 10) || new Date().toISOString().slice(0, 10);
+  const date = toDateString(startedAt);
   const crossRefs = extractCrossRefs(userMsgs, allTexts);
 
   const files = {};
@@ -977,7 +979,7 @@ function main() {
   if (markerData) {
     try {
       files["markers.md"] = buildMarkersMd(
-        sessionId, date, markerData, coinageResult, "haiku-marker-v1",
+        sessionId, date, markerData, coinageResult, MARKER_EXTRACTION_METHOD,
       );
     } catch (e) {
       logErr(`markers assembly failed: ${e.message}`);

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -33,7 +33,13 @@ function logErr(msg) {
 }
 
 function toDateString(iso) {
-  return (iso && iso.length >= 10) ? iso.slice(0, 10) : new Date().toISOString().slice(0, 10);
+  if (iso && iso.length >= 10) return iso.slice(0, 10);
+  // Fallback uses extraction time, which may misalign for sessions spanning
+  // midnight (relative-phrase normalization anchors to wrong day). Logged so
+  // observability can surface degraded normalization frequency.
+  const fallback = new Date().toISOString().slice(0, 10);
+  logErr(`toDateString: missing/short ISO input (got ${JSON.stringify(iso)}); falling back to extraction time ${fallback} — temporal anchor may misalign for cross-day sessions`);
+  return fallback;
 }
 
 // --- SIGHUP guard ---
@@ -679,12 +685,14 @@ function buildMarkersMd(sessionId, date, haikuMarkers, coinageResult, extraction
   }
   lines.push("");
 
+  // Optional chaining (i?.x) guards against null/undefined array elements,
+  // since validateMarkers only checks Array shape, not item structure.
   const renderers = {
-    actor: (items) => items.map((i) => `- ${escMd(i.name ?? "")} (role: ${escMd(i.role ?? "")}, phrase: \`${escMd(i.phrase_in_text ?? "")}\`)`),
-    temporal: (items) => items.map((i) => `- ${escMd(i.iso ?? "")} (phrase: \`${escMd(i.phrase_in_text ?? "")}\`, kind: ${escMd(i.kind ?? "")})`),
-    emotional: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")} (polarity: ${escMd(i.polarity ?? "")})`),
-    cognitive: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")} (function: ${escMd(i.function ?? "")})`),
-    singularity: (items) => items.map((i) => `- ${escMd(i.verbatim ?? "")}`),
+    actor: (items) => items.map((i) => `- ${escMd(i?.name ?? "")} (role: ${escMd(i?.role ?? "")}, phrase: \`${escMd(i?.phrase_in_text ?? "")}\`)`),
+    temporal: (items) => items.map((i) => `- ${escMd(i?.iso ?? "")} (phrase: \`${escMd(i?.phrase_in_text ?? "")}\`, kind: ${escMd(i?.kind ?? "")})`),
+    emotional: (items) => items.map((i) => `- ${escMd(i?.verbatim ?? "")} (polarity: ${escMd(i?.polarity ?? "")})`),
+    cognitive: (items) => items.map((i) => `- ${escMd(i?.verbatim ?? "")} (function: ${escMd(i?.function ?? "")})`),
+    singularity: (items) => items.map((i) => `- ${escMd(i?.verbatim ?? "")}`),
   };
   for (const cat of ["actor", "temporal", "emotional", "cognitive", "singularity"]) {
     const items = haikuMarkers[cat];

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -169,16 +169,20 @@ extractor registry:
 dispatch binding: InputType = StructuredIdentifier → Track = entropy
 
 ── SALIENCE MARKERS ──
-detect : Session → MarkerProfile
+detect : Session × Σ? → MarkerProfile
 categories: { coinage, actor, temporal, emotional, cognitive, singularity }   -- working hypothesis (Emergent admitted)
-laws:
-  monotonicity:   s₁ ⊆ s₂ ⟹ detect(s₁) ⊆ detect(s₂)
-  locality:       detect(s₁ ⊔ s₂) = detect(s₁) ⊔ detect(s₂)                 -- disjoint sessions
-  idempotence:    detect(witnesses(detect(s))) = detect(s)                    -- second pass stable
+
+semantic invariants:
+  traceability:    detect(s) contains only markers grounded in SSOT session content or normalized from session-anchored context
+  boundedness:     ∀c ∈ categories, |detect(s).c| ≤ category_limit
+  stability:       repeated detect(s) under the same extractor version should preserve recall-relevant category intent, but exact set equality is not required
+  locality*:       detect is applied per session; cross-session comparison is ranking-layer only, except corpus-statistical coinage
+  monotonicity*:   adding content may refine, normalize, merge, or reject prior candidate markers; exact set inclusion is not guaranteed
 
 coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
   where salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
   -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
+  -- Stage 1 conjecture under Deficit Empiricism: relaxation rationale = empirical evidence of 88.5% noise rate in MarkerProfile.temporal corpus-wide audit (2026-05-04).
 
 dispatch binding: InputType = NaturalRecall → Track = salience
                   InputType = Mixed → Track = hybrid    -- union scan: entropy ∪ salience
@@ -201,12 +205,12 @@ degraded_scan: INDEX_semantic = ∅ ⟹ scan'(SSOT, Track, trace)             --
 The protocol essence (form) consists of FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, and the
 formal blocks ENTROPY EXTRACTION / SALIENCE MARKERS / STORE TOPOLOGY / KNOWN FAILURE MODES.
 The essence makes no reference to specific tools, agents, platforms, schedulers, or storage
-media. Any realization (matter) satisfying the morphism laws and the store topology realizes
-Anamnesis.
+media. Any realization (matter) satisfying the entropy extraction laws, salience semantic
+invariants, and store topology realizes Anamnesis.
 
 form ⊥ matter:
-  form   = ⟨FLOW, MORPHISM, TYPES, laws of extract/detect/scan⟩             -- protocol definition
-  matter = ⟨tool names, file paths, language, scheduler, storage backend⟩   -- realization
+  form   = ⟨FLOW, MORPHISM, TYPES, laws of extract/scan, invariants of detect⟩   -- protocol definition
+  matter = ⟨tool names, file paths, language, scheduler, storage backend⟩         -- realization
 
 TOOL GROUNDING below specifies one such realization (Claude Code substrate); it is
 non-normative with respect to the protocol's epistemic content.

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -169,20 +169,20 @@ extractor registry:
 dispatch binding: InputType = StructuredIdentifier → Track = entropy
 
 ── SALIENCE MARKERS ──
-detect : Session × Σ? → MarkerProfile
+detect : Session × Anchor? → MarkerProfile     -- Anchor? = optional ISO date for temporal normalization (e.g., session start)
 categories: { coinage, actor, temporal, emotional, cognitive, singularity }   -- working hypothesis (Emergent admitted)
 
 semantic invariants:
   traceability:    detect(s) contains only markers grounded in SSOT session content or normalized from session-anchored context
   boundedness:     ∀c ∈ categories, |detect(s).c| ≤ category_limit
-  stability:       repeated detect(s) under the same extractor version should preserve recall-relevant category intent, but exact set equality is not required
+  stability:       repeated detect(s) under the same extractor version should preserve recall-relevant category intent, but exact set equality is not required (idempotence not claimed — LLM-extracted categories are non-deterministic; stability subsumes intent-level repeatability)
   locality*:       detect is applied per session; cross-session comparison is ranking-layer only, except corpus-statistical coinage
   monotonicity*:   adding content may refine, normalize, merge, or reject prior candidate markers; exact set inclusion is not guaranteed
+  -- Stage 1 conjecture under Deficit Empiricism: invariant relaxation (exact laws → starred semantic invariants) justified by 88.5% noise rate in MarkerProfile.temporal corpus-wide audit (2026-05-04); the coinage formula below remains deterministic and is unaffected.
 
 coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
   where salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
   -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
-  -- Stage 1 conjecture under Deficit Empiricism: relaxation rationale = empirical evidence of 88.5% noise rate in MarkerProfile.temporal corpus-wide audit (2026-05-04).
 
 dispatch binding: InputType = NaturalRecall → Track = salience
                   InputType = Mixed → Track = hybrid    -- union scan: entropy ∪ salience
@@ -190,7 +190,7 @@ dispatch binding: InputType = NaturalRecall → Track = salience
 ── STORE TOPOLOGY ──
 Store = SSOT ⊕ INDEX ; memory/ = realization-layer adjunct (non-scanned, user-curated)
   SSOT             = authoritative session record (complete, append-only)
-  INDEX_semantic   = per-session semantic extraction (IdentifierTuples, MarkerProfile, Coinage, narrative) -- derived from SSOT, rebuildable, lossy
+  INDEX_semantic   = per-session semantic extraction (IdentifierTuples, MarkerProfile?, Coinage, narrative) -- derived from SSOT, rebuildable, lossy; MarkerProfile? is conditional on successful Haiku extraction + validation (markers.md absent on extraction error or schema-validation failure)
   INDEX_substitute = substitute channel raw message log -- append-only, primary capture, authoritative (loss non-recoverable)
 
 scan_{Track} : (Store, Trace) → List(Candidate)
@@ -199,6 +199,7 @@ scan_{Track} : (Store, Trace) → List(Candidate)
   scan_hybrid(Store, trace)     = scan_entropy ∪ scan_salience
 
 degraded_scan: INDEX_semantic = ∅ ⟹ scan'(SSOT, Track, trace)             -- SSOT guarantees semantic recall; cold start falls back to SSOT directly
+  -- partial INDEX (e.g., MarkerProfile? = ∅ while IdentifierTuples / Coinage / narrative present) is a normal mode and does NOT trigger total fallback; scan_salience returns empty for the missing component and ranking degrades gracefully
   -- INDEX_substitute loss non-recoverable (SSOT lacks subagent-channel messages); precondition for Cold-Start invariant (see Verification)
 
 ── SUBSTRATE AGNOSTICISM ──

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -320,9 +320,9 @@ Heuristic signals for empty intention detection (not hard gates):
 
 | Signal | Detection |
 |--------|-----------|
-| Vague temporal reference | Past-tense hedging about prior sessions or discussions (e.g., "we discussed this before", "there was something about...") |
-| Existence without specification | User asserts prior context exists but cannot name it specifically (e.g., "there was a discussion about...", "I think there was an issue related to...") |
-| Self-referential recall markers | Verbs of remembering paired with uncertainty markers (e.g., "I remember seeing...", "I vaguely recall...", "somewhere we talked about...") |
+| Vague temporal reference | Past-tense hedging about prior sessions or discussions without an exact pointer |
+| Existence without specification | User asserts prior context exists but cannot name it specifically |
+| Self-referential recall markers | Verbs of remembering paired with uncertainty markers |
 | Failed self-recall | User attempts to reference prior context but trails off, hedges, or uses approximation language |
 | Cognitive effort signals | User pauses mid-reference, self-corrects, or expresses frustration at not finding a prior discussion |
 
@@ -358,7 +358,7 @@ Detect empty intention and extract contextual trace. This phase is **silent** �
 4. If `not-empty_intention(V)`: present finding per Rule 16 before proceeding (Anamnesis not activated)
 5. If `empty_intention(V)`: record V with extracted trace — proceed to Phase 1
 
-**Scan scope**: Bound text, conversation context, session history. Does NOT modify files or call external services.
+**Scan scope**: Read-only over bound text, conversation context, and session history.
 
 ### Phase 1: Track-Dispatched Scan + Rank
 
@@ -383,7 +383,7 @@ Dispatch the scan on the classified `Track`, execute track-appropriate lookup ov
 
 4. If `|C[]| = 0`: NullMatch pathway. Inform user what was searched and not found. Before declaring NullMatch, attempt at least one Socratic probe enrichment (Rule 17). After enrichment attempts exhausted: surface the search scope summary and the accumulated recall trace (keywords, temporal signals, user hints from probing), then offer Aitesis handoff — the recall INDEX (hypomnesis/) may lack the entry (lifecycle gap: SessionEnd did not fire; or pre-store: session predates hypomnesis implementation), but the SSOT (session JSONL) may still contain the information. The accumulated trace from Anamnesis probing becomes context seed for Aitesis to search JSONL directly via session ID.
 
-**Scope restriction**: Read-only investigation only (Read, Grep, Glob). No file modifications.
+**Scope restriction**: Investigation uses Read, Grep, Glob exclusively.
 
 ### Phase 2: Narrative Recognition (Constitution)
 
@@ -394,7 +394,7 @@ Dispatch the scan on the classified `Track`, execute track-appropriate lookup ov
 **Narrative presentation format**:
 
 Present the candidate as narrative text — the discussion's story, not just its result:
-- **When/Where**: Temporal and spatial context — when the discussion happened (with temporal distance, e.g., "3 days ago" or "2 weeks ago"), which session or document. Use short session reference in narrative for readability.
+- **When/Where**: Temporal and spatial context — when the discussion happened, expressed as temporal distance from the current session, plus which session or document. Use short session reference in narrative for readability.
 - **Source**: Provenance of the stored context — whether it was user-crystallized (via /crystallize) or auto-generated (SessionEnd hook narrative)
 - **Origin**: What prompted the discussion — the question or situation that started it
 - **Direction**: How the discussion developed — what path was taken, what was explored
@@ -467,9 +467,9 @@ After integration: `recall_complete` → present convergence evidence trace (Vag
 
 6. **Track-internal ranking strategy**: Ranking composes track-appropriate signals — entropy track: literal precision (corpus rarity) dominates; salience track: Σ-match + marker-profile overlap + temporal neighborhood + adjacent vector discovery. Single-signal scans have structural blind spots regardless of track.
 
-7. **Adaptive ambiguity handling**: When trace ambiguity is high (0-1 specific signals), present hypomnesis store overview or consider /clarify composition before targeted scanning. Do not scan blindly on vague expressions — orient the user first.
+7. **Adaptive ambiguity handling**: When trace ambiguity is high (0-1 specific signals), orient the user first — present hypomnesis store overview or consider /clarify composition before targeted scanning.
 
-8. **One candidate per cycle**: Present one highest-priority candidate per Phase 2 cycle; do not bundle multiple candidates.
+8. **One candidate per cycle**: Present one highest-priority candidate per Phase 2 cycle — single-candidate presentation keeps recognition focus on a single identity decision.
 
 9. **Recognition respected**: User's recognition or rejection is final for that candidate in the current session.
 
@@ -481,20 +481,20 @@ After integration: `recall_complete` → present convergence evidence trace (Vag
 
 13. **Cross-protocol awareness**: Defer to Aitesis when user needs new information (no empty intention); defer to /clarify when expression itself is ambiguous (expression gap ≠ recall gap). Compose `/recollect * /inquire` when recognized context needs enrichment. On NullMatch after exhausted probing, offer Aitesis handoff with accumulated trace and enumerate possible causes — lifecycle gap / pre-store, missing extractor, or PartialExtract from corrupted source — giving actionable diagnosis; INDEX may lack entries (lifecycle gaps or pre-store sessions) while SSOT retains the information.
 
-14. **Context-Question Separation**: Present all narrative context, evidence, and adjacent vectors as text before the Constitution interaction; the interaction contains only the recognition question and options with differential implications. Embedding narrative in the Constitution interaction = protocol violation.
+14. **Context-Question Separation**: Present all narrative context, evidence, and adjacent vectors as text before the Constitution interaction; the interaction contains only the recognition question and options with differential implications.
 
 15. **Convergence evidence**: Present transformation trace before declaring recall_complete.
 
 16. **Activation surfacing**: If Phase 0 determines no empty intention (e.g., user provides a specific reference), present the finding before proceeding without Anamnesis.
 
-17. **No premature NullMatch**: At least one Socratic probe enrichment must precede NullMatch declaration. First scan returning zero → probe → enriched re-scan → NullMatch only if still empty.
+17. **Probe-first NullMatch**: At least one Socratic probe enrichment precedes any NullMatch declaration. First scan returning zero → probe → enriched re-scan → NullMatch declaration if still empty.
 
-18. **No skipped Qc**: Phase 2 Constitution interaction is mandatory even with single high-confidence candidate. Synthesis of identification is constitutive — cannot auto-resolve via confidence score. High confidence justifies Light intensity, not constitution elision.
+18. **Mandatory Qc**: Phase 2 Constitution interaction runs for every cycle, including single high-confidence candidates. Synthesis of identification is constitutive; confidence score governs intensity (Light/Medium/Heavy), not whether the gate runs.
 
-19. **No asserted recognition**: AI presents; user constitutes recognition. Asserting "this must be what you want" = protocol violation.
+19. **AI presents, user constitutes**: AI presents candidates as recognition options; the user's recognition response constitutes the identity match — presentation and constitution are separate acts.
 
-20. **No merged probe+recognition**: Socratic probing (Qs) and recognition (Qc) are separate Constitution interactions — the probe deepens recall context, Qc verifies identity. Combining them = protocol violation.
+20. **Separate Qs and Qc**: Socratic probing (Qs) and recognition (Qc) run as two distinct Constitution interactions — Qs deepens recall context first, Qc verifies identity second.
 
 21. **Cross-LOOP narrative persistence**: Narrative format and adjacent vector enrichment persist across LOOP iterations; subsequent attempts reference prior candidates and explain the differential.
 
-22. **Substrate non-coupling**: Protocol essence (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, five formal blocks) must not name specific tools, agents, platforms, or storage media. Realization bindings belong exclusively to TOOL GROUNDING (semantic autonomy at the realization boundary).
+22. **Substrate non-coupling**: Protocol essence (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, five formal blocks) names epistemic operations only — realization bindings (tool names, file paths, storage media) belong exclusively to TOOL GROUNDING (semantic autonomy at the realization boundary).


### PR DESCRIPTION
## Summary

Anamnesis `MarkerProfile`의 5개 의미 카테고리(actor / temporal / emotional / cognitive / singularity) 추출을 정규식 → Haiku LLM으로 마이그레이션. `coinage`는 Zipf 통계 그대로 유지 (SKILL.md `coinage(s, corpus, θ)` 정의식 보존). SKILL.md `── SALIENCE MARKERS ──` 형식 법칙(monotonicity/locality/idempotence)을 LLM 비결정성과 양립 가능한 semantic invariants(traceability/boundedness/stability)로 완화.

**경험적 근거** (코퍼스 감사 2026-05-04):

| 분류 | 건수 | 비율 |
|---|---:|---:|
| ISO 날짜 (`yyyy-mm-dd`) | 97 | 11.5% |
| 비율/범위 정규식 오탐 (`1/2`, `2-3`) | 556 | **66.1%** |
| `next ...` 미래 의도 토큰 | 135 | 16.1% |
| `last ...` 상대 토큰 | 29 | 3.4% |
| bare 상대어 (`오늘`, `today`) | 10 | 1.2% |
| 기타 | 14 | 1.7% |
| **합계** | **841** | 100% |

`MarkerProfile.temporal` 항목의 88.5%가 노이즈 또는 frontmatter `started_at` 중복. Haiku 의미 추출로 신호 비율을 ~95%+로 끌어올리고 scan_salience 랭킹의 노이즈 제거.

## 변경 내역

**Commit A** (`d5feb8b`): SKILL.md semantic invariants 재작성 + `plugin.json` 0.4.23 → 0.4.24
- `── SALIENCE MARKERS ──` 블록(171-181): 정확 법칙 → semantic invariants(`traceability` / `boundedness` / `stability` / `locality*` / `monotonicity*`). `coinage(s, corpus, θ)` 통계 정의식 byte-identical 보존.
- `── SUBSTRATE AGNOSTICISM ──`(200-205): "morphism laws and the store topology" → "entropy extraction laws, salience semantic invariants, and store topology"
- `form ⊥ matter`(207-208): "laws of extract/detect/scan" → "laws of extract/scan, invariants of detect"
- Stage 1 conjecture rationale 1줄 추가: 88.5% 노이즈 audit 인용으로 self-citing trail 제공 (AI 리뷰어 false-alarm 방지)

**Commit B** (`75e78c0`): `hypomnesis-write.mjs` Haiku 4번째 호출 + 데드 코드 제거
- 신규: `buildMarkerPrompt(allTexts, startedAt)` — `started_at`을 anchor로 LLM이 상대→절대 정규화 수행. SKIP rules: `@team-agent` 핸들 / 분수·범위 / 미래 의도 토큰
- 신규: `validateMarkers(data)` — 5개 키 Array 존재 검사
- 교체: `buildMarkersMd` — Haiku 5개 카테고리 + 통계 coinage 통합 렌더, frontmatter에 `extraction_method: haiku-marker-v1` 옵저버빌리티 태그
- main() 흐름: 3개 Haiku 직후 `isLowInfo` 분기 후, deterministic two-track 전에 4번째 Haiku marker call. fail-open — markers 추출 실패가 write abort 트리거 안 함
- 데드 코드 제거: `MARKER_PATTERNS`(정규식 5종), `COINAGE_PATTERN`(미사용), `detectMarkers`(정규식 추출 함수)
- `computeCoinage` byte-untouched (SKILL.md `coinage(s, corpus, θ)` 정의식 보존 검증)

**손대지 않은 영역**: `── ENTROPY EXTRACTION ──` 블록 (deterministic 법칙 유지), `── STORE TOPOLOGY ──`, `── KNOWN FAILURE MODES ──`, `MarkerProfile` TYPES 정의, `anamnesis/README*.md` (6개 차원 prose 그대로 유효), 기존 `markers.md` 파일 (no migration).

## 검증

**자동화 (husky pre-commit + 수동 재실행)**:
- ✅ `node --test scripts/package.test.js` — 48/48 PASS
- ✅ `node .claude/skills/verify/scripts/static-checks.js .` — fail 0, warn 0 (Anamnesis 관련)
- ✅ `node scripts/package.js --dry-run` — anamnesis 0.4.24 packaging 성공

**Spot-check 그렙** (PR 직전 1분 작업):
- ✅ `scripts/package.test.js`에 markers/MarkerProfile/hypomnesis 참조 0건
- ✅ `anamnesis/README*.md`에 정규식/regex/pattern 언급 0건 (prose 갱신 불필요)
- ✅ `COINAGE_PATTERN` 잔재 0건 (제거 완전)

**End-to-end 검증** (머지 후 1주 내):
- 합격 임계치: 신규 markers.md 5건 이상 샘플링, `temporal` 카테고리에서 (ISO 정규화 + 빈 배열) 비율 ≥ **95%** (현 baseline 11.5% 대비). 동일 기준 `actor`에 적용 (휴먼/역할 + 빈 배열 ≥ 95%)
- READ-side fallback (필수): markers.md 부재 시 `/recollect`가 `degraded_scan`(SKILL.md:197) 경로로 SSOT까지 fallback 하는지 확인 — 본 PR 핵심 안전판

## 위험·롤백

**Rollback 트리거 (정량)** — 하나라도 충족 시 즉시 Commit B revert:
- SessionEnd 평균 처리 시간 +50% sustained 3일 (`~/.claude/logs/hooks.log`)
- haiku 토큰 비용 +50% (월간 청구 기준)
- markers Haiku 호출 실패율 ≥ 10% sustained 24시간 (logErr 카운트)

**Rollback 비대칭성**:
- ✅ Commit B만 revert: `MARKER_PATTERNS`/`detectMarkers` 복원, A의 완화된 invariants는 정규식이 더 강한 만족이므로 모순 없음
- ⛔ Commit A만 revert는 금지: form ⊥ matter 위반 (mjs는 비결정 Haiku인데 SKILL.md는 정확 `idempotence` 주장)

## 참고

- 구현 plan: `~/.claude/plans/jazzy-singing-noodle.md` (한국어)
- Codex 자문 (option A' 권고): `gpt-5.5/high`, 본 PR 설계 결정의 외부 검증 trail
- 마이그레이션 정책: 없음. 기존 markers.md는 stale로 잔존, SessionEnd 쿨다운 만료 시 자연 overwrite. `degraded_scan` semantics가 read 측 correctness 보장
