### PR TITLE
refactor: hermeneutic-cycle 캐노니컬 원리 파일 + structural-specs 헤딩 정돈

### DIFF
--- a/.claude/principles/README.md
+++ b/.claude/principles/README.md
@@ -18,6 +18,7 @@ The split realizes the orthogonal e-tier × o-tier mapping established in this p
 | File | Source | Demoted sections |
 |------|--------|------------------|
 | `architectural-principles.md` | `.claude/rules/architectural-principles.md` | Unix Philosophy Homomorphism, Session Text Composition, Cross-Session Knowledge Composition, Dual Advisory Layer, Coexistence over Mirroring, Three-Tier Termination, Audience Reach, Utility Skills delegation, Direction over Accumulated Workload |
+| `hermeneutic-cycle.md` | `docs/structural-specs.md` | Pattern over Vocabulary (Gadamerian formal-block mapping) + 6 surface catalog (Primary / Secondary / Tertiary / Inter-version / Inter-agent / Operational axis) |
 
 ## Demotion Ledger
 
@@ -32,6 +33,7 @@ The split realizes the orthogonal e-tier × o-tier mapping established in this p
 | Audience Reach (incl. Session-level observer exception, Bidirectional Reach) | `architectural-principles.md` | 2026-04-27 | T2-T3 — plugin encapsulation context, infrequent |
 | Utility Skills — Adversarial Anticipation Delegation | `architectural-principles.md` | 2026-04-27 | T3 — utility skill authoring guidance only |
 | Direction over Accumulated Workload | `architectural-principles.md` | 2026-04-27 | T2 — contributor authoring decision principle |
+| Pattern over Vocabulary (Gadamerian formal-block mapping + Primary/Secondary surfaces) | `structural-specs.md` | 2026-05-14 | T2-T3 — extracted to dedicated `hermeneutic-cycle.md` as canonical home; structural-specs slimmed to gate runtime semantics only |
 
 ## Philosophy
 

--- a/.claude/principles/architectural-principles.md
+++ b/.claude/principles/architectural-principles.md
@@ -16,7 +16,7 @@ Inter-protocol data flows as natural language in the session context — no stru
 
 ## Cross-Session Knowledge Composition
 
-Anamnesis's hypomnesis store persists session recall indices that enrich protocol detection in subsequent sessions. This is the session-boundary extension of Session Text Composition — where intra-session data flows through conversation context, cross-session data flows through the hypomnesis store. Each protocol's Phase 0/1 can leverage accumulated domain knowledge to narrow scan scope and improve detection precision (Tertiary hermeneutic circle).
+Anamnesis's hypomnesis store persists session recall indices that enrich protocol detection in subsequent sessions. This is the session-boundary extension of Session Text Composition — where intra-session data flows through conversation context, cross-session data flows through the hypomnesis store. Each protocol's Phase 0/1 can leverage accumulated domain knowledge to narrow scan scope and improve detection precision (Tertiary hermeneutic circle; see [`hermeneutic-cycle`](hermeneutic-cycle.md)).
 
 **Formal layer boundary**: Cross-session enrichment operates as a runtime heuristic inscribed in protocol operational prose, not as a formal phase step. PHASE TRANSITIONS and TOOL GROUNDING blocks remain unchanged — enrichment does not introduce new phase transitions or tool calls. This boundary is intentional: heuristic inputs influence detection sensitivity but do not alter the protocol's formal specification.
 

--- a/.claude/principles/hermeneutic-cycle.md
+++ b/.claude/principles/hermeneutic-cycle.md
@@ -38,6 +38,7 @@ Each surface operationalizes the same structural pattern at a different scale. C
 - **Closure visibility** — `Has-Cycle` vs `No-Cycle` profile state determines whether a decision can be relay-resolved (Extension-default) or requires Constitution.
 - **Substrate respect** — "skip with hermeneutic respect" acknowledges that an evidence-gate is part of the cycle; premature attempts violate substrate-first.
 - **Cross-version traceability** — Issue / PR inscriptions surviving across sessions are the substrate of the inter-version surface; severing them breaks the cycle's backward reach.
+- **Authoring placement (invariant / horizon test)** — At inscription time, content mapping to `preserves` / `invariant` blocks (stable references, productive prejudices) compiles to T1 auto-load; content mapping to `LOOP` / `CONVERGENCE` blocks (revisable interpretations, fusion-conditioned outputs) belongs in T2–T3 lazy-load or `docs/`. Per Tier Factorization, this prevents compiling horizons that should remain hermeneutically revisable. External research substrate for the test: issue #402.
 
 ## Naming
 

--- a/.claude/principles/hermeneutic-cycle.md
+++ b/.claude/principles/hermeneutic-cycle.md
@@ -10,7 +10,7 @@ The hermeneutic cycle pattern is already structurally encoded in formal blocks �
 |---|---|---|
 | `preserves:` (MORPHISM) | Vorverständnis (pre-understanding) | Fixed reference point across the circle. Input is read-only; only understanding (output) evolves |
 | `invariant:` (MORPHISM) | Produktives Vorurteil (productive prejudice) | Directional constraint on the circle. "X over Y" pattern prevents degenerative interpretation |
-| `LOOP` | Hermeneutischer Zirkel (hermeneutic circle) | Part-whole reinterpretation via backward flow. Present in all 10 protocols |
+| `LOOP` | Hermeneutischer Zirkel (hermeneutic circle) | Part-whole reinterpretation via backward flow. Present in every protocol |
 | `CONVERGENCE` | Horizontverschmelzung (horizon fusion condition) | Convergence condition for achieved understanding. Productive termination of the circle |
 | `Qs` gate | Horizon Fusion Point | Constitutive gate — user contributes new meaning, fusing horizons |
 | `Qc` gate | Horizon Navigation | Classificatory gate — path selection within existing understanding space |
@@ -46,4 +46,4 @@ Each surface operationalizes the same structural pattern at a different scale. C
 
 ## Tier
 
-Lives in `.claude/principles/` (axis_β = T2–T3, lazy-load, authoring/verify-time invocation). axis_α inherits from referenced sources. Per Tier Factorization (`.claude/rules/architectural-principles.md`), this file names the family for authoring coherence; runtime detection is operationalized at each surface (LOOP blocks at runtime, hypomnesis store at session boundary, VCS at inter-version scale, Constitution gate per Phase 2).
+Lives in `.claude/principles/` (axis_β = T2–T3, lazy-load, authoring/verify-time invocation). Per Tier Factorization (`.claude/rules/architectural-principles.md`), this file names the family for authoring coherence; runtime detection is operationalized at each surface (LOOP blocks at runtime, hypomnesis store at session boundary, VCS at inter-version scale, Constitution gate per Phase 2).

--- a/.claude/principles/hermeneutic-cycle.md
+++ b/.claude/principles/hermeneutic-cycle.md
@@ -1,0 +1,48 @@
+# Hermeneutic Cycle
+
+Part-whole reinterpretation via backward flow. The pattern is already structurally encoded in formal blocks across protocols; this file names the family and catalogs the surfaces on which the cycle is observed in this project.
+
+## Pattern over Vocabulary
+
+The hermeneutic cycle pattern is already structurally encoded in formal blocks — renaming blocks to philosophical terminology adds no structural value. Pattern recognition takes precedence over vocabulary transition.
+
+| Formal Block | Gadamerian Concept | Role |
+|---|---|---|
+| `preserves:` (MORPHISM) | Vorverständnis (pre-understanding) | Fixed reference point across the circle. Input is read-only; only understanding (output) evolves |
+| `invariant:` (MORPHISM) | Produktives Vorurteil (productive prejudice) | Directional constraint on the circle. "X over Y" pattern prevents degenerative interpretation |
+| `LOOP` | Hermeneutischer Zirkel (hermeneutic circle) | Part-whole reinterpretation via backward flow. Present in all 10 protocols |
+| `CONVERGENCE` | Horizontverschmelzung (horizon fusion condition) | Convergence condition for achieved understanding. Productive termination of the circle |
+| `Qs` gate | Horizon Fusion Point | Constitutive gate — user contributes new meaning, fusing horizons |
+| `Qc` gate | Horizon Navigation | Classificatory gate — path selection within existing understanding space |
+
+Gate-runtime semantics for Qc/Qs (and the `Basis:` interpretive transparency annotation) live in `docs/structural-specs.md`; this file holds the cycle's structural definition and surface catalog.
+
+## Observed surfaces
+
+Each surface operationalizes the same structural pattern at a different scale. Cross-references point to where the cycle is invoked in the codebase; this file is the single home for the *concept*, not its runtime invocation.
+
+**Primary circle (intra-protocol)** — Each protocol's `LOOP` section encodes backward flow where partial resolution triggers whole re-interpretation, conditioned by `preserves:` (the text being interpreted remains fixed; only the interpretation evolves).
+
+**Secondary pattern (inter-protocol)** — Complementary pairs form Pre/Post cycles on the context fitness axis — Aitesis↔Epharmoge (context), Prothesis↔Analogia (structure). These cycles operate heuristically via Output Style nudge, driven by observed session conditions rather than graph.json structural edges. See Dual Advisory Layer in `.claude/principles/architectural-principles.md`.
+
+**Tertiary surface (inter-session)** — Cross-Session Knowledge Composition via Anamnesis's hypomnesis store. Each protocol's Phase 0/1 can leverage accumulated domain knowledge to narrow scan scope and improve detection precision. Operational definition in `.claude/principles/architectural-principles.md` (Cross-Session Knowledge Composition section). Local-inscription mechanism in `anamnesis/skills/recollect/SKILL.md`; cross-session task persistence in `epistemic-cooperative/skills/comment-review/SKILL.md`. Operational detail (spiral mechanism + Aitesis asymmetry + pollution caveat) in `docs/structural-specs.md` § "Cross-Session Tertiary Pattern".
+
+**Inter-version surface (온고지신 / 溫故知新)** — VCS history (commits, PRs, issues) as substrate informing present design. The pattern: surveying past inscriptions to inform present judgment, then inscribing the present decision back into the substrate for future sessions. Operationalized in `epistemic-cooperative/skills/dispatch/SKILL.md` — "issue body + redirection inscription" preserves rejection traces so the next fresh-context session engages the cycle without re-deriving. PR review-loop chains (e.g., #353–#371 Rules consolidation cascade) realize the same pattern at the commit/PR level.
+
+**Inter-agent surface (Constitution-as-Horizontverschmelzung)** — Every Phase 2 Constitution gate is a horizon fusion point. The user's horizon merges with the AI's pre-understanding (Vorverständnis), and the gate answer becomes the productive prejudice (Produktives Vorurteil) constraining the next cycle. Formal correspondence: A2 Constitution kind (`axioms.md`) is the gate-level realization of horizon fusion; the `Qs` gate row in the Pattern over Vocabulary table is its formal mapping.
+
+**Operational axis (closure / categorization)** — Hermeneutic-cycle availability acts as a closure clause in autonomous decisions. `epistemic-cooperative/skills/dispatch/SKILL.md` invokes it for Extension-default closure (the "northstar + hermeneutic circle" closure clause), for "hermeneutic respect" toward substrate-locked items, and as a categorization axis bounding Periagoge's induce. The availability is itself a profile variable: `hermeneutic_circle_availability` in `epistemic-cooperative/skills/steer/SKILL.md`.
+
+## Operational implications
+
+- **Closure visibility** — `Has-Cycle` vs `No-Cycle` profile state determines whether a decision can be relay-resolved (Extension-default) or requires Constitution.
+- **Substrate respect** — "skip with hermeneutic respect" acknowledges that an evidence-gate is part of the cycle; premature attempts violate substrate-first.
+- **Cross-version traceability** — Issue / PR inscriptions surviving across sessions are the substrate of the inter-version surface; severing them breaks the cycle's backward reach.
+
+## Naming
+
+"Hermeneutic cycle", "hermeneutic circle", and "Hermeneutischer Zirkel" are synonyms. Default to "hermeneutic cycle" in prose; "Hermeneutischer Zirkel" when explicitly mapping to `LOOP` block; profile-variable form `hermeneutic_circle_availability` preserved as identifier convention. "Tertiary hermeneutic circle" is the historic label for the inter-session surface (`.claude/principles/architectural-principles.md:19`) — new prose prefers "Tertiary surface" or names the scale (Cross-Session Knowledge Composition).
+
+## Tier
+
+Lives in `.claude/principles/` (axis_β = T2–T3, lazy-load, authoring/verify-time invocation). axis_α inherits from referenced sources. Per Tier Factorization (`.claude/rules/architectural-principles.md`), this file names the family for authoring coherence; runtime detection is operationalized at each surface (LOOP blocks at runtime, hypomnesis store at session boundary, VCS at inter-version scale, Constitution gate per Phase 2).

--- a/docs/structural-specs.md
+++ b/docs/structural-specs.md
@@ -99,26 +99,15 @@ Three separate rules manage cognitive load at runtime:
 
 These disciplines are complementary. A protocol can satisfy Context-Question Separation and Plain emit discipline while still increasing context-switch cost by scattering adjacent evidence across distant paragraphs or mixing unrelated findings into one decision round. Round-local salience bundling closes that gap without introducing measurement: the binding unit is the round-local judgment surface, not a quantified load score.
 
-## Pattern over Vocabulary
-
-The hermeneutic circle pattern is already structurally encoded in formal blocks — renaming blocks to philosophical terminology adds no structural value. Pattern recognition takes precedence over vocabulary transition.
-
-| Formal Block | Gadamerian Concept | Role |
-|---|---|---|
-| `preserves:` (MORPHISM) | Vorverständnis (pre-understanding) | Fixed reference point across the circle. Input is read-only; only understanding (output) evolves |
-| `invariant:` (MORPHISM) | Produktives Vorurteil (productive prejudice) | Directional constraint on the circle. "X over Y" pattern prevents degenerative interpretation |
-| `LOOP` | Hermeneutischer Zirkel (hermeneutic circle) | Part-whole reinterpretation via backward flow. Present in all 10 protocols |
-| `CONVERGENCE` | Horizontverschmelzung (horizon fusion condition) | Convergence condition for achieved understanding. Productive termination of the circle |
-| `Qs` gate | Horizon Fusion Point | Constitutive gate — user contributes new meaning, fusing horizons |
-| `Qc` gate | Horizon Navigation | Classificatory gate — path selection within existing understanding space |
+## Gate Runtime Semantics
 
 **Qc/Qs runtime distinction**: The Qc/Qs classification is a definition-time property of the gate — Qs expects constitutive response, Qc expects classificatory response. At runtime with Text+Stop realization, this distinction blurs: Qc gate responses can carry constitutive surplus (new meaning beyond the classification). The formal answer type (closed coproduct) captures the classification; the constitutive surplus is captured by Phase 3 `integrate` — a sense operation whose non-obvious interpretive contribution may be surfaced through Output Style `Basis:` marker when non-trivial (A2 Visibility).
 
 **Interpretive transparency architecture**: `Basis:` is a discretionary session-level annotation — it fires when AI interpretation transcends mechanical derivation, unlike the former `integrate-echo` which was a mandatory structural relay. The semantic boundary shifts from a deducibility test (augmentation not derivable from {input, context_structure}) to an observability criterion (cite specific evidence grounding the interpretation). This relocation from protocol-owned TOOL GROUNDING to the session-level observation layer follows the Session-level observer exception (Audience Reach) — the same architectural pattern governing nudge.
 
-**Primary circle** (intra-protocol): Each protocol's LOOP section encodes backward flow where partial resolution triggers whole re-interpretation, conditioned by `preserves:` (the text being interpreted remains fixed; only the interpretation evolves).
+The `Qs` gate's formal correspondence to Horizontverschmelzung (horizon fusion) and the cycle's structural pattern are catalogued in `.claude/principles/hermeneutic-cycle.md`.
 
-**Secondary pattern** (inter-protocol): Complementary pairs form Pre/Post cycles on the context fitness axis — Aitesis↔Epharmoge (context), Prothesis↔Analogia (structure). These cycles operate heuristically via Output Style nudge, driven by observed session conditions rather than graph.json structural edges.
+## Type Naming and Artifact Observability
 
 **Artifact-observability boundary** (type naming principle): Protocol input type names encode their temporal relationship to observable artifacts — the dividing line being Read/Grep observability:
 - **Aitesis** (Prospect): Pre-artifact. Context sufficiency is assessed before artifacts are produced. X cannot yet be Read/Grep'd.
@@ -127,7 +116,11 @@ The hermeneutic circle pattern is already structurally encoded in formal blocks 
 
 This boundary informs type naming: `Prospect` (forward-looking, unrealized), `Result` (completed work product), `Text` (abstract structure carrier). The temporal encoding in type names provides protocol discrimination signal at SKILL.md load time, per A4 Semantic Autonomy.
 
+## Intra-Protocol Context Separation
+
 **Context bifurcation** (intra-protocol context separation): Within a single protocol, context collected for different purposes must not be conflated. In Prothesis: `gather(context)` (Phase 1, meta) collects broad context to identify relevant perspectives; `inquire(parallel)` (Phase 3, object) collects perspective-specific evidence through each lens independently. The semantic separation exists in MORPHISM; TOOL GROUNDING realizes it operationally by specifying different collection targets per phase. Passing meta-context to object-level agents biases their investigation toward the lead agent's framing, undermining the epistemic value of independent perspective analysis.
+
+## Cross-Session Tertiary Pattern
 
 **Tertiary pattern** (cross-session, both halves operative): Anamnesis hypomnesis store persists session recall indices → next session's protocol Phase 0/1 detection is enriched by accumulated domain knowledge → better protocol execution produces richer insights → hypomnesis store deepens → spiral deepening. The storage half (Anamnesis hypomnesis write) and the consumption half (each consuming protocol's Phase 0/1 reading stored knowledge) together complete the cross-session pattern. Unlike Primary/Secondary which operate within a single session, Tertiary operates across session boundaries with persistent knowledge as the medium. Consumption-half is operative across all 11 consuming protocols as Cross-session enrichment paragraphs in SKILL.md prose. **Aitesis carries protocol-internal sophistication** — EvidenceSource fiber + `source: "memory:{path}"` tagging + staleness guard scoped to its empirical-evidence operation, grounded in `.claude/rules/axioms.md` A2 Cognitive Partnership Move's Citable axis (Extension/Relay basis = external source). **The other 10 consuming protocols use the simpler heuristic-input pattern** — Phase 0/1 may bias toward accumulated domain patterns, with protocol-specific pollution resistance (halt characteristics, gate judgment) per `.claude/principles/architectural-principles.md` Cross-Session Knowledge Composition Pollution caveat. The asymmetry is intentional: applying Aitesis-style evidence-source machinery uniformly would misclassify Constitution operations (where AI inference is the basis) as Extension. Operational-fidelity monitoring (whether enrichment improves Phase 0/1 detection vs. surfaces pollution) is the ongoing observation focus.
 

--- a/epistemic-cooperative/skills/sophia/references/philosophers.md
+++ b/epistemic-cooperative/skills/sophia/references/philosophers.md
@@ -116,7 +116,7 @@ handles this correctly: a user with D4=30 scores high similarity with Wittgenste
 ### Hermeneutics — How We Understand
 
 #### Gadamer (1900-2002)
-- **Tradition**: Philosophical hermeneutics
+- **Tradition**: Philosophical hermeneutics (see [`hermeneutic-cycle`](../../../../.claude/principles/hermeneutic-cycle.md))
 - **Core method**: Dialogue as fusion of horizons; understanding through conversation
 - **Dimension profile**: D1=55 D2=75 D3=95 D4=40 D5=60 D6=65
 - **Defining**: D3 (Dialogical — understanding IS dialogue)


### PR DESCRIPTION
## 요약

해석학적 순환 개념이 epistemic-protocols 리포 내 여러 위치에서 *사용* 되지만 한 곳에서 *정의* 되지 않은 상태였다. 새 principle 파일을 단일 home 으로 inscribe + `docs/structural-specs.md` 의 conceptual content 슬림화 + 자식 단락에 자체 헤딩 부여 + invariant/horizon authoring placement test 인스크라이브.

## 변경

**신규** `.claude/principles/hermeneutic-cycle.md` (49 라인) — T2–T3 zone
- 구조적 핵심: 부분-전체 재해석 via backward flow
- Gadamerian 형식 블록 매핑 (`preserves`/`invariant`/`LOOP`/`CONVERGENCE`/`Qs`/`Qc`)
- 6 표면 카탈로그:
  - **Primary** (intra-protocol) — LOOP block
  - **Secondary** (inter-protocol) — Pre/Post pair via Dual Advisory
  - **Tertiary** (inter-session) — Cross-Session Knowledge Composition
  - **Inter-version** (온고지신 / 溫故知新) — VCS 역사 substrate
  - **Inter-agent** (Constitution-as-Horizontverschmelzung) — gate horizon 융합
  - **Operational axis** (closure / categorization)
- §Operational implications에 *Authoring placement (invariant / horizon test)* 1 bullet 추가 — Codex 외부 검증 종합("invariants는 컴파일, horizons는 컴파일 금지")의 prospective authoring 변환 (issue #402 참조)

**슬림화** `docs/structural-specs.md`
- 기존 `## Pattern over Vocabulary` 섹션 (Gadamerian 표 + Primary/Secondary 단락) → 새 principle 파일로 이동
- 슬림 `## Gate Runtime Semantics` 섹션만 잔존 (Qc/Qs runtime + Basis interpretive transparency)
- 우산 헤딩 제거로 떠밀린 자식 단락 3개에 자체 헤딩 부여:
  - `## Type Naming and Artifact Observability`
  - `## Intra-Protocol Context Separation`
  - `## Cross-Session Tertiary Pattern`
- Tertiary surface 양방향 cross-ref (principle ↔ structural-specs)

**Cross-ref** (contributor-scope only — Audience Reach 준수)
- `.claude/principles/architectural-principles.md:19` — Tertiary 항목에 cross-ref
- `epistemic-cooperative/skills/sophia/references/philosophers.md:119` — Gadamer 항목에 cross-ref (`references/` subdir, packaged runtime surface 밖)

## 배경 — Audience Reach 보호

Runtime SKILL.md → `.claude/principles/` 의 Markdown link 가 본 PR 의 *초안* 단계에서 cross-ref 로 추가됐었으나, pre-commit `artifact-self-containment` 검증이 packaged runtime surface escape 로 차단. 4 SKILL.md (recollect, comment-review, dispatch, steer) 의 hermeneutic 용어 프로즈는 그대로 유지하되 별도 link 인스크립션은 *추가하지 않음*. 결과: 단일 home 으로 contributor 가 discover 가능 + runtime audience 는 보호. 본 PR 작업 자체가 그 원칙의 실측 검증이 됨.

## 동기

- 단일 canonical home 부재로 신규 contributor 가 7+ 위치를 통합 재구성하는 비용
- `## Pattern over Vocabulary` 우산 헤딩이 사실상 hermeneutic-cycle conceptual content 만 가졌으나 무관 단락들 (type naming, context bifurcation) 도 같이 묶여 있던 구조 결함
- 사용자 enrichment 로 surfaces 두 개 명시 (온고지신, Horizontverschmelzung) — 기존 inscription 들이 implicit 으로 사용해온 surface 들이 first-class 카탈로그 entry 가 됨

## 외부 검증 컨텍스트

[Issue #402](https://github.com/jongwony/epistemic-protocols/issues/402)에 가다머 진영 vs 그라이스 진영 외부 검증 리서치 인스크라이브 (Codex CLI + Tavily, 4 sections, 18 인용).

**핵심 종합**: *invariants는 컴파일, horizons는 컴파일 금지*. 본 PR이 hermeneutic-cycle 개념을 `.claude/principles/` (T2-T3 lazy-load)에 위치시킨 것이 이 종합의 *사례*이며, 추가로 인스크라이브된 *Authoring placement test*는 그 종합의 *prospective 적용 도구*. Codex 종합 5항 중 4항(프로토콜 정체성·권한 가시성 보존, 광범위 격률 글로벌 컴파일 금지, philosophy lazy-load, action-local만 SKILL.md)이 본 PR에 정렬; 잔여 5항(empirical 압력)은 별도 PR 후보.

**후속 PR 후보** (issue #402 잔여):
- safeguards.md prescriptive density → invitational 전환 (Euporia B.2)
- CLAUDE.md narrative inversion (Euporia B.3)
- 3-tier 실증 실험 (full compiled vs minimal invariant vs lazy-only) — Codex가 명시한 다음 실증 단계

## Test plan

- [x] `node --test scripts/package.test.js` 통과 (artifact-self-containment FAIL=0; 1 pre-existing warn for prothesis/frame Horizontverschmelzung 잔존)
- [x] `.claude/principles/hermeneutic-cycle.md` 마크다운 렌더링 확인 (Gadamerian 표 6행)
- [x] `docs/structural-specs.md` 신규 4 `##` 헤딩 정상 구조 (Gate Runtime Semantics, Type Naming, Context Separation, Cross-Session Tertiary)
- [x] Tertiary surface 양방향 cross-ref 작동 (principle ↔ structural-specs § Cross-Session Tertiary Pattern)
- [ ] §Operational implications 4번째 bullet (Authoring placement) 렌더링 확인
- [ ] Merge 후 fresh-context 세션의 `/induce`/`/inquire` 가 hermeneutic-cycle 참조 시 새 파일이 cited 되는지 (next-session 검증)
- [ ] CI 워크플로 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
