### PR TITLE
refactor: 한글 추상화로 language-purity 잔여 처리 (#362) — Euporia cycle revised

### DIFF
--- a/.claude/skills/verify/scripts/language-purity.js
+++ b/.claude/skills/verify/scripts/language-purity.js
@@ -8,6 +8,8 @@
  *   - src/**                      Landing page i18n
  *   - docs/**                     Repo documentation reports
  *   - .claude/rules/editing-conventions.md  Korean commit convention text
+ *   - anamnesis/scripts/hypomnesis-write.mjs        Korean unicode range in tokenization regex
+ *   - epistemic-cooperative/agents/session-analyzer.md  Literal grep patterns for Korean user corrections
  *
  * Severity: warn (Stage 1 surface posture; fail promotion gated on Stage 2
  * retention evidence). One warn record per file with Korean lines listed.
@@ -42,6 +44,8 @@ const WHITELIST_PATTERNS = [
   /^design(\/|$)/,                        // root design docs
   /^examples(\/|$)/,                      // root examples
   /^\.claude\/rules\/editing-conventions\.md$/,
+  /^anamnesis\/scripts\/hypomnesis-write\.mjs$/,                      // Korean unicode range in tokenization regex
+  /^epistemic-cooperative\/agents\/session-analyzer\.md$/,            // Literal grep patterns for Korean user corrections
 ];
 
 const TEXT_EXTENSIONS = new Set([

--- a/.claude/skills/verify/scripts/language-purity.js
+++ b/.claude/skills/verify/scripts/language-purity.js
@@ -8,8 +8,6 @@
  *   - src/**                      Landing page i18n
  *   - docs/**                     Repo documentation reports
  *   - .claude/rules/editing-conventions.md  Korean commit convention text
- *   - anamnesis/scripts/hypomnesis-write.mjs        Korean unicode range in tokenization regex
- *   - epistemic-cooperative/agents/session-analyzer.md  Literal grep patterns for Korean user corrections
  *
  * Severity: warn (Stage 1 surface posture; fail promotion gated on Stage 2
  * retention evidence). One warn record per file with Korean lines listed.
@@ -44,8 +42,6 @@ const WHITELIST_PATTERNS = [
   /^design(\/|$)/,                        // root design docs
   /^examples(\/|$)/,                      // root examples
   /^\.claude\/rules\/editing-conventions\.md$/,
-  /^anamnesis\/scripts\/hypomnesis-write\.mjs$/,                      // Korean unicode range in tokenization regex
-  /^epistemic-cooperative\/agents\/session-analyzer\.md$/,            // Literal grep patterns for Korean user corrections
 ];
 
 const TEXT_EXTENSIONS = new Set([

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -572,7 +572,12 @@ function computeCoinage(userMsgs, allTexts, corpusPath, currentSessionId, budget
     ...userMsgs.map((m) => m.text),
     ...allTexts,
   ].join(" ").toLowerCase();
-  const tokenRe = /\b[a-zA-Z가-힣_][a-zA-Z가-힣_0-9-]{3,29}\b/g;
+  // Coinage targets English technical vocabulary (function names, identifiers,
+  // jargon). Korean natural-language tokens are handled by Haiku extraction in
+  // the 5 semantic categories above; admitting the Hangul range
+  // (U+AC00..U+D7A3) here would pollute coinage with common conversation
+  // tokens that carry no salience.
+  const tokenRe = /\b[a-zA-Z_][a-zA-Z_0-9-]{3,29}\b/g;
   const sessionCounts = new Map();
   for (const match of sessionText.matchAll(tokenRe)) {
     const t = match[0];

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /misuse, /crystallize, /rehydrate, /dispatch. See each skill's SKILL.md for details.",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/agents/session-analyzer.md
+++ b/epistemic-cooperative/agents/session-analyzer.md
@@ -137,19 +137,22 @@ The main agent (Phase 3) determines protocol mapping and coverage status (covere
 
 Detect user correction and backtracking patterns from session JSONL. These serve as direct evidence for anti-pattern detection.
 
-**Detection patterns** (Grep on session JSONL):
+**Detection approach** (semantic classification by you as a multilingual model):
 
-| Signal | Grep Pattern | Notes |
-|--------|-------------|-------|
-| Explicit correction | `"role":"user"` lines containing: "no,", "that's wrong", "not what I", "undo", "revert", "아니", "그게 아니라", "되돌려" | Require ≥20 chars context around keyword |
-| Backtracking | `"role":"user"` lines containing: "go back", "actually,", "wait,", "잠깐", "다시" followed by task keyword | "actually" alone too common; require co-occurrence with task-relevant keyword |
+You natively understand multilingual conversational cues; do not rely on a literal keyword table. Locate user messages via Grep on `"role":"user"`, then read each candidate message and classify by intent:
+
+| Signal | Semantic intent |
+|--------|-----------------|
+| Explicit correction | The user reverses or contradicts a prior assistant action — a no/wrong/undo/revert reaction, or any phrasing whose effect is "do not proceed in that direction". Cross-language; surface phrasing is incidental. |
+| Backtracking | The user redirects mid-task to a prior point — go-back / wait / hold-on cues paired with a task reference, signaling rewind across at least one substantive task step. Distinguish from minor adjustments where the task continues unchanged. |
 
 **Process**:
-1. Grep for correction/backtracking patterns with `output_mode: "count"` for each session
-2. If count > 0: extract one representative snippet per Step 2.5 methodology (user message + preceding AI response pair)
-3. Report: correction count per session, representative snippet (if found)
+1. Grep `"role":"user"` to enumerate user message regions per session
+2. Read a sampled subset of user messages and classify each by the semantic intents above; count corrections + backtracking events per session
+3. If count > 0: extract one representative snippet per Step 2.5 methodology (user message + preceding AI response pair)
+4. Report: correction count per session, representative snippet (if found)
 
-**Quality gate**: Only report corrections where the user message is ≥20 characters and clearly a correction (not ambiguous). Report `(no quality correction snippet)` if criteria not met.
+**Quality gate**: Only report corrections where the user message is ≥20 characters and the semantic classification is unambiguous. Report `(no quality correction snippet)` if criteria not met.
 
 ### Targeted Step (Mode 2 Only)
 
@@ -162,7 +165,7 @@ When `friction_pointers` are provided, skip Steps 1-2 and extract snippets targe
    - **Tier 1**: Grep for extracted keywords in the session JSONL — highest precision
    - **Tier 2**: Grep for friction-key behavioral proxies if Tier 1 yields no results:
      - `wrong_approach` → `"name":"Edit"` clusters (repeated edits)
-     - `misunderstood_request` → correction language patterns ("no,", "that's wrong", "not what I", "아니", "그게 아니라")
+     - `misunderstood_request` → user messages whose semantic intent reads as correction or rejection of the assistant's prior interpretation (cross-language; classify by intent, not by literal keyword)
      - `user_rejected_action` → `"name":"AskUserQuestion"` near rejection context
      - `excessive_changes` → `"name":"Edit"` high-frequency regions
      - `context_loss` → `"name":"Read"` clusters (re-reading attempts)


### PR DESCRIPTION
## 배경

`/dispatch` 사이클 conservative scope (#362, #358).

**Cycle 갱신** — 첫 시도 (whitelist 접근, commit `e7f54f4`) 후 사용자 challenge 가 `/elicit` (Euporia) cycle 을 trigger:
> "정규식이 들어간 것 자체를 문제삼았는데 '기능적으로 필수' 가 뭘 의미하나요?"

Euporia substrate trace 결과 결정적 반증 등장:
- `language-purity.js:16-17` self-referential precedent — 검사기 본인이 charCode 추상화로 literal Korean 회피 (`"so this verifier file remains self-pure under its own check"`)
- vendor `marked.min.js`: `\p{L}\p{N}/u` Unicode property 광범위 사용 — 환경 지원 확인
- 비-vendor 코드 전체에서 Hangul range 사용 위치 단 1곳 — 격리된 구현 선택, 컨벤션 아님

`whitelist` 응답은 abstraction path 가 존재했음에도 누락한 결과. axis 전환: **Korean 을 코드에서 의도적 추상화** (Korean 의도성을 코드 구조 자체에 inscribe).

## 변경 사항 (axis-revised)

### Commit 1 — Revert whitelist (`2310ac6`)

`e7f54f4` (PR #382 첫 시도) 되돌림.

### Commit 2 — `refactor(anamnesis)` (`8911c94`)

`anamnesis/scripts/hypomnesis-write.mjs:575` — coinage tokenizer 영문 한정.

| | Before | After |
|---|---|---|
| Regex | `/\b[a-zA-Z가-힣_][a-zA-Z가-힣_0-9-]{3,29}\b/g` | `/\b[a-zA-Z_][a-zA-Z_0-9-]{3,29}\b/g` |

**근거**: `computeCoinage` 의 목적은 영문 기술 어휘 (function names, identifiers, jargon) 의 salience 계산. Korean 자연어 토큰은 이미 Haiku extraction 의 5 semantic categories (actor / temporal / emotional / cognitive / singularity) 가 처리. Hangul range 포함은 common conversation token 으로 coinage set 오염.

`anamnesis` plugin version: 0.4.27 → 0.4.28.

### Commit 3 — `refactor(epistemic-cooperative)` (`a2451e8`)

`epistemic-cooperative/agents/session-analyzer.md` — Haiku agent 의 자체 추론으로 grep literal pattern 대체.

frontmatter `model: haiku` 확인 — agent 자체가 Haiku, multilingual 자체 추론 가능. literal Korean phrase ("아니", "그게 아니라", "되돌려", "잠깐", "다시") grep pattern 은 Haiku 능력 미활용.

| 위치 | Before | After |
|---|---|---|
| Step 2.7 Conversation Quality Signals | "Detection patterns (Grep)" 표 — literal Korean 포함 | "Detection approach (semantic classification)" 표 — agent 의 multilingual native 이해로 의미 분류 |
| Targeted Step Tier 2 fallback | `misunderstood_request` 프록시 = literal Korean phrase grep | `misunderstood_request` = "user messages whose semantic intent reads as correction or rejection" (cross-language) |

부수 효과: 한국어/영어 외에 임의 언어 correction phrasing 도 동일 prose 로 처리 — 다국어 정확도 개선.

`epistemic-cooperative` plugin version: 2.15.5 → 2.15.6.

## 검증

`node .claude/skills/verify/scripts/static-checks.js .`:
- fail: 0
- warn: 3 (전부 사전 존재; `Wirkungsgeschichte` 2건 + `Horizontverschmelzung` 1건 — 본 PR 범위 외)
- pass: 99
- `language-purity` warn: 2 → 0
- `version-staleness` warn: 0 (두 plugin version bump 반영)

## Dispatch 사이클 — Categorization (변경 없음)

- **Aligned + actionable (1)** — #362 (`closes #362`)
- **Stale / Superseded (1)** — #358 (별도 inscribed comment, 이미 close 권고)
- **Substrate-locked (4)** — #376, #346, #321(a/b), #28
- **Pilot-data-dependent (3)** — #373, #372, #49
- **Stale (1)** — #246

## Cycle meta — Euporia 결과로 PR axis 전환 trace

| Cycle | Frame | Outcome |
|---|---|---|
| Cycle 0 (PR 첫 시도) | "기능적으로 필수" → 화이트리스트 | abstraction path 누락 |
| Cycle 1 (Euporia trigger) | substrate trace → 4 의미 후보 (F1-F4) + hypomnesis/session-analyzer 처리 좌표 | F2 redirect (Haiku-위임 = abstraction path) + G "의도적 한글 제외" + H "Haiku agent 자체 추론" |
| Cycle 1 → action | revert + abstraction 2 commits | language-purity 0 warns, 의도성 inscribe in code structure |

## Test plan

- [x] `node .claude/skills/verify/scripts/static-checks.js .` — fail=0
- [x] `language-purity` warn: 2 → 0
- [x] `version-staleness` warn: 0 (anamnesis + epistemic-cooperative plugin.json 반영)
- [x] 사전 존재 warn 3건이 본 변경 외 영역임을 확인 (Wirkungsgeschichte, Horizontverschmelzung)

closes #362

https://claude.ai/code/session_01SuaoM6PwrUAabffdZCyx6Z