### PR TITLE
feat(steer+hook): trial index convention + gh-comments-convergence PostToolUse hook

### DIFF
--- a/.claude/hooks/gh-comments-convergence.mjs
+++ b/.claude/hooks/gh-comments-convergence.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// .claude/hooks/gh-comments-convergence.mjs
+//
+// Cross-CLI PostToolUse hook (Claude Code, Codex CLI v0.124.0+, others).
+// Fires when fetch_comments.py output contains numbered findings;
+// injects guidance for the AI's upcoming Constitution-gate decision.
+//
+// Cross-CLI installation:
+//   - Claude Code: wired via .claude/settings.json (this project)
+//   - Codex CLI:   in ~/.codex/hooks.json or [hooks] block of config.toml,
+//                  with [features] codex_hooks = true. Same script,
+//                  same stdin/stdout JSON contract.
+//   - Gemini CLI / others: same pattern; consult each CLI's hook docs.
+//
+// Extension point: append entries to GUIDANCES below as the trial expands.
+// Each entry is self-contained — no external doc references in the message.
+//
+// Stage 2 trial: epistemic-protocols project. Inventory at .claude/steer-trials.md.
+
+import { readFileSync } from 'node:fs';
+
+const GUIDANCES = [
+  {
+    name: 'option-set-entropy',
+    applies: (parsed) =>
+      (parsed.review_threads?.length ?? 0) > 0 ||
+      (parsed.conversation_comments?.length ?? 0) > 0,
+    message:
+      'Before presenting numbered items as Constitution options, evaluate ' +
+      'option-set entropy. If your analysis converges to a single dominant ' +
+      'option — no inter-item conflict, all items independently applicable, ' +
+      'no contested approach orthogonal to mechanical fix — present as relay ' +
+      'output (e.g., apply-all with a Basis line citing the convergence ' +
+      'judgment) rather than wrapping a converged outcome in false options. ' +
+      'If multiple genuinely viable choices remain (path/line collisions, ' +
+      'architectural disagreement, divergent approaches), surface the gate. ' +
+      'Override to gate when in doubt.',
+  },
+  // Append new entries here as the Stage 2 trial extends.
+  // Pattern: { name: string, applies: (parsed) => boolean, message: string }.
+];
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(0, 'utf-8'));
+} catch {
+  process.exit(0);
+}
+
+const cmd = payload.tool_input?.command ?? payload.command ?? '';
+if (!cmd.includes('fetch_comments.py')) process.exit(0);
+
+const stdoutRaw =
+  payload.tool_response?.stdout ??
+  payload.output?.stdout ??
+  payload.stdout ??
+  '';
+
+let parsed;
+try {
+  parsed = JSON.parse(stdoutRaw);
+} catch {
+  process.exit(0);
+}
+
+const matched = GUIDANCES.filter((g) => g.applies(parsed));
+if (matched.length === 0) process.exit(0);
+
+const message =
+  '[gh-comments PostToolUse — Stage 2 trial guidance]\n\n' +
+  matched.map((g) => `• ${g.message}`).join('\n\n');
+
+console.log(
+  JSON.stringify({
+    systemMessage: message,
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: message,
+    },
+  }),
+);

--- a/.claude/hooks/gh-comments-convergence.mjs
+++ b/.claude/hooks/gh-comments-convergence.mjs
@@ -68,7 +68,7 @@ if (matched.length === 0) process.exit(0);
 
 const message =
   '[gh-comments PostToolUse — Stage 2 trial guidance]\n\n' +
-  matched.map((g) => `• ${g.message}`).join('\n\n');
+  matched.map((g) => `• [${g.name}] ${g.message}`).join('\n\n');
 
 console.log(
   JSON.stringify({

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PROJECT_DIR}/.claude/hooks/gh-comments-convergence.mjs",
+            "statusMessage": "Evaluating gh-comments option-set entropy"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/steer-trials.md
+++ b/.claude/steer-trials.md
@@ -7,7 +7,7 @@ Project-local inventory of trials inscribed by `/steer` in this project. Lazy-lo
 Each entry records:
 - **Date** — ISO 8601 date of disposition
 - **Disposition** — `Approve` (rule-file write) or `RouteToOperationalLayer` (operational-layer realization)
-- **Mismatch signal** (RouteToOperationalLayer only) — `ProgrammaticTrigger` / `LayerMixing` / `BehavioralEnforcement`
+- **Mismatch signals** (RouteToOperationalLayer only) — set of `ProgrammaticTrigger` / `LayerMixing` / `BehavioralEnforcement` (compound mismatches are common)
 - **Recommended layer** (RouteToOperationalLayer only) — `Hook(event)` / `SystemPrompt` / `CI_CD` / `Settings` / `Other`
 - **Realization** — concrete file paths or rule-layer locations affected
 - **Origin context** — brief one-line summary of the originating audit (cluster type, evidence count, motivating session)
@@ -20,7 +20,7 @@ Each entry records:
 ### 2026-05-05 — gh-comments-convergence hook
 
 - **Disposition**: RouteToOperationalLayer
-- **Mismatch signal**: ProgrammaticTrigger + BehavioralEnforcement (per-turn rule prose was inadequate; deterministic detection of `fetch_comments.py` invocation needed)
+- **Mismatch signals**: {ProgrammaticTrigger, BehavioralEnforcement} (per-turn rule prose was inadequate; deterministic detection of `fetch_comments.py` invocation needed)
 - **Recommended layer**: `Hook(PostToolUse)` — Bash matcher, fetch_comments.py command detection
 - **Realization**:
   - Script: `.claude/hooks/gh-comments-convergence.mjs` (cross-CLI mjs; Node stdlib only)

--- a/.claude/steer-trials.md
+++ b/.claude/steer-trials.md
@@ -1,0 +1,39 @@
+# /steer Stage 2 Trial Index (epistemic-protocols)
+
+Project-local inventory of trials inscribed by `/steer` in this project. Lazy-loaded — read on demand. Each entry corresponds to one Approve or RouteToOperationalLayer disposition emitted by `/steer`.
+
+## Format
+
+Each entry records:
+- **Date** — ISO 8601 date of disposition
+- **Disposition** — `Approve` (rule-file write) or `RouteToOperationalLayer` (operational-layer realization)
+- **Mismatch signal** (RouteToOperationalLayer only) — `ProgrammaticTrigger` / `LayerMixing` / `BehavioralEnforcement`
+- **Recommended layer** (RouteToOperationalLayer only) — `Hook(event)` / `SystemPrompt` / `CI_CD` / `Settings` / `Other`
+- **Realization** — concrete file paths or rule-layer locations affected
+- **Origin context** — brief one-line summary of the originating audit (cluster type, evidence count, motivating session)
+- **Falsification** — condition(s) that trigger re-evaluation
+- **Re-evaluation** — schedule or trigger for next `/steer` re-run
+- **Status** — `active` / `completed` / `retracted`
+
+## Active Trials
+
+### 2026-05-05 — gh-comments-convergence hook
+
+- **Disposition**: RouteToOperationalLayer
+- **Mismatch signal**: ProgrammaticTrigger + BehavioralEnforcement (per-turn rule prose was inadequate; deterministic detection of `fetch_comments.py` invocation needed)
+- **Recommended layer**: `Hook(PostToolUse)` — Bash matcher, fetch_comments.py command detection
+- **Realization**:
+  - Script: `.claude/hooks/gh-comments-convergence.mjs` (cross-CLI mjs; Node stdlib only)
+  - Wiring: `.claude/settings.json` (Claude Code PostToolUse Bash matcher)
+  - Cross-CLI: install instructions in script header comment (Codex CLI v0.124.0+, Gemini CLI, etc.)
+- **Origin context**: 2026-05-04~05 audit session; cross-session evidence: 22 decided `/gh-address-comments` invocations across past sessions, 59% "all" selection rate, 3 invocations with explicit "no-conflict → all" phrasing. Cluster: Emergent / non-EP skill Standing-authority pattern.
+- **Falsification** (any one triggers re-evaluation):
+  - post-relay user correction rate > 20% (AI's convergence assessment unreliable)
+  - relay-applied finding revert within same PR cycle > 0 (AI applied what shouldn't have been applied)
+  - continued Constitution gate surfacing > 50% of invocations post-installation (rule not being applied — drift)
+- **Re-evaluation**: `/steer` re-run at the earlier of {1-2 months post-installation, first falsification trigger}
+- **Status**: active
+
+## Completed / Retracted Trials
+
+(empty)

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /comment-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "/catalog for protocol handbook, /onboard for quick recommendation + protocol learning, /probe for deficit recognition fit review (multi-hypothesis surfacing before protocol commitment), /report for Growth Map (usage analysis + insights integration), /dashboard for coverage dashboard, /compose for protocol composition authoring, /introspect for deep self-analysis pipeline (behavioral profile + HTML report), /sophia for philosopher match (behavioral dimension analysis), /curses for strength-shadow analysis and attitude recommendations, /write for multi-perspective blog drafting from session insights, /comment-review for markdown artifact review before fixation (publish/commit/deposit/merge) via inquire × gap × contextualize through a channel-first browser preview loop, /review-ensemble for cross-model code review composition (Claude /frame + Codex) with unified verdict aggregation, /steer for project profile recalibration via session calibration drift audit (Periagoge family specialization with writable rule inscription), /misuse for retrospective protocol contract violation detection across /ground and /induce sessions, /crystallize for inscribing a session's horizon-fusion residue into a four-layer Horizon-Fusion Text (HFT) for cross-session continuity (writer half of the HFT pair), /rehydrate for entering a previously inscribed HFT to prime the current session with the originating session's Vorverständnis (reader half of the HFT pair). /probe, /steer, /misuse, /crystallize, /rehydrate are Stage 2 evidence-collection instruments.",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/steer/SKILL.md
+++ b/epistemic-cooperative/skills/steer/SKILL.md
@@ -139,9 +139,9 @@ Assemble a profile diff from confirmed cluster implications:
    - **Layer mixing**: the diff compresses universal principle, specific instance, recognition mechanism, and falsification metrics into a single rule-file bullet — the resulting contract is ambiguous between universal rule and concrete operational guidance
    - **Behavioral enforcement focus**: the diff's load-bearing requirement is *what AI does at runtime*, not *what is visible to user judgment* — per `architectural-principles.md §Epistemic Completeness Boundary`, behavioral enforcement is operational-substrate territory (system prompts, hooks, CI/CD, settings.json), not epistemic substrate
 
-When any signal fires, set `mismatch_flag` and carry it into Phase 5; the diff itself is still assembled (the user retains override authority — picking Approve forces prose inscription regardless of the recommendation).
+When one or more signals fire, accumulate them into `mismatch_signals` (Set(MismatchSignal)) and carry it into Phase 5; the diff itself is still assembled (the user retains override authority — picking Approve forces prose inscription regardless of the recommendation).
 
-Phase 4 emits no surfacing. The assembled diff (with optional mismatch_flag) becomes the input to Phase 5.
+Phase 4 emits no surfacing. The assembled diff (with `mismatch_signals` set, possibly empty) becomes the input to Phase 5.
 
 ### Phase 5: Circular Return — Final Approve and Write
 
@@ -169,10 +169,10 @@ Backup target: <existing_profile_path>.bak.YYYYMMDD-HHMMSS
 Write target:  <existing_profile_path>
 ```
 
-When `mismatch_flag` is set (Phase 4 fit-shape check fired), surface the mismatch signal as text output between the diff presentation and the approval interaction:
+When `mismatch_signals` is non-empty (Phase 4 fit-shape check fired one or more signals), surface them as text output between the diff presentation and the approval interaction:
 
 ```
-Fit-shape mismatch detected: <signal type> — <one-sentence explanation>
+Fit-shape mismatches detected: <signal_a, signal_b, ...> — <one-sentence explanation per signal>
 Recommended operational layer: <hook event | system prompt | CI/CD | settings.json | other>
 Realization template (if RouteToOperationalLayer is selected): <concrete trigger + behavior outline>
 ```
@@ -215,8 +215,8 @@ Steer(scope) → Phase0(scope, user_confirm) →
           Reorient(cluster, implication'): record_modified(cluster, implication') → next
           Stop: break loop
       Assemble(confirmed_clusters, P_existing) → diff →
-      fit_shape_check(diff) → mismatch_flag →
-      present(diff, backup_path, mismatch_flag) → Qc(approve) → Stop → A →
+      fit_shape_check(diff) → mismatch_signals →
+      present(diff, backup_path, mismatch_signals) → Qc(approve) → Stop → A →
         Approve: backup(P_existing) → write(P_proposed, layer) → append_index(layer) → emit(UpdatedProjectProfile)
         Modify(adjustments): regenerate(diff, adjustments) → re-present Phase5
         Reject: emit(NoUpdateNote) → no write
@@ -232,11 +232,13 @@ SessionCalibrationMoves
   → classify(moves, drift_taxonomy)     -- trial inscription complete
   → present_per_cluster(cluster, V)     -- per-cluster validation
   → assemble_diff(confirmed)            -- tier resolution
-  → fit_shape_check(diff)               -- operational-layer material detection
-  → present_diff(approve, mismatch_flag) -- final Constitution interaction
-  → write(profile, layer, backup) | emit(OperationalLayerRecommendation)
-                                        -- circular return (inscription to rule layer) OR routing
-  → append_index(layer)                  -- trial inventory append (Approve and RouteToOperationalLayer only)
+  → fit_shape_check(diff)                -- operational-layer material detection
+  → present_diff(approve, mismatch_signals)  -- final Constitution interaction
+  → [Approve: write(profile, layer, backup); RouteToOperationalLayer: (no write)]
+                                          -- branch on disposition; write only on Approve
+  → append_index(layer)                   -- trial inventory append (both branches)
+  → emit(UpdatedProjectProfile | OperationalLayerRecommendation)
+                                          -- circular return (inscription) OR routing artifact
   → UpdatedProjectProfile | OperationalLayerRecommendation
 requires: calibration_drift_opaque(scope) ∧ scope_resolved(user)  -- activation precondition + Phase 0 confirmation
 deficit:  CalibrationDriftOpaque             -- activation precondition (user-invoked Layer 1)
@@ -269,19 +271,20 @@ Diff              = { before: ProjectProfile, after: ProjectProfile,
                       conflicts: List(VariableConflict) }
 VariableConflict  = { variable: ProfileVariable, candidates: List(ProfileValue) }
 A                 = ApprovalDisposition ∈ {Approve, Modify(adjustments), Reject, Defer, RouteToOperationalLayer}
-MismatchSignal    ∈ {ProgrammaticTrigger, LayerMixing, BehavioralEnforcement} — Phase 4 fit-shape check output; absent when diff fits project-profile.md structure
+MismatchSignal    ∈ {ProgrammaticTrigger, LayerMixing, BehavioralEnforcement} — atomic Phase 4 fit-shape signal
+MismatchSignals   = Set(MismatchSignal) — Phase 4 fit-shape check output; empty set when diff fits project-profile.md structure; non-empty set lists all detected signals (compound mismatches are common, e.g., ProgrammaticTrigger + BehavioralEnforcement co-occurring)
 RecommendedLayer  ∈ {Hook(HookEvent), SystemPrompt, CI_CD, Settings, Other(String)}
 HookEvent         ∈ {SessionStart, SessionEnd, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact, Notification}
 UpdatedProjectProfile = session text { layer, diff, backup_path, write_path, index_entry_path }
 NoUpdateNote      = session text { reviewed_clusters, dismissed_diff }
 DiffArtifact      = session text { diff_markdown, suggested_apply_path }
-OperationalLayerRecommendation = session text { mismatch_signal: MismatchSignal,
+OperationalLayerRecommendation = session text { mismatch_signals: MismatchSignals,
                                                 recommended_layer: RecommendedLayer,
                                                 realization_template: String,
                                                 trial_scope: String,
                                                 index_entry_path: Path }
 TrialIndexEntry   = { date: ISO8601Date, disposition: A,
-                      mismatch_signal: Optional(MismatchSignal),
+                      mismatch_signals: MismatchSignals,
                       recommended_layer: Optional(RecommendedLayer),
                       realization_refs: List(Path | String),
                       origin_context: String,
@@ -312,8 +315,8 @@ Phase 3: clusters → loop:
            present(cluster, evidence) → Qc(cluster) → Stop → V → integrate    -- per-cluster Constitution interaction [Tool]
            V = Stop → break loop
 Phase 4: confirmed_clusters → assemble_diff(P_existing) → diff →
-           fit_shape_check(diff) → mismatch_flag                                -- tier resolution + fit-shape detection (sense)
-Phase 5: diff, mismatch_flag → present(diff, backup_path, mismatch_flag) → Qc(approve) → Stop → A  -- final Constitution interaction [Tool]
+           fit_shape_check(diff) → mismatch_signals                                -- tier resolution + fit-shape detection (sense)
+Phase 5: diff, mismatch_signals → present(diff, backup_path, mismatch_signals) → Qc(approve) → Stop → A  -- final Constitution interaction [Tool]
            A = Approve → Write(backup) → Write(P_proposed) → Append(steer_trials_md) → emit(UpdatedProjectProfile)
            A = Modify → regenerate(diff) → Phase 5 re-entry
            A = Reject → emit(NoUpdateNote)
@@ -350,8 +353,8 @@ Phase 3 Qc                (constitution) → present (per-cluster verdict; const
 Phase 3 integrate         (track)        → Internal Λ update (cluster verdict recording)
 Phase 4 assemble_diff     (sense)        → Internal analysis (variable-level diff construction)
 Phase 4 fit_shape_check   (sense)        → Internal analysis (operational-layer material detection — programmatic-trigger / layer-mixing / behavioral-enforcement signals)
-Phase 5 present           (extension)    → TextPresent+Proceed (diff + backup path + mismatch_flag pre-gate)
-Phase 5 Qc                (constitution) → present (final approval; writable side effect with cross-session persistence; user authority required; option set extends to RouteToOperationalLayer when mismatch_flag is set)
+Phase 5 present           (extension)    → TextPresent+Proceed (diff + backup path + mismatch_signals pre-gate)
+Phase 5 Qc                (constitution) → present (final approval; writable side effect with cross-session persistence; user authority required; option set extends to RouteToOperationalLayer when mismatch_signals is non-empty)
 Phase 5 backup            (transform)    → Write (timestamped backup file; Approve disposition only)
 Phase 5 Write             (transform)    → Write (proposed profile to layer path; Approve disposition only)
 Phase 5 append_index      (transform)    → Write (append TrialIndexEntry to steer-trials.md at chosen layer; Approve and RouteToOperationalLayer dispositions only; create file on first entry)
@@ -362,7 +365,7 @@ converge                  (extension)    → TextPresent+Proceed (convergence ev
 Λ = { phase: Phase, scope: Scope, P_existing: ProjectProfile,
       moves: List(CalibrationMove), clusters: List(Cluster),
       cluster_verdicts: List<(Cluster, V)>,
-      diff: Optional(Diff), mismatch_flag: Optional(MismatchSignal),
+      diff: Optional(Diff), mismatch_signals: MismatchSignals,
       recommended_layer: Optional(RecommendedLayer),
       modify_iterations: Nat,
       backup_path: Optional(Path), write_path: Optional(Path),

--- a/epistemic-cooperative/skills/steer/SKILL.md
+++ b/epistemic-cooperative/skills/steer/SKILL.md
@@ -192,13 +192,13 @@ Options:
 
 After response:
 
-- **Approve** — execute write sequence: (i) create timestamped backup of existing file (or skip backup when existing file is absent), (ii) write the new profile to the target path, (iii) emit UpdatedProjectProfile session-text artifact with the diff trace and the backup path for rollback
+- **Approve** — execute write sequence: (i) create timestamped backup of existing file (or skip backup when existing file is absent), (ii) write the new profile to the target path, (iii) append a structured entry to the trial index (`steer-trials.md` at the same layer scope), (iv) emit UpdatedProjectProfile session-text artifact with the diff trace, the backup path for rollback, and the index entry path
 - **Modify** — accept the user's variable-level adjustments, regenerate the diff, re-present Phase 5 Constitution interaction
-- **Reject** — emit NoUpdateNote session-text artifact recording the reviewed clusters and dismissed diff; existing file unchanged
-- **Defer** — emit the diff as a paste-ready markdown block AND keep the existing profile file unchanged for now; the user retains the audit work for manual application later (distinct from Reject, which discards the diff entirely)
-- **RouteToOperationalLayer** — emit OperationalLayerRecommendation session-text artifact recording: (i) the fit-shape mismatch signal that triggered the routing, (ii) the recommended operational layer per finding shape (hooks, system prompt, CI/CD, settings.json), (iii) a realization template (concrete trigger + behavior outline + scope) for downstream implementation. Existing rule file unchanged. Steer's role is to recognize the routing and emit the realization template; implementation belongs to a downstream task using the appropriate substrate tooling
+- **Reject** — emit NoUpdateNote session-text artifact recording the reviewed clusters and dismissed diff; existing file unchanged; trial index untouched (no inscription to track)
+- **Defer** — emit the diff as a paste-ready markdown block AND keep the existing profile file unchanged for now; the user retains the audit work for manual application later (distinct from Reject, which discards the diff entirely); trial index untouched until the user manually applies the diff
+- **RouteToOperationalLayer** — emit OperationalLayerRecommendation session-text artifact recording: (i) the fit-shape mismatch signal that triggered the routing, (ii) the recommended operational layer per finding shape (hooks, system prompt, CI/CD, settings.json), (iii) a realization template (concrete trigger + behavior outline + scope) for downstream implementation. Append a structured entry to the trial index (`steer-trials.md` at the same layer scope) so the proposed routing is inventoried even when implementation is deferred to a downstream task. Existing rule file unchanged. Steer's role is to recognize the routing and emit the realization template; implementation belongs to a downstream task using the appropriate substrate tooling
 
-After integration, log the disposition. The rule file write is the Circular Return — the inscribed profile becomes the new prejudgment baseline for the next `/steer` invocation, and meanwhile shapes Cognitive Partnership Move defaults across all subsequent sessions.
+After integration, log the disposition. The rule file write (Approve) or the index inscription (Approve and RouteToOperationalLayer) is the Circular Return — the inscribed profile becomes the new prejudgment baseline for the next `/steer` invocation, and the trial index becomes the at-a-glance inventory of trials this project's `/steer` has produced.
 
 ```
 ── FLOW ──
@@ -217,11 +217,11 @@ Steer(scope) → Phase0(scope, user_confirm) →
       Assemble(confirmed_clusters, P_existing) → diff →
       fit_shape_check(diff) → mismatch_flag →
       present(diff, backup_path, mismatch_flag) → Qc(approve) → Stop → A →
-        Approve: backup(P_existing) → write(P_proposed, layer) → emit(UpdatedProjectProfile)
+        Approve: backup(P_existing) → write(P_proposed, layer) → append_index(layer) → emit(UpdatedProjectProfile)
         Modify(adjustments): regenerate(diff, adjustments) → re-present Phase5
         Reject: emit(NoUpdateNote) → no write
         Defer: emit(DiffArtifact) → no write
-        RouteToOperationalLayer: emit(OperationalLayerRecommendation) → no write
+        RouteToOperationalLayer: append_index(layer) → emit(OperationalLayerRecommendation)
       converge
 
 ── MORPHISM ──
@@ -236,6 +236,7 @@ SessionCalibrationMoves
   → present_diff(approve, mismatch_flag) -- final Constitution interaction
   → write(profile, layer, backup) | emit(OperationalLayerRecommendation)
                                         -- circular return (inscription to rule layer) OR routing
+  → append_index(layer)                  -- trial inventory append (Approve and RouteToOperationalLayer only)
   → UpdatedProjectProfile | OperationalLayerRecommendation
 requires: calibration_drift_opaque(scope) ∧ scope_resolved(user)  -- activation precondition + Phase 0 confirmation
 deficit:  CalibrationDriftOpaque             -- activation precondition (user-invoked Layer 1)
@@ -271,13 +272,23 @@ A                 = ApprovalDisposition ∈ {Approve, Modify(adjustments), Rejec
 MismatchSignal    ∈ {ProgrammaticTrigger, LayerMixing, BehavioralEnforcement} — Phase 4 fit-shape check output; absent when diff fits project-profile.md structure
 RecommendedLayer  ∈ {Hook(HookEvent), SystemPrompt, CI_CD, Settings, Other(String)}
 HookEvent         ∈ {SessionStart, SessionEnd, UserPromptSubmit, PreToolUse, PostToolUse, Stop, SubagentStop, PreCompact, Notification}
-UpdatedProjectProfile = session text { layer, diff, backup_path, write_path }
+UpdatedProjectProfile = session text { layer, diff, backup_path, write_path, index_entry_path }
 NoUpdateNote      = session text { reviewed_clusters, dismissed_diff }
 DiffArtifact      = session text { diff_markdown, suggested_apply_path }
 OperationalLayerRecommendation = session text { mismatch_signal: MismatchSignal,
                                                 recommended_layer: RecommendedLayer,
                                                 realization_template: String,
-                                                trial_scope: String }
+                                                trial_scope: String,
+                                                index_entry_path: Path }
+TrialIndexEntry   = { date: ISO8601Date, disposition: A,
+                      mismatch_signal: Optional(MismatchSignal),
+                      recommended_layer: Optional(RecommendedLayer),
+                      realization_refs: List(Path | String),
+                      origin_context: String,
+                      falsification: Optional(String),
+                      reevaluation: Optional(String),
+                      status: TrialStatus }
+TrialStatus       ∈ {active, completed, retracted}
 Phase             ∈ {0, 1, 2, 3, 4, 5}
 
 ── SCOPE-BINDING ──
@@ -303,11 +314,11 @@ Phase 3: clusters → loop:
 Phase 4: confirmed_clusters → assemble_diff(P_existing) → diff →
            fit_shape_check(diff) → mismatch_flag                                -- tier resolution + fit-shape detection (sense)
 Phase 5: diff, mismatch_flag → present(diff, backup_path, mismatch_flag) → Qc(approve) → Stop → A  -- final Constitution interaction [Tool]
-           A = Approve → Write(backup) → Write(P_proposed) → emit(UpdatedProjectProfile)
+           A = Approve → Write(backup) → Write(P_proposed) → Append(steer_trials_md) → emit(UpdatedProjectProfile)
            A = Modify → regenerate(diff) → Phase 5 re-entry
            A = Reject → emit(NoUpdateNote)
            A = Defer → emit(DiffArtifact)
-           A = RouteToOperationalLayer → emit(OperationalLayerRecommendation)
+           A = RouteToOperationalLayer → Append(steer_trials_md) → emit(OperationalLayerRecommendation)
 
 ── LOOP ──
 Phase 3 → Phase 4 → Phase 5 →
@@ -343,6 +354,7 @@ Phase 5 present           (extension)    → TextPresent+Proceed (diff + backup 
 Phase 5 Qc                (constitution) → present (final approval; writable side effect with cross-session persistence; user authority required; option set extends to RouteToOperationalLayer when mismatch_flag is set)
 Phase 5 backup            (transform)    → Write (timestamped backup file; Approve disposition only)
 Phase 5 Write             (transform)    → Write (proposed profile to layer path; Approve disposition only)
+Phase 5 append_index      (transform)    → Write (append TrialIndexEntry to steer-trials.md at chosen layer; Approve and RouteToOperationalLayer dispositions only; create file on first entry)
 Phase 5 emit              (extension)    → TextPresent+Proceed (UpdatedProjectProfile or NoUpdateNote or DiffArtifact or OperationalLayerRecommendation, per disposition)
 converge                  (extension)    → TextPresent+Proceed (convergence evidence trace)
 
@@ -354,6 +366,7 @@ converge                  (extension)    → TextPresent+Proceed (convergence ev
       recommended_layer: Optional(RecommendedLayer),
       modify_iterations: Nat,
       backup_path: Optional(Path), write_path: Optional(Path),
+      index_path: Optional(Path), index_entry: Optional(TrialIndexEntry),
       disposition: Optional(A), active: Bool, cause_tag: String }
 
 ── COMPOSITION ──
@@ -370,8 +383,9 @@ converge                  (extension)    → TextPresent+Proceed (convergence ev
 **Write paths**:
 - Proposed profile: same path as the existing profile at the chosen layer
 - Backup: `<existing_profile_path>.bak.YYYYMMDD-HHMMSS` (timestamp ensures backups accumulate without overwrite); backup is created before the proposed profile write so rollback is `mv <backup_path> <existing_profile_path>`
+- Trial index: `.claude/steer-trials.md` (project_local) or `~/.claude/steer-trials.md` (user_global). Lazy-loaded inventory file appended to on Approve and RouteToOperationalLayer dispositions; created on first entry. Reject and Defer leave it untouched.
 
-**First-time induction**: when the existing profile file is absent, Phase 1 treats `P_existing = P_∅` (empty profile). Phase 5 Approve writes the proposed profile without backup (nothing to back up). The emitted UpdatedProjectProfile artifact notes the first-time induction status.
+**First-time induction**: when the existing profile file is absent, Phase 1 treats `P_existing = P_∅` (empty profile). Phase 5 Approve writes the proposed profile without backup (nothing to back up). The emitted UpdatedProjectProfile artifact notes the first-time induction status. The trial index append still occurs.
 
 ## Rules
 
@@ -392,6 +406,7 @@ converge                  (extension)    → TextPresent+Proceed (convergence ev
 15. **Stage 2 evidence-collection modality** — This skill is released as a Stage 2 evidence-collection instrument; architectural inscription (graph.json placement, advisory edges, formal lineage to /induce) is deferred until variation-stable retention evidence accumulates. Every emitted UpdatedProjectProfile, NoUpdateNote, DiffArtifact, and OperationalLayerRecommendation carries an N=1 dogfooding caveat acknowledging the single-user evidence base.
 16. **Vocabulary discipline** — Output uses positive framing: "drift", "calibration", "fit", "recalibration", "induce", "steering". Output frames per-cluster verdicts as recognition acts and the final approval as a writable inscription. The skill describes evidence and diffs; verdicts and approvals belong to the user.
 17. **Routing to operational layer when finding shape mismatches** — When the Phase 4 fit-shape check detects that the assembled diff requires programmatic-trigger enforcement, mixes universal principle with specific instance and recognition mechanism, or has behavioral enforcement (rather than visibility) as its load-bearing requirement, surface RouteToOperationalLayer as a Phase 5 disposition. The operational layer (hooks, system prompts, CI/CD, settings.json) realizes Standing-authority delegation per `architectural-principles.md §Epistemic Completeness Boundary`. Steer's role is to recognize the routing and emit a realization template (concrete trigger + behavior outline + scope); implementation belongs to a downstream task using the appropriate substrate tooling. The user retains override authority — selecting Approve forces prose inscription despite the routing recommendation.
+18. **Trial index inscription** — On Approve and RouteToOperationalLayer dispositions, append a structured TrialIndexEntry to `steer-trials.md` at the chosen layer (`.claude/steer-trials.md` for project_local, `~/.claude/steer-trials.md` for user_global). The entry records date, disposition type, mismatch signal (when RouteToOperationalLayer), realization references (rule file path or operational-layer artifact paths), origin context, falsification conditions (if specified), re-evaluation cadence, and current status. The index file is lazy-loaded — its purpose is single-glance trial inventory across sessions, not per-turn enforcement. Reject and Defer dispositions do not append (no inscription to track yet). The index file is created on first entry; existing entries are not retroactively backfilled. Layer scope of the index matches the disposition's layer — index inscription does not cross layer boundaries.
 
 ## UX Safeguards
 
@@ -403,6 +418,7 @@ converge                  (extension)    → TextPresent+Proceed (convergence ev
 - **Self-referential N=1 caveat** — Every emitted artifact (UpdatedProjectProfile, NoUpdateNote, DiffArtifact) carries the caveat acknowledging the single-user evidence base. The skill itself is a Stage 2 evidence-collection instrument, and this caveat is part of how that modality is honored (Rule 15 reinforcement).
 - **Defer disposition as escape hatch** — When the user is unsure about writing, the Defer option emits the diff as a session-text artifact for manual application. This honors the "writable side effect needs explicit approval" principle while preserving the audit work (Three-Tier Termination — `user_withdraw`-class disposition with partial state preservation).
 - **Operational-layer routing visibility** — When Phase 4 fit-shape check fires, Phase 5 surfaces the mismatch signal and recommended layer alongside the standard approval options. The user retains override authority: Approve forces prose inscription despite the routing recommendation, RouteToOperationalLayer accepts the recommendation and emits a realization template. The diff itself is unchanged across the two paths — routing is about *where* the inscription lives, not *what* it says (Rule 17 reinforcement).
+- **Trial index as single-glance inventory** — `steer-trials.md` at the chosen layer accumulates one TrialIndexEntry per Approve and per RouteToOperationalLayer disposition. The file is lazy-loaded so its growth does not inflate per-turn token cost; the user opens it on demand to review what trials are active, completed, or retracted. Each entry is self-contained (date, disposition, realization references, falsification, status) so a single read of the file gives the complete inventory without cross-session JSONL scanning (Rule 18 reinforcement).
 
 ## Trigger Signals
 
@@ -427,8 +443,8 @@ Skip Steer when:
 | User Esc key at any Constitution interaction | Deactivate Steer (ungraceful, no disposition record, no write) |
 | Phase 0 detects insufficient moves in scope | Deactivate with no-op note |
 | Phase 3 user selects Stop | Break loop, proceed to Phase 4 with assembled-so-far |
-| Phase 5 user selects Approve | Write executed, emit UpdatedProjectProfile, converge |
+| Phase 5 user selects Approve | Write executed (profile + trial index append), emit UpdatedProjectProfile, converge |
 | Phase 5 user selects Reject | No write, emit NoUpdateNote, converge |
 | Phase 5 user selects Defer | No write, emit DiffArtifact, converge |
-| Phase 5 user selects RouteToOperationalLayer (only available when fit-shape mismatch detected) | No write, emit OperationalLayerRecommendation, converge |
+| Phase 5 user selects RouteToOperationalLayer (only available when fit-shape mismatch detected) | No profile write; trial index append; emit OperationalLayerRecommendation; converge |
 | Phase 5 Modify re-entry exhausted (3 max) | Surface assembled diff as DiffArtifact (defer-equivalent) → converge |


### PR DESCRIPTION
## Summary

PR #336에서 도입한 `RouteToOperationalLayer` disposition을 실제 운영 가능한 형태로 끌어올림. 두 묶음을 한 PR에 응집:

- **Task C**: `/steer` SKILL.md에 trial index inscription convention 추가 (Rule 18)
- **Task B**: `/gh-address-comments` 게이트의 첫 Stage 2 trial — PostToolUse hook + settings.json + steer-trials.md 첫 entry

## Base

`feat/steer-route-to-operational-layer` (PR #336) 위에 stack. PR #336이 머지되면 자동으로 `main`에 rebase됨.

## Changes

### `/steer` SKILL.md — trial index convention (Task C)

| 변경 | 내용 |
|---|---|
| **신규 Rule 18** | Approve / RouteToOperationalLayer 시 `steer-trials.md`(layer-scoped)에 TrialIndexEntry append 의무화 |
| **TYPES** | `TrialIndexEntry` / `TrialStatus` 신규 · `UpdatedProjectProfile` + `OperationalLayerRecommendation`에 `index_entry_path` 필드 추가 |
| **FLOW · MORPHISM · PHASE TRANSITIONS · TOOL GROUNDING · MODE STATE** | `append_index` 단계 일관 갱신 |
| **Storage Reference** | `steer-trials.md` 경로 (project-local · user-global) 추가 |
| **UX Safeguard** | "Trial index as single-glance inventory" — lazy-loaded, per-turn token cost 0 |
| **Mode Deactivation** | Approve / RouteToOperationalLayer 행에 trial index append 명시 |

### `gh-comments-convergence` PostToolUse hook (Task B)

| 파일 | 역할 |
|---|---|
| `.claude/hooks/gh-comments-convergence.mjs` | Cross-CLI hook script (~70줄, Node stdlib only). GUIDANCES 배열 기반 확장 패턴 |
| `.claude/settings.json` | Claude Code PostToolUse Bash matcher (`$CLAUDE_PROJECT_DIR` placeholder) |
| `.claude/steer-trials.md` | Trial inventory 첫 entry (gh-comments-convergence) |

**Hook 메시지 — plugin encapsulation 준수**:
- `axioms.md §A5` · `project-profile.md` 등 외부 식별자 인용 없음
- 원칙 자체를 본문에 직접 진술 (option-set entropy 평가 + relay/gate 분기)
- "validate before relaying" 명시로 false positive 방어

**Cross-CLI 호환성**:
- Script header 주석에 Codex CLI v0.124.0+, Gemini CLI 등 설치 안내 inline
- stdin/stdout JSON 계약은 모든 hook-지원 CLI 공통

**검증된 시나리오**:
1. `fetch_comments.py` + findings 존재 → A5 reminder message emit ✓
2. non-fetch command → silent exit ✓
3. `fetch_comments.py` + 0 findings → silent exit ✓

### Trial inventory 첫 entry

`.claude/steer-trials.md`의 Active Trials에 `2026-05-05 — gh-comments-convergence hook` entry. 22 cross-session 증거 + falsification 조건 (정정 빈도 >20% / revert 발생 / gate surfacing >50%) + 1-2개월 re-evaluation cadence inscribed.

## Version

`epistemic-cooperative` plugin.json 2.10.0 → 2.11.0 (행동 추가, 시그니처 유지)

## Self-Finding의 Closed Loop

1. 직전 세션에서 `/gh-address-comments` 패턴 inscription 시도 → project-profile.md 부적합 발견
2. PR #336 — 발견을 plugin contract 정련(`RouteToOperationalLayer`)으로 회수
3. **이 PR** — 그 disposition의 첫 운영 instance(hook) + visibility infrastructure(trial index)를 함께 inscribe
4. 다음 `/steer` 사용자는 같은 spiral을 반복하지 않고 직접 routing → trial 등록까지 도달

## Test plan

- [ ] `/verify` fail/warn 0 (이미 로컬 확인)
- [ ] Hook 동작 검증: `fetch_comments.py` 실제 호출 시 `additionalContext` 주입 확인 (PR review에서 자연 발생)
- [ ] AI가 주입된 guidance를 받고 A5 적용을 시도하는지 — 다음 `/gh-address-comments` 호출에서 관찰
- [ ] `.claude/steer-trials.md` 가 lazy-loaded 유지 (auto-load 안 됨)
- [ ] PR #336 머지 후 자동 rebase

## Falsification (이 trial 자체)

다음 조건 발생 시 `/steer` 재실행으로 trial 재평가:
- post-relay 사용자 정정 빈도 > 20%
- relay-applied finding revert > 0 (PR cycle 내)
- 후속 `/gh-address-comments` 호출에서 gate surfacing이 여전히 > 50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
