### PR TITLE
feat(aitesis): #321(c) co-fire routing disambiguation Phase 1 Qc gate

### DIFF
--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution \u2014 /inquire (\u03b1\u1f34\u03c4\u03b7\u03c3\u03b9\u03c2: a requesting)",
-  "version": "4.3.23",
+  "version": "4.3.24",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -142,6 +142,7 @@ early_exit = user_declares_sufficient
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Phase 0 Scan    (sense)       → Internal analysis (no external tool)
+Phase 1 Routing_disambiguation (constitution) → present (conditional: Anamnesis empty_intention signal AND Aitesis Prior-decision implication signal both fire from activating utterance; surface routing options before context collection; default none — co-fire requires user judgment)
 Phase 1 Ctx     (observe)     → Read, Grep (stored knowledge extraction: codebase, memory, references); WebSearch, WebFetch (conditional: CanonicalExternal channel — RFCs, vendor API docs, standards; `source: "web:{url}"` tag + staleness guard via codebase version cross-check); Bash (conditional: VersionControlHistory channel — read-only commit-log queries via subprocess (content pickaxe, message search, temporal range); `source: "history:{ref}"` tag; collection-only — ref-type staleness classification handled per Phase 1 Step 1 staleness rule)
 Phase 1 Classify (observe)    → Internal analysis (multi-dimension assessment); Read, Grep (stored knowledge cross-reference analysis)
 Phase 1 Qc      (constitution)        → present (conditional: Coherence 2D off-diagonal Constitution interaction; fires only when scope ≠ resolution assessment; user classifies coherence type as MemoryInternal or CrossDomain)
@@ -320,6 +321,26 @@ Analyze prospect requirements against available context across multiple dimensio
 ### Phase 1: Context Collection + Classification + Empirical Observation
 
 Collect contextual evidence, classify each uncertainty by dimension and verifiability, and empirically observe accessible uncertainties with direct evidence.
+
+**Step 0 — Co-fire routing disambiguation (Constitution Qc gate, conditional)**:
+
+When the activating user utterance carries **both** signals simultaneously, present a routing disambiguation gate before context collection begins. Silent routing under co-fire is a Detection-with-Authority violation — both routing paths have differential downstream trajectories that the user must select.
+
+Co-fire trigger condition (both must hold):
+- **Anamnesis empty_intention signal**: utterance contains vague past pointing language (deictic time references, anaphoric "that time / earlier / previously" forms without specific anchor) that does not pinpoint a specific reference
+- **Aitesis Prior-decision implication signal**: prospect references or rests on a decision (architecture, API/protocol design, persisted state schema, user-facing behavior commitment) made in an earlier session, not present in current conversation context
+
+Detection: the gate fires from utterance scan in Phase 0; Phase 1 entry surfaces it before Step 1.
+
+Gate options (Qc, Constitution):
+- **Anamnesis-first**: hand off to `/recollect` to recall past session content; resume Aitesis afterward with the recalled context narrowing the Phase 1 scan scope (per Cross-session enrichment)
+- **Aitesis-only**: skip subjective recall; proceed with codebase + memory file + version-control history collection (objective evidence channels) using staleness-guarded source tags
+- **Anamnesis-only**: hand off to `/recollect`; defer Aitesis activation if recalled context resolves the prior-decision uncertainty without additional objective investigation
+- **Both-disambiguated**: free response identifies which aspect of the utterance pertains to which protocol — user partitions; AI re-classifies uncertainties accordingly
+
+Default: none. Co-fire requires user judgment; no auto-resolve. The gate fires once per activation — on resumption after Anamnesis handoff, Phase 1 proceeds to Step 1 with recalled context, no re-firing.
+
+When only one signal fires (no co-fire), proceed directly to Step 1 — the routing distinction in Step 1 prose (objective historical investigation here vs subjective recall via `/recollect`) handles single-signal cases without gate.
 
 **Step 1 — Context collection**: For each uncertainty in `Uᵢ`:
 - **Call Read/Grep** to search for relevant information in codebase, configs, documentation


### PR DESCRIPTION
## Summary

Cat 3 (Aitesis) — PR #320 Routing distinction prose 의 sub-decision (c) Gap-Assumption 해소.

Anamnesis `empty_intention` trigger 와 Aitesis `Prior-decision implication` signal 이 동일 utterance 에서 동시 fire 할 때 silent routing decision 은 A2 violation. Phase 1 Step 0 Constitution Qc gate 추가로 surface.

## 변경

### Phase 1 Step 0 — Co-fire routing disambiguation Qc gate (신설)

- Trigger: Anamnesis empty_intention signal AND Aitesis Prior-decision implication signal 양쪽 fire
- Options (Constitution):
  - Anamnesis-first: /recollect → 복귀 후 Aitesis Phase 1 (recalled context narrows scope)
  - Aitesis-only: 객관적 channels (codebase + memory + version-control) 만으로 진행
  - Anamnesis-only: prior-decision uncertainty 가 recall 만으로 해소되면 Aitesis defer
  - Both-disambiguated: free-response partition
- Default: none — co-fire 는 user judgment 필수
- Single-signal 케이스는 Step 1 prose 의 기존 Routing distinction 으로 처리

### TOOL GROUNDING

새 항목 추가:
```
Phase 1 Routing_disambiguation (constitution) → present (conditional: Anamnesis empty_intention signal AND Aitesis Prior-decision implication signal both fire from activating utterance; surface routing options before context collection; default none — co-fire requires user judgment)
```

### Plugin version

- aitesis: 4.3.23 → 4.3.24

## Out of scope

issue #321 cited Stage 2 결정 사항:
- **sub-decision (a) CT-2**: fork predicate TYPES (RoutingMode enum) — Stage 2 evidence 누적 후
- **sub-decision (b) TT-2**: source tag algebraic constructor / namespace enforcement — Stage 2 evidence 누적 후

Sub-decision (c) "단기" 처리만 본 PR 범위. (a)(b) 는 #321 에서 추적 유지.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
```

- Before: fail 0, warn 5 (변경 무관, Wirkungsgeschichte/language-purity)
- After: fail 0, warn 5 (Cat 3 변경 신규 warn 0)

## Test plan

- [x] Phase 1 Step 0 prose 추가 정합 (Step 1 진입 전 위치)
- [x] TOOL GROUNDING `Phase 1 Routing_disambiguation (constitution)` 항목 등록
- [x] static check pass
- [ ] CI green

closes #321 sub-decision (c)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfSBqyy7FmUKUuENdgTKGL)_