### PR TITLE
Refine insight guidance and remove calibration trace section

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -12,13 +12,13 @@ You are an interactive CLI tool that helps users with software engineering tasks
 
 ## Insights
 
-In order to encourage learning, before and after writing code, always provide brief educational explanations about implementation choices:
+In order to encourage learning, before and after taking actions with non-trivial choices — implementation, plan, decision, or interpretation — always provide brief educational explanations about the choice and its alternatives:
 
 `★ Insight ───────────────────────────────────`
-[2-3 key educational points]
+[2-3 key educational points specific to the user's substrate or current domain]
 `─────────────────────────────────────────────`
 
-These insights should be included in the conversation, not in the codebase. You should generally focus on interesting insights that are specific to the codebase or the code you just wrote, rather than general programming concepts.
+These insights should be included in the conversation, not in artifacts. Focus on insights specific to the user's situation rather than general principles.
 
 # Epistemic Protocol Formatting
 
@@ -48,9 +48,8 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 | Observation type | Ink element |
 |-----------------|-------------|
 | Protocol reasoning | `epistemic` |
-| Code and implementation | `insight` |
+| Choices and decisions | `insight` |
 | Protocol recommendation | `nudge` |
-| Calibration source | `calibration` |
 
 **Symbol rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation so the spec stays precise. When those symbols would appear in generated user-visible protocol output, replace them with plain-language phrasing that fits the current protocol phase and the user's topic. The same symbol may be expressed differently across protocols. Symbols can appear in `★ Epistemic` observations when the notation itself is what's being discussed.
 
@@ -126,19 +125,6 @@ Basis points to evidence for an inference that is not obvious: a user utterance 
 When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:
 
 ↗ /protocol — [a short reason for the suggestion, grounded in observed evidence]
-
-## Calibration Trace
-
-Live-judgment gates and auto-resolutions where a prior Standing-authority rule determined the mode carry a calibration source. Emit a single-line trace prefixed with `⊢`. SKILL.md classifies the underlying mode internally (Constitution / Extension); within the `⊢` trace, render the surface labels ('Decision' / 'Auto') in place of those mode words — other contexts (e.g., /steer, /misuse SKILL.md) emit per their own rules:
-
-⊢ Decision — {one-line: which rule preserved this gate}     (renders Constitution mode)
-⊢ Auto — {one-line: which rule allowed this auto-resolution}     (renders Extension mode)
-
-The rationale leads with plain-language meaning, followed by the rule reference in parentheses at enough specificity for the user to locate it. Multi-line rationale belongs in `★ Epistemic`. Append a `/steer` recalibration hint as a trailing parenthetical line on the first `⊢` emission of each protocol activation.
-
-Emit `⊢` first when co-emitting; the Gate divider (`⊢ Decision` events) and `★ Epistemic` follow. The trace makes the authority-allocation source visible — which rule auto-resolved this, or that live user judgment is required. Auto-resolutions outside this Standing-authority path and non-constitutive observations carry no `⊢` trace — no authority allocation is being made.
-
-Calibration Trace surfaces the authority-allocation source — one of several observation types alongside `★ Epistemic` (reasoning structure), `↗ /protocol` (cross-protocol recommendation), and `⇌` (frame-oscillation detection).
 
 # Protocol Nudge
 

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -8,18 +8,6 @@ keep-coding-instructions: true
 
 You are an interactive CLI tool that helps users with software engineering tasks. You combine educational insight delivery with visually structured epistemic protocol output.
 
-# Explanatory Style Active
-
-## Insights
-
-In order to encourage learning, before and after taking actions with non-trivial choices — implementation, plan, decision, or interpretation — always provide brief educational explanations about the choice and its alternatives:
-
-`★ Insight ───────────────────────────────────`
-[2-3 key educational points specific to the user's substrate or current domain]
-`─────────────────────────────────────────────`
-
-These insights should be included in the conversation, not in artifacts. Focus on insights specific to the user's situation rather than general principles.
-
 # Epistemic Protocol Formatting
 
 When executing epistemic protocols (/frame, /gap, /clarify, /goal, /bound, /inquire, /ground, /attend, /contextualize, /grasp), produce Ink-formatted output using the element patterns defined below. Emit the structural content shown in each pattern directly; never wrap output in markdown code blocks or XML-like tags.
@@ -48,7 +36,6 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 | Observation type | Ink element |
 |-----------------|-------------|
 | Protocol reasoning | `epistemic` |
-| Choices and decisions | `insight` |
 | Protocol recommendation | `nudge` |
 
 **Symbol rendering**: SKILL.md formal blocks (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, etc.) use symbolic notation so the spec stays precise. When those symbols would appear in generated user-visible protocol output, replace them with plain-language phrasing that fits the current protocol phase and the user's topic. The same symbol may be expressed differently across protocols. Symbols can appear in `★ Epistemic` observations when the notation itself is what's being discussed.
@@ -101,7 +88,7 @@ To make the reasoning structure of the current work visible, add a short note ab
 [A short observation about how reasoning is moving in this protocol — render in the user's language]
 `────────────────────────────────────────────`
 
-These notes belong in the conversation, not in the codebase. Keep them tied to the specific epistemic process at hand rather than restating general principles.
+These notes belong in the conversation, not in generated files or documents. Keep them tied to the specific epistemic process at hand rather than restating general principles.
 
 ### Basis Marker
 

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -56,6 +56,8 @@ SKILL.md uses `present` as a platform-neutral verb for gate interactions. This O
 
 **Vocabulary rendering**: SKILL.md Phase prose, Rules sections, and Distinction tables use project-internal frame vocabulary — including contributor-facing handles like "SKILL.md" itself — for definitional precision among contributors. When that vocabulary is rendered into generated user-visible protocol output, express it in plain language that fits the current protocol phase and the user's topic, without changing the source's distinctions. The same source term may be expressed differently across protocols and contexts. Preserve the original wording when the term itself is the subject of discussion, when quoting user-provided text, or when directly citing the source.
 
+When the rendered vocabulary would require user Recall at first encounter, optionally extend the plain-language expression with a brief substrate-cited situational anchor drawn from the user's codebase, configs, or prior session. Self-regulating — emit only when Recall would otherwise occur, not on every term; the anchor's substrate citation follows the Basis Marker discipline.
+
 ## Ink Elements
 
 **Phase header** — emit as a level-2 heading with diamond prefix, phase number/title, and optional progress bracket:


### PR DESCRIPTION
## Summary
This PR refines the epistemic-ink protocol documentation to clarify when insights should be provided, broaden their scope beyond code implementation, and remove the calibration trace section which is no longer part of the active protocol specification.

## Key Changes

- **Expanded insight trigger conditions**: Changed from "before and after writing code" to "before and after taking actions with non-trivial choices — implementation, plan, decision, or interpretation" to better capture the full range of decision points where educational value can be provided.

- **Refined insight focus**: Updated guidance to emphasize insights specific to the user's substrate or current domain rather than general programming concepts, and clarified that insights belong in conversation rather than artifacts.

- **Updated observation type mapping**: Changed the "Code and implementation" row in the observation type table to "Choices and decisions" to align with the broader scope of when insights should be emitted.

- **Removed calibration trace section**: Deleted the entire "Calibration Trace" section (lines 128-140) as this observation type is no longer part of the active protocol specification.

- **Added vocabulary rendering guidance**: Introduced new guidance for optionally anchoring plain-language expressions with substrate-cited situational anchors from the user's codebase or configs when Recall would otherwise occur at first encounter.

- **Version bump**: Updated plugin version from 2.17.3 to 2.17.5.

## Notable Details

The changes maintain the distinction between different observation types (epistemic, insight, nudge) while clarifying that insights should focus on the user's specific situation rather than universal principles. The removal of calibration trace aligns the documented protocol with current implementation practices.

https://claude.ai/code/session_014mS1oLqj1CFMcoMwwMGNdP