### PR TITLE
refactor(CLAUDE.md): northstar 지평융합 재합성 (#385)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## Northstar
 
-Epistemic Protocols is a domain-free metalanguage of structured types and morphisms for human-AI collaboration: it constrains AI attention without bias, elicits unknowns into utterance, and reflexively re-forms misalignment at each turn — the loop dissolves compounding cost before it forces whole-system refactoring.
+Epistemic Protocols is a domain-free metalanguage of structured types and morphisms for human-AI collaboration: it constrains AI attention without bias, elicits unknowns into utterance, and reflexively re-forms misalignment within the loop — the loop dissolves compounding cost before it forces whole-system refactoring.
+
+## Project Overview
 
 In this repository, that machinery is realized as a Claude Code plugin marketplace for epistemic dialogue — each protocol structures a specific decision point: **FrameworkAbsent → FramedInquiry** (Prothesis), **GapUnnoticed → AuditedDecision** (Syneidesis), **ResultUngrasped → VerifiedUnderstanding** (Katalepsis), **BoundaryUndefined → DefinedBoundary** (Horismos), **ContextInsufficient → InformedExecution** (Aitesis), **MappingUncertain → ValidatedMapping** (Analogia), **AbstractionInProcess → CrystallizedAbstraction** (Periagoge), **AbstractAporia → ResolvedEndpoint** (Euporia), **ExecutionBlind → SituatedExecution** (Prosoche), **ApplicationDecontextualized → ContextualizedExecution** (Epharmoge), **RecallAmbiguous → RecalledContext** (Anamnesis) during human-AI interaction.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Epistemic Protocols is a layered system for human-AI collaboration: it inserts structured checkpoints at decision points so misalignment is surfaced early, judged explicitly, and adapted before it compounds into expensive downstream work.
+Epistemic Protocols is a domain-free metalanguage of structured types and morphisms for human-AI collaboration: it constrains AI attention without bias, elicits unknowns into utterance, and reflexively re-forms misalignment at each turn — the loop dissolves compounding cost before it forces whole-system refactoring.
 
 In this repository, that machinery is realized as a Claude Code plugin marketplace for epistemic dialogue — each protocol structures a specific decision point: **FrameworkAbsent → FramedInquiry** (Prothesis), **GapUnnoticed → AuditedDecision** (Syneidesis), **ResultUngrasped → VerifiedUnderstanding** (Katalepsis), **BoundaryUndefined → DefinedBoundary** (Horismos), **ContextInsufficient → InformedExecution** (Aitesis), **MappingUncertain → ValidatedMapping** (Analogia), **AbstractionInProcess → CrystallizedAbstraction** (Periagoge), **AbstractAporia → ResolvedEndpoint** (Euporia), **ExecutionBlind → SituatedExecution** (Prosoche), **ApplicationDecontextualized → ContextualizedExecution** (Epharmoge), **RecallAmbiguous → RecalledContext** (Anamnesis) during human-AI interaction.
 


### PR DESCRIPTION
#385 /induce(Periagoge) 결정화 결과 — 3-horizon Horizontverschmelzung으로 northstar 라인 재합성. 시도 1(addendum) → Reorient → 시도 2(fusion) → Confirm. 셋 horizon 모두 변환:
- (a) 기존 northstar 골격
- (a) 사용자 본질감각 — domain-free metalanguage / AI 어텐션 / unknown 발화
- (b) 외부 채널 — reflexive revision trajectory (#376/#385)
- (c) Vorverständnis — compounding cost / whole-system refactoring (세션 메타 언급)

이 northstar는 모든 core protocol(11개) + 모든 utility를 포괄. 남은 implementation(/realign 신설, crystallize/rehydrate retire, sync, PR #384 close)은 후속 issue #386으로 결정화.

## Review Disposition

claude[bot] review 5건 중 옵션 B 적용 — 구조(`## Northstar` 별도 섹션) + #5(turn → loop) 적용, #1-4 considered-and-declined. dispatch SKILL.md Phase 6 패턴(verbatim quote → fresh-context re-derivation 방지) 준수.

### #5 — 적용 (commit 26fd710)

> "reflexively re-forms misalignment at each turn" overgeneralizes. A3 operates per-protocol, not per-turn; the "reflexive" claim applies narrowly to / utilities. ... Consider "iteratively refines detection at each protocol loop" or similar, scoped to active protocols.

→ `at each turn` → `within the loop`. 사용자 #385 (a) 응답의 `loop` 어휘 ("반복 교정이 루프로 들어갔지만") 회복.

### #1-4 — Considered-and-declined

#385 horizon-fusion 결과 사용자 어휘 보존. 4건 모두 사용자 (a) 응답에서 직접 채택된 표현 — re-derivation 시 본 disposition이 provenance 제공.

**#1 `domain-free`** —
> "domain-free" is defensible (protocols are application-domain-independent) but undefined locally and easy to misread as "context-free" or "ungrounded." Consider anchoring this claim or using a term like "domain-agnostic" if the intent is independence from specific application domains.

→ 사용자 직접 어휘: "domain free 인 metalanguage 에 가까운 카테고리 이론과 타입이론을 채택". 다음 단락(11 protocol enumeration)이 의미 anchoring 역할.

**#2 `metalanguage`** —
> "metalanguage" is partly accurate given the formal blocks in SKILL.md, but technically oversells the scope. The formal blocks are a structured notation, not a fully defined metalanguage with its own inference semantics. Consider "formal notation" or "structured types and morphisms" (already present elsewhere in the sentence) as more precise.

→ 사용자 직접 어휘 보존. hedge("에 가까운")는 fusion에서 탈락하나 어휘 자체는 사용자 결정.

**#3 `without bias`** —
> "constrains AI attention without bias" is a strong, ungrounded claim. A2 (Detection with Authority) preserves user judgment authority rather than asserting bias-freedom. The phrase "without bias" overstates the protocol's guarantees. Consider "informs user judgment about AI attention" or remove the bias claim entirely.

→ 사용자 직접 어휘: "의도에 모순과 편향이 없는 방식의 지침을 원하며". A2와 fully aligned는 아니나 사용자 의도(편향 없음)의 직접 인용.

**#4 `elicits unknowns into utterance`** —
> "elicits unknowns into utterance" is poetic, but less precise than the existing framing in CLAUDE.md of deficits and their A1–A6 morphisms. The new phrase obscures the concrete mechanism: the protocols surface gaps/mismatches and structure user judgment. Consider anchoring this to recognizable terminology (e.g., "surfaces hidden gaps in understanding").

→ 사용자 직접 어휘: "모델이 unknown 를 발화에서 끄집어내는 목적". `unknown(silent) → utterance(vocalized)` 구조 보존; bot 대안은 평탄화.

🤖 #385 /induce 세션 산출물 + /contextualize S3 disposition

https://claude.ai/code/session_01MsCmxNPe65ASRNfhaKbVq3