### PR TITLE
refactor(scripts): retire된 plugin 이름이 남아있는 회귀 가드 주석 정리

### DIFF
--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -535,10 +535,7 @@ describe('package.js CLI', () => {
     // merge time. Any additive change (new plugin, new reference doc, new
     // agent) only increases this count. A shrink indicates an unintended
     // regression (plugin removed or files accidentally excluded from the
-    // packager), which should fail. Baseline reset to 30 after the
-    // crystallize/rehydrate retire + /realign introduction net -1 plugin
-    // shrink with two references/hft-format.md files dropped — that shrink
-    // was intentional and the guard updated accordingly.
+    // packager), which should fail.
     assert.ok(
       bundle.files >= 30,
       `expected bundle.files >= 30 (regression guard), got ${bundle.files}`


### PR DESCRIPTION
baseline=30 invariant 의미는 코드에 보존되므로 결정 이력 문장만 제거.
이미 제거된 crystallize/rehydrate skill 이름의 마지막 잔존 참조 정리.

https://claude.ai/code/session_01L72b4jmYuWFmU4W5YFTabx