### PR TITLE
refactor(release): Phase 4 axis enumeration + Phase 5 horizon fusion sub-protocol 추가

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -58,6 +58,20 @@ Deprioritize:
 - Single-PR review-round commits, CI test count bumps, version bumps without content
 - Commits whose only effect is subsumed by a broader commit in the same range
 
+**Theme axis enumeration** (conditional on commit set complexity):
+
+When the commit set admits multiple plausible theme axes — distinct ways to group the same commits under different unifying frames — enumerate ALL axes before drafting. Trigger: 5+ semantically distinct change clusters in the commit range, or no single dominant change that carries the release on its own.
+
+For each candidate axis, present as a numbered list (text output, not a gate option set — the user's response is free-form selection, supplement, or a new axis):
+- **Theme line**: the unifying frame the axis would emphasize
+- **Foregrounds**: which commits become the narrative centerpiece
+- **Backgrounds**: which commits become accompanying detail
+- **Trade-off signal**: structural strength (faithful to commit shape) vs. interpretive weight (post-hoc grouping)
+
+Include a brief epistemic observation on which axes preserve the commit set's actual shape vs. which apply heavier grouping. When the commit set admits a single dominant theme — one frame is uniquely the best fit and other framings would feel like post-hoc reframing — skip axis enumeration and proceed directly to drafting.
+
+After enumeration, draft narrative using the axis the agent judges best-fit; the gate at Phase 5 lets the user pick a different axis if preferred.
+
 Draft narrative using this template (Korean, matching repo's PR body convention):
 
 ```
@@ -74,22 +88,37 @@ Draft narrative using this template (Korean, matching repo's PR body convention)
 {script-generated body}
 ```
 
-Emoji selection is descriptive (choose what fits the change's semantic class), not prescriptive. Examples observed across releases: ✍️ editing/writing, 🔎 introspection, 🧠 memory/cognition, 🏛️ structural/axiom, 🪢 cross-cutting principle, 🔍 verification, 🎯 classification, ⚡ simplification.
+Emoji selection is descriptive: choose an emoji whose visual semantic matches the change class. The same change class may take different emoji across releases — match the release's framing, not a fixed table.
 
-### Phase 5: Gate
+### Phase 5: Gate with horizon fusion
 
 **Context** (emit before the gate, as text output):
+- Theme axis enumeration when generated in Phase 4 (re-surface for Recognition; the user may select a different axis than the one the agent drafted from)
 - Full composed body preview: narrative draft + `---` + script-generated body
 - Theme sentence and bullet selection rationale
 
-**Question**: Apply the drafted narrative to the draft release?
+**Experiential elicitation** (emit as part of context):
+
+Background narratives benefit from the user's experiential grounding — the lived origin that motivated the release. The AI draft maps commit shape; the user supplies the grounding that makes the shape readable. Explicitly invite the user to supplement Background; supplementation is optional. When the AI draft already captures the origin from commit content alone, the invitation can be lightweight — but it must still be surfaced so the option is recognized rather than recalled.
+
+**Question**: Apply the drafted narrative, supplement with experiential context, modify other elements, or skip?
 
 Options:
 1. **Apply** — prepend narrative as drafted; proceed to Phase 6
-2. **Modify** — user supplies edits or regeneration directive; revised draft re-presents at Phase 5 (loop until Apply or Skip)
-3. **Skip** — leave script-generated body as-is (patch-only releases per Rule 5); proceed to Phase 6 with no prepend
+2. **Add experiential context** — user supplies lived origin / environmental observation; AI fuses it with the draft Background as a new horizon (preserving the AI's commit-mapping spine, adding the user's experiential grounding); revised draft re-presents at Phase 5 (loop)
+3. **Modify** — user supplies edits to axis selection, bullet text, emoji, or tone; revised draft re-presents at Phase 5 (loop)
+4. **Skip** — leave script-generated body as-is (patch-only releases per Rule 5); proceed to Phase 6 with no prepend
 
-This gate is mandatory even if the narrative seems obvious — theme choice is a constitutive judgment the user owns.
+This gate is mandatory even if the narrative seems obvious — theme choice and origin framing are constitutive judgments the user owns.
+
+**Horizon fusion sub-protocol** (engaged when user selects Add experiential context):
+
+1. Treat the AI draft Background as Horizon A — the commit-shape narrative
+2. Treat the user's experiential input as Horizon B — the lived origin
+3. Fuse: preserve Horizon B's voice and the arc the user actually supplied; let Horizon A inform which protocol/utility is named in the closing sentence
+4. Bullets remain anchored to Horizon A (commit-mapping); only Background absorbs Horizon B
+5. Per-horizon trace (preserved / transformed / dropped) is internal — render only the fused candidate at Phase 5
+6. Iteration is expected: each loop pass refines whatever dimension the prior pass left under-specified. Continue looping until Apply or Skip — do not pre-empt convergence by treating the first fusion as final.
 
 ### Phase 6: Apply + surface
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -60,7 +60,7 @@ Deprioritize:
 
 **Theme axis enumeration** (conditional on commit set complexity):
 
-When the commit set admits multiple plausible theme axes — distinct ways to group the same commits under different unifying frames — enumerate ALL axes before drafting. Trigger: 5+ semantically distinct change clusters in the commit range, or no single dominant change that carries the release on its own.
+When the commit set admits multiple plausible theme axes — distinct ways to group the same commits under different unifying frames — enumerate ALL axes before drafting. Trigger: no single dominant change carries the release on its own; 5+ semantically distinct change clusters in the commit range is a heuristic signal of this condition, not the trigger by itself.
 
 For each candidate axis, present as a numbered list (text output, not a gate option set — the user's response is free-form selection, supplement, or a new axis):
 - **Theme line**: the unifying frame the axis would emphasize
@@ -93,7 +93,7 @@ Emoji selection is descriptive: choose an emoji whose visual semantic matches th
 ### Phase 5: Gate with horizon fusion
 
 **Context** (emit before the gate, as text output):
-- Theme axis enumeration when generated in Phase 4 (re-surface for Recognition; the user may select a different axis than the one the agent drafted from)
+- Theme axis enumeration when generated in Phase 4 — condense to a labels-only form (axis names without per-axis 4-tuple) and reference the Phase 4 detail above when full re-surfacing would bloat the gate context; otherwise re-surface in full. Either form preserves Recognition that the user may select a different axis than the one the agent drafted from.
 - Full composed body preview: narrative draft + `---` + script-generated body
 - Theme sentence and bullet selection rationale
 
@@ -117,7 +117,7 @@ This gate is mandatory even if the narrative seems obvious — theme choice and 
 2. Treat the user's experiential input as Horizon B — the lived origin
 3. Fuse: preserve Horizon B's voice and the arc the user actually supplied; let Horizon A inform which protocol/utility is named in the closing sentence
 4. Bullets remain anchored to Horizon A (commit-mapping); only Background absorbs Horizon B
-5. Per-horizon trace (preserved / transformed / dropped) is internal — render only the fused candidate at Phase 5
+5. Per-horizon trace (preserved / transformed / dropped) renders as a single line before the fused candidate at Phase 5 — naming what each horizon contributed, what was transformed in fusion, and what was dropped. The trace surfaces fusion accountability, matching the trace-visibility pattern in `/realign`.
 6. Iteration is expected: each loop pass refines whatever dimension the prior pass left under-specified. Continue looping until Apply or Skip — do not pre-empt convergence by treating the first fusion as final.
 
 ### Phase 6: Apply + surface


### PR DESCRIPTION
## 배경

v2026.05.12 release 흐름에서 관찰된 두 마찰점을 release skill의 procedure에 inscribe.

- Phase 5 첫 turn에서 단일 theme draft를 제시하자 user가 "다른 테마도 있나요?" 질문 → 단일 draft가 다른 theme axis Recognition을 막은 흔적
- 이후 turn들에서 user의 experiential context(노션 받아쓰기 dogfooding origin)가 단계적으로 fusion되며 수렴 → 현재 template은 이 elicitation pathway를 명시하지 않음

두 패턴 모두 future session에서 재발할 수 있는 구조라 SKILL.md procedure에 inscribe.

## 변경 내용

### Phase 4: Theme axis enumeration 추가

조건: commit set이 5+ semantically distinct change cluster을 가지거나 single dominant change가 release를 carry하지 않을 때.

- ALL candidate axes를 numbered list로 enumerate (gate option set 아님 — free-form 응답)
- 각 axis마다 4-tuple 제시: Theme line / Foregrounds / Backgrounds / Trade-off signal
- AI는 best-fit axis로 초안 작성, Phase 5에서 user가 다른 axis 선택 가능
- 단일 dominant theme일 때 skip하고 직접 draft

### Phase 5: Gate with horizon fusion

- 기존 "Phase 5: Gate" → "Phase 5: Gate with horizon fusion"으로 확장
- Context section에 axis enumeration 재게재 (Recognition 보강)
- Experiential elicitation subsection 추가 — AI draft가 commit shape를 매핑하면 user의 lived origin이 shape를 읽기 쉽게 한다는 framing
- Options 3→4: `Add experiential context` 신설 (Modify와 별개 trajectory per Differential Future Requirement)
- Horizon fusion sub-protocol 추가: Horizon A (AI commit-shape) + Horizon B (user lived origin) 분리, bullets는 Horizon A 앵커, Background만 Horizon B 흡수, iteration loop 명시

### /zero-shot audit findings 6건 즉시 반영

1회차 audit에서 anchoring example 6건 적발. Boundary test ("removing this example increases LLM latitude") 양성 6건 모두 principle-only restatement로 응축. False positive 0.

| Line | Finding | Action |
|---|---|---|
| 71 | "(one feature carries the release, or all changes converge on one motif)" | "one frame is uniquely the best fit and other framings would feel like post-hoc reframing" |
| 91 (pre-existing) | 8 emoji-class 표 | "match the release's framing, not a fixed table" |
| 102 | 3-category list + e.g. feat: anchor | "the lived origin that motivated the release" |
| 118 | hedged narrative arc | "the arc the user actually supplied" |
| 121 | 5-dimension list | "whatever dimension the prior pass left under-specified" |

## Override Gate 점검

per `.claude/rules/instruction-hygiene.md`:

- **Friction evidence**: 이번 세션 Phase 5 게이트 4회 반복 — 현재 template은 axis enumeration도 experiential elicitation도 명시하지 않음
- **Specificity beyond default**: axis enumeration step과 horizon-fusion sub-protocol은 일반화된 "Modify" 옵션과 다른 별개 trajectory

## Test plan

- [ ] `/verify` static checks 통과 확인 (fail 0 유지)
- [ ] `/zero-shot` 재실행 시 release SKILL.md findings 0건 확인
- [ ] 다음 release에서 Phase 4 axis enumeration이 실제로 trigger되는지 dogfooding 관찰
- [ ] 다음 release에서 Phase 5 Add experiential context option이 horizon fusion sub-protocol을 발화시키는지 dogfooding 관찰
