### PR TITLE
refactor(core): 12개 코어 SKILL.md에서 Distinction 표 일괄 제거 — Unix 철학 격리 1차

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -372,7 +372,6 @@ function checkRequiredSections() {
 
   const requiredSections = [
     '## Definition',
-    '## Distinction from Other Protocols',
     '## Mode Activation',
     '## Protocol',
     '## Rules',
@@ -1397,35 +1396,7 @@ function checkCrossRefScan() {
     }
   }
 
-  // Sub-check 4: Verify distinction table consistency across SKILL.md files
-  // Each protocol SKILL.md should reference all canonical protocol names in its distinction table
-  for (const relPath of PROTOCOL_FILES) {
-    const fullPath = path.join(projectRoot, relPath);
-    if (!fs.existsSync(fullPath)) continue;
-
-    const content = fs.readFileSync(fullPath, 'utf8');
-
-    // Check if file has a distinction table (look for the section)
-    if (!content.includes('Distinction from Other Protocols')) continue;
-
-    // Extract the table section
-    const tableMatch = content.match(/\| Protocol.*\|[\s\S]*?(?=\n\n|\n\*\*Key|\n##)/);
-    if (!tableMatch) continue;
-
-    const tableSection = tableMatch[0];
-
-    for (const protocolName of Object.keys(CANONICAL_PROTOCOLS)) {
-      if (!tableSection.includes(protocolName)) {
-        results.warn.push({
-          check: 'cross-ref-scan',
-          file: relPath,
-          message: `Distinction table missing protocol "${protocolName}"`
-        });
-      }
-    }
-  }
-
-  // Sub-check 5: Array completeness — cross-check PROTOCOL_FILES, CANONICAL_PROTOCOLS,
+  // Sub-check 4: Array completeness — cross-check PROTOCOL_FILES, CANONICAL_PROTOCOLS,
   // package.js PLUGINS, graph.json nodes, and marketplace.json plugins against filesystem ground truth
   {
     // Ground truth: directories containing .claude-plugin/plugin.json
@@ -1693,7 +1664,7 @@ function checkCrossRefScan() {
     }
   }
 
-  // Sub-check 6: Verify edge types in graph.json match CLAUDE.md allowlist
+  // Sub-check 5: Verify edge types in graph.json match CLAUDE.md allowlist
   const graphPath = path.join(projectRoot, '.claude', 'skills', 'verify', 'graph.json');
   if (fs.existsSync(graphPath)) {
     try {

--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution \u2014 /inquire (\u03b1\u1f34\u03c4\u03b7\u03c3\u03b9\u03c2: a requesting)",
-  "version": "4.3.32",
+  "version": "4.3.33",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -184,30 +184,6 @@ Within this hierarchy, the AI first collects contextual evidence via codebase ex
 
 Write is authorized for observation instrument setup (temporary test artifacts with mandatory cleanup). Cite-or-observe is the structural expression of the upper boundary — the adversarial guard against stopping at Inference when Evidence is achievable.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-- **Syneidesis** surfaces gaps at decision points for the user to judge (information flows AI→user) — Aitesis infers context the AI lacks before execution (information flows user→AI)
-
-**Heterocognitive distinction**: Aitesis monitors the AI's own context sufficiency (heterocognitive — "do I have enough context to execute?"), while Syneidesis monitors the user's decision quality (metacognitive — "has the user considered all angles?"). The operational test: if the information gap would be filled by the user providing context, it's Aitesis; if it would be filled by the user reconsidering their decision, it's Syneidesis.
-
-**Factual vs evaluative**: Aitesis uncertainties span multiple dimensions — factual (objectively correct answers discoverable from the environment), coherence (consistency among collected facts), and relevance (whether collected facts are relevant to the execution goal). Syneidesis gaps are evaluative — they require judgment about trade-offs and consequences. Phase 1 context collection exists because factual uncertainties may be partially resolved or enriched from the codebase. Coherence/CrossDomain and relevance dimensions are detected but routed to downstream protocols. Coherence/MemoryInternal contradictions are evidence-resolvable and follow the factual resolution path. Evaluative gaps cannot be self-resolved.
-
 ## Mode Activation
 
 ### Activation

--- a/analogia/.claude-plugin/plugin.json
+++ b/analogia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "analogia",
   "description": "Validate structural mapping between domains \u2014 /ground (\u1f00\u03bd\u03b1\u03bb\u03bf\u03b3\u03af\u03b1: a proportion)",
-  "version": "1.6.32",
+  "version": "1.6.33",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -103,34 +103,6 @@ converge     (extension)       → TextPresent+Proceed (convergence evidence tra
 
 **Structural Correspondence over Abstract Assertion**: When text contains abstract frameworks applied to a user's domain, validate that structure-preserving mappings exist between the abstract and concrete domains through explicit correspondences and concrete instantiations, rather than asserting that the abstraction applies. The purpose is to verify mapping adequacy, not to simplify the abstraction.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-- **Prothesis** selects analytical frameworks when none exist — Analogia validates whether a selected framework structurally maps to the user's concrete domain
-- **Aitesis** verifies context sufficiency for execution (factual: "do I have enough information?") — Analogia verifies structural correspondence between domains (relational: "does this abstract structure preserve when mapped to your context?")
-- **Katalepsis** verifies user comprehension after AI work — Analogia validates the structural mapping that precedes comprehension
-- **Epharmoge** checks post-execution applicability to context — Analogia checks pre-execution mapping validity between abstraction levels
-- **Periagoge** (`/induce`) forms a new abstraction from a cocone of concrete instances (no source abstraction Sₐ available — colimit-shaped input: `essence_sensed` over instances + `locator_absent(A)`) — Analogia validates the mapping from an existing Sₐ to a target Sₜ. Route colimit-shaped inputs to `/induce` for abstraction formation; Analogia remains scoped to mapping validation from a source abstraction to a concrete target.
-
-**Structural mapping distinction**: Analogia operates on the functor between domains — not the content of either domain (Aitesis), nor the framework choice (Prothesis), nor the comprehension state (Katalepsis). The operational test: if the uncertainty is about whether abstract structure A corresponds to concrete structure B, it's Analogia; if it's about whether enough context exists to execute, it's Aitesis; if it's about which framework to apply, it's Prothesis.
-
-See `references/best-practices.md` for user-language triggers and grounding scenarios.
-
 ## Mode Activation
 
 ### Activation

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -260,30 +260,6 @@ The scan finds candidates; the narrative Qc enables recognition; the user consti
 
 3. **Guided recall orientation on Refine**: When initial candidates do not match, the protocol facilitates structured recognitive orientation — presenting concrete navigation through adjacent memory vectors rather than open-ended questions. The user's vague memory and the stored context are brought into productive contact through specific alternatives that enable recognition.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-**Anamnesis vs Aitesis**: Both involve information access. Aitesis discovers facts the user does not know (ContextInsufficient — "I need information"). Anamnesis verifies context the user vaguely knows exists (RecallAmbiguous — "I know this was discussed, but where?"). The phenomenological test: does the user have an empty intention seeking fulfillment (Anamnesis) or no intention at all regarding the topic (Aitesis)? When the user has an empty intention but the recalled content is wholly absent from stores, the protocol exits with NullMatch — the recall target may not exist in the stored context.
-
-**Composition `/recollect * /inquire`**: When recognized context needs further information enrichment, Anamnesis can compose with Aitesis — the emitted ClueVector_prose enters session text and becomes input substrate for downstream context inference. On NullMatch, Aitesis is seeded with the accumulated recall trace to search SSOT directly (INDEX may lack entries while SSOT retains the information).
-
-**Anamnesis vs Prothesis**: Prothesis selects analytical frameworks when none exist (FrameworkAbsent). Anamnesis locates prior discussions when the user has vague recall of their existence (RecallAmbiguous). If the user does not know a framework was ever discussed, it is not Anamnesis — it is Prothesis or Aitesis.
-
 ## Mode Activation
 
 ### Activation

--- a/elenchus/.claude-plugin/plugin.json
+++ b/elenchus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "elenchus",
   "description": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -110,31 +110,6 @@ converge                (extension)    → TextPresent+Proceed (per-source dispo
 
 **Dialectical Vetting over Silent Trust**: Working context accumulated across a session carries silent decay — sources age, provenance chains lengthen, downstream concentration warps incidental claims into load-bearing premises, and cross-source contradictions hide behind topical proximity. Elenchus surfaces each suspect source against a deliberately posited antithesis before action; the user judges each disposition per source. The loop dissolves compounding context cost before it forces whole-system refactoring downstream.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| **Euporia** | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-
-**Key differences**:
-
-- **Elenchus vs Aitesis**: Aitesis infers context insufficiency (missing context) and asks the user to supply it; the deficit is *absence*. Elenchus operates on already-collected context whose apparent sufficiency has become suspect through age, weak provenance, conflict, or high-leverage accumulation; the deficit is *contaminated/decayed presence*. Polarity is orthogonal — Aitesis fills gaps; Elenchus stress-tests fills.
-- **Elenchus vs Syneidesis**: Syneidesis surfaces decision-point gaps the user may have missed when committing to a decision; the audit is over the decision itself. Elenchus tests the *working context* feeding pre-execution sync; the audit is over the inputs, not the commit. Syneidesis follows commitment; Elenchus precedes it.
-- **Elenchus vs Euporia**: Euporia traces decision coordinates from intent through user-externalized substrate when the axis is undetermined. Elenchus operates when the axis is determined and a working context is committed — the question is not "where in your substrate does this intent resolve?" but "is the context I've collected actually robust against antithesis?"
-- **Elenchus vs Epharmoge**: Both surface a (item, standard) → audit → mismatch → user judgment → adapted item shape, but temporal posture is distinct. Epharmoge runs *post-execution* — does the result fit the application context? Elenchus runs *pre-execution* — does the working context survive antithesis before action? The two are stack-compatible; an Epharmoge-confirmed fit can become an Elenchus-suspect input in a later session as time and downstream concentration accumulate.
-- **Elenchus vs Katalepsis**: Both are User-initiated. Katalepsis verifies the user's comprehension of an AI-produced result (the user is the measurement target). Elenchus tests the working context whose downstream the user is about to commit to (the context is the measurement target). The wildcard `* → katalepsis` precondition automatically covers Elenchus.
-
 ## Mode Activation
 
 ### Activation

--- a/epharmoge/.claude-plugin/plugin.json
+++ b/epharmoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epharmoge",
   "description": "Detect application-context mismatch after execution \u2014 /contextualize (\u1f10\u03c6\u03b1\u03c1\u03bc\u03bf\u03b3\u03ae: an application)",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -91,32 +91,6 @@ converge (extension)  → TextPresent+Proceed (convergence evidence trace; proce
 
 Formal predicate: `correct(R) ∧ ¬warranted(R, X)` — the output is correct but not warranted in this context (Dewey's warranted assertibility; Ryle's knowing-how vs knowing-that).
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-- **Aitesis** infers context the AI lacks *before* execution (User→AI direction) — Epharmoge evaluates whether the completed result *fits* the context (AI→User direction). Same axis (context fitness), opposite timing and information flow.
-- **Katalepsis** verifies the user's *comprehension* of correct results (`P'≅R`) — Epharmoge verifies the result's *applicability* to context (`R≅X`). Convergence conditions are structurally incompatible.
-- **Syneidesis** surfaces gaps in the user's *decision quality* — Epharmoge surfaces gaps in the AI's *execution quality*. Different audit targets even when addressing the same domain.
-
-**Context fitness axis**: Aitesis and Epharmoge form a pre/post pair on the context fitness axis. Aitesis asks "do I have enough context to execute well?" (factual uncertainties, User→AI). Epharmoge asks "does my execution actually fit the context?" (evaluative mismatches, AI→User). They are complementary, not redundant — Aitesis may gather sufficient context, yet the resulting execution may still not fit contextual constraints that only become visible post-execution.
-
-**Independence from Aitesis**: Epharmoge's information source is the result itself (`R`) compared against observed context (`X`), not a re-scan of pre-execution context. This ensures non-circularity — even when Aitesis has fully resolved context uncertainties, Epharmoge can detect mismatches that emerge only from the actual output.
-
 ## Mode Activation
 
 ### Conditional Activation Prerequisite

--- a/euporia/.claude-plugin/plugin.json
+++ b/euporia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "euporia",
   "description": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/euporia/skills/elicit/SKILL.md
+++ b/euporia/skills/elicit/SKILL.md
@@ -136,33 +136,6 @@ converge             (extension)    → TextPresent+Proceed (intent readback + p
 
 Per cycle, the trio `(D[step], A[step], I'[step])` is recorded pairwise into `D_history`, `A_history`, and `I_history`. Partial-cycle termination via user Esc during Phase 1 — when `D[]` is computed before any `A` is recorded — discards the partial entry; the invariant `|D_history| = |A_history| = |I_history| = cycle_n` is restored at the termination boundary by decrementing `cycle_n` by 1.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| **Euporia** | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-
-- **Euporia vs Periagoge**: Directional dual. Periagoge forms a new abstraction from a cocone of concrete instances (bottom-up direction — given {Iᵢ}, construct emergent abstraction). Euporia traces decision coordinates from intent through externalized substrate (top-down direction — given I, surface (D[], coordinates)). The two compose as orthogonal directions of the same dialectic substrate; they do not subsume one another.
-- **Euporia vs Aitesis**: Aitesis infers context insufficiency *before execution* and asks the user to supply missing facts (information flows user→AI, fact layer). Euporia operates on *abstract aporia* — intent whose axis is itself undetermined — and the answers are not facts but coordinate values implicit in the user's externalized substrate. Aitesis asks "what is X?", Euporia asks "where in your substrate does this intent's endpoint reside?" No suppression edge in graph.json — sequential composition is intended (fact-supply ⊥ coordinate-explication operate at distinct layers).
-- **Euporia vs Prothesis**: Prothesis selects among *named* analytical frameworks for a given inquiry. Euporia surfaces *unnamed* dimension projections traced from substrate, with axes emergent per cycle. When the inquiry's frames are already named and the operation is selection, Prothesis applies; when intent is axis-agnostic and dimensions must be reverse-traced from substrate, Euporia applies.
-- **Euporia vs Syneidesis**: Syneidesis surfaces decision-point gaps for the user to judge (decision-quality layer). Euporia surfaces dimension projections for the user to answer (coordinate-explication layer). The two are stack-compatible — Syneidesis can audit a Euporia-resolved endpoint for downstream gaps.
-- **Euporia vs Horismos**: Bidirectional advisory — Horismos → Euporia (BoundaryMap narrows substrate scope) and Euporia → Horismos (resolved coordinates inform downstream boundary). Same-session re-entry of either protocol after the other's convergence is permitted but treated as distinct activation; each invocation produces a fresh ResolvedEndpoint or BoundaryMap, with the prior instance becoming session evidence rather than auto-cycling input.
-
-**Reverse-induction distinction**: Euporia operates on the reverse-trace from intent to externalized substrate coordinates. The operational test: Euporia applies when the intent carries `axis_undetermined(I)` and the substrate contains implicit coordinates `substrate_implicit(I)`. The substrate is the *user's* externalized cognition — their codebase, their rules, their past sessions, their environment — not the AI's pre-trained knowledge. The protocol's distinguishing feature is reverse-tracing from extended mind, not domain-general inference. When the intent is axis-determined (a single axis-specific protocol covers it), defer to that protocol; Euporia is for axis-emergent aporia, not axis-fixed deficits.
-
 ## Mode Activation
 
 ### Activation

--- a/horismos/.claude-plugin/plugin.json
+++ b/horismos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "horismos",
   "description": "Define epistemic boundaries per decision \u2014 /bound (\u1f41\u03c1\u03b9\u03c3\u03bc\u03cc\u03c2: a bounding)",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/horismos/skills/bound/SKILL.md
+++ b/horismos/skills/bound/SKILL.md
@@ -194,31 +194,6 @@ Round-local BoundaryMap composition: each Phase 2 cycle produces a complete Boun
 
 **Multi-consumer architectural independence**: BoundaryMap is consumed by 5 downstream protocols — Aitesis as gate threshold, Prothesis as framework filter, Syneidesis as gap relevance filter, Prosoche as risk evaluation threshold, Euporia as substrate scope narrowing. This shared consumption is why Horismos requires independent protocol status rather than absorption into any single consumer; the boundary is a multi-consumer signal, not a private operation of a specific downstream. Independent invocation preserves the symmetric advisory relationship across all 5 consumers.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-
-**Horismos vs Aitesis**: Both are pre-execution heterocognitive protocols. Aitesis probes factual gaps (context insufficiency — "do I have enough information to execute?"), Horismos probes constitutive boundaries (ownership classification — "who decides what?"). Both share an Akinator-style functor (probe → enrich → ask → integrate), but the ontology differs: Aitesis uncertainties have factual answers discoverable from the environment, while Horismos domains require constitutive decisions about responsibility allocation. The operational test: if the answer exists somewhere in the environment, it is Aitesis; if the answer must be constituted by the user, it is Horismos.
-
-**Horismos vs Epitrope (deprecated)**: Epitrope produced a DelegationContract via scenario-based interview, accumulating an expertise profile across interactions. Horismos produces a BoundaryMap via direct per-decision classification. No scenario calibration, no accumulated profile, no team coordination (team coordination moved to Prosoche). Each invocation starts fresh for the current task scope.
-
-**Horismos vs Periagoge / Euporia (loop topology borrowing)**: Horismos's per-cycle-emergent loop borrows topology from Periagoge (in-process abstraction crystallization through dialectical iteration) and Euporia (cycle-emergent dimension surfacing with cycle counter visibility and user-judged termination). The borrowing is **topological only** — Horismos's runtime is independent of `/induce`/`/elicit` invocations, and identity is preserved through the formal block: deficit `BoundaryUndefined → DefinedBoundary`, 4-value `BoundaryClassification` per cycle plus 2-value `FinalGateAnswer` at Phase 4 (vs Periagoge's `Confirm/Widen/Narrow/Fuse/Reorient` move set), evidence-cited domain anchors (vs Euporia's substrate-traced coordinate values). The shared structure is the **loop carrier** (per-cycle re-scan, cycle counter visibility, user-judged termination, essence-style cumulative artifact); dialectical content remains specific to each source protocol.
-
 ## Mode Activation
 
 ### Activation

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.23.32",
+  "version": "1.23.33",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -107,25 +107,6 @@ converge    (extension)  → TextPresent+Proceed (convergence evidence trace; pr
 
 **Comprehension over Explanation**: AI verifies user's understanding rather than lecturing. The goal is confirmed comprehension, not information transfer.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key difference**: AI work exists but the result remains ungrasped by the user. Katalepsis guides user to firm understanding through structured verification.
-
 ## Mode Activation
 
 ### Activation

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -109,30 +109,6 @@ converge           (extension)   → TextPresent+Proceed (convergence evidence t
 
 **Dialectical Triangulation over Unilateral Proposal**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI proposes a candidate paired with a personalized grounding example drawn from the user's own domain; the user shapes through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI assertion.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-
-- **Periagoge vs Analogia**: Directional dual. Analogia validates a given abstract structure against a concrete target (static substitution — given Sₐ, establish Sₐ → Sₜ correspondence). Periagoge forms a new abstraction from concrete instances (dynamic colimit — given {Iᵢ}, construct emergent abstraction). When the input carries `essence_sensed(A)` with `locator_absent(A)` (formal `¬located(A)`; manifests in Analogia as a missing source abstraction Sₐ), Analogia's substitution interface produces source-domain confabulation; Periagoge resolves that misfit by handling abstraction formation directly.
-- **Periagoge vs Prothesis**: Prothesis selects among candidate analytical frameworks (including cases where multiple candidates are already named). Periagoge forms a new abstraction from an instance cocone when no locator is available. Comparative analysis between already-named candidate readings — even with multiple instances or strong essence sensing — is Prothesis territory (frame selection), not Periagoge's colimit formation. Scope is specified by the operation kind, not by instance count.
-
-**Formation distinction**: Periagoge operates on the colimit — the emergent structure arising from a cocone of concrete instances. The operational test: Periagoge applies when concrete instances carry `essence_sensed(A)` and `locator_absent(A)`. Instance accumulation contributes evidence strength; the gate is essence signal plus locator gap.
-
 ## Mode Activation
 
 ### Activation

--- a/prosoche/.claude-plugin/plugin.json
+++ b/prosoche/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prosoche",
   "description": "Route upstream epistemic deficits and evaluate execution-time risks \u2014 /attend (\u03c0\u03c1\u03bf\u03c3\u03bf\u03c7\u03ae: attention)",
-  "version": "1.6.47",
+  "version": "1.6.48",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -241,30 +241,6 @@ Post-gate execution belongs to non-epistemic substrates. After Phase 3 records `
 
 When elevated-risk findings reach Phase 2, the epistemic part (intent transmission, evidence, judgment surfacing) is Prosoche's; the substrate part (whether the harness permits the action, whether the deploy succeeds, whether the comment reaches its audience) is delegated by handoff.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key differences**:
-- **Aitesis** infers context the AI lacks *before* execution (factual uncertainties, User→AI) — Prosoche evaluates risk signals *during* execution (action assessment, AI→User). Aitesis asks "do I have enough context?" while Prosoche asks "is this action safe to execute?"
-- **Syneidesis** surfaces gaps in *decision quality* for user judgment — Prosoche surfaces risks in *execution actions* for user approval. Syneidesis operates at the decision layer; Prosoche operates at the execution layer.
-- **Epharmoge** evaluates *applicability* of completed results after execution — Prosoche evaluates *risk* of pending actions before they execute. Both are AI→User, but at different temporal points: Prosoche is pre-action, Epharmoge is post-completion.
-
-**Task-bounded execution**: Unlike daemon-model protocols that run continuously throughout a session, Prosoche materializes intent into a concrete task list at activation, processes each task through risk classification and delegation, and deactivates when all tasks are resolved (completed or halted). This makes Prosoche's scope explicit and its convergence deterministic.
-
 ## Mode Activation
 
 ### Activation

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.29",
+  "version": "5.17.30",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -188,25 +188,6 @@ AgentRef  = { name: String, type: String, perspective: Option(String) }
 
 **Placement over Prescription**: AI places available perspectives before the user without prescribing which to adopt. User selects.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key difference**: Prothesis operates at the framework-selection level — choosing which analytical lenses to apply — while all other protocols operate within an already-established framework. It is also the only protocol that can assemble a multi-agent team for parallel perspective analysis (Mode 2) or provide lightweight lens recommendations (Mode 1). Syneidesis surfaces gaps in a decision, Aitesis verifies execution context, but both assume the analytical lens is already chosen. Prothesis is the protocol that chooses the lens.
-
 ## Mode Activation
 
 ### Activation

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points \u2014 /gap (\u03c3\u03c5\u03bd\u03b5\u03af\u03b4\u03b7\u03c3\u03b9\u03c2: knowing-together)",
-  "version": "2.21.41",
+  "version": "2.21.42",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -84,25 +84,6 @@ converge (extension)   → TextPresent+Proceed (convergence evidence trace; proc
 
 **Surfacing over Deciding**: AI makes visible; user judges.
 
-## Distinction from Other Protocols
-
-| Protocol | Initiator | Deficit → Resolution | Focus |
-|----------|-----------|----------------------|-------|
-| **Prothesis** | AI-guided | FrameworkAbsent → FramedInquiry | Perspective selection |
-| **Syneidesis** | AI-guided | GapUnnoticed → AuditedDecision | Decision-point gaps |
-| **Horismos** | AI-guided | BoundaryUndefined → DefinedBoundary | Epistemic boundary definition |
-| **Aitesis** | AI-guided | ContextInsufficient → InformedExecution | Context sufficiency sensing |
-| **Analogia** | AI-guided | MappingUncertain → ValidatedMapping | Abstract-concrete mapping validation |
-| **Periagoge** | AI-guided | AbstractionInProcess → CrystallizedAbstraction | In-process abstraction crystallization |
-| Euporia | Hybrid | AbstractAporia → ResolvedEndpoint | Extended-Mind reverse induction |
-| **Prosoche** | User-initiated | ExecutionBlind → SituatedExecution | Risk-assessed execution |
-| **Epharmoge** | AI-guided | ApplicationDecontextualized → ContextualizedExecution | Post-execution applicability |
-| **Elenchus** | User-initiated | ContextSuspect → VettedContext | Dialectical context vetting (pre-execution) |
-| **Anamnesis** | AI-guided | RecallAmbiguous → RecalledContext | Vague recall recognition |
-| **Katalepsis** | User-initiated | ResultUngrasped → VerifiedUnderstanding | Comprehension verification |
-
-**Key difference**: Syneidesis audits the user's decision quality at committed action points (metacognitive: "has the user considered all angles?"). This is distinct from Aitesis, which monitors AI's context sufficiency (heterocognitive: "do I have enough context to execute?"), and Epharmoge, which evaluates AI's execution quality post-hoc ("does the result fit the context?"). The operational test: if the gap would be filled by the user reconsidering their decision, it's Syneidesis; if by providing context, it's Aitesis; if by adapting the result, it's Epharmoge.
-
 ## Mode Activation
 
 ### Activation


### PR DESCRIPTION
## 배경 — 격리 방향 1차 PR

`/sublate` 세션에서 코어 프로토콜 아키텍처 방향을 재정련:

- **원 제안**: 코어 12개를 하나의 `epistemic-core` 플러그인으로 통합 → **Discarded**
  - 안티테제: 플러그인 병합은 토큰 효율화와 인과 단절 (Skill lazy-load 시맨틱); "모듈화"는 분리의 동의어이지 집약의 동의어가 아님
- **수렴 방향**: 코어 프로토콜은 서로를 신경쓰지 않는 격리된 단일-목적 도구; 자연어 세션 컨텍스트 아래 자연 합성 — `Unix Philosophy Homomorphism` + `Session Text Composition` 원칙과 정렬

본 PR은 격리 방향의 1차 작업 — 각 코어 SKILL.md에 인스크라이브된 *타-프로토콜 카탈로그*(`Distinction from Other Protocols` 표 + Key differences 단락)를 일괄 제거합니다.

## 근거

타-프로토콜 명명·카탈로그는 *"명시적 지정이 LLM 어텐션을 높인다"* 가정에서 출발한 보조 스캐폴딩이었으며, 사용자 온보딩 편의를 위해 도입된 것이었습니다. 본 프로젝트의 `safeguards.md` Safeguard-tier 트레지엑토리 정의("모델이 개선될수록 덜 중요해지는 가드")와 부합하여 — Opus 4.7급 instruction-following 능력에서 해당 스캐폴딩의 한계 효용이 비용을 하회한다고 판단.

## 변경 내역

### 1. 코어 SKILL.md (12개)

각 코어 SKILL.md에서 다음을 제거:

- `## Distinction from Other Protocols` 헤더 및 12-행 비교표
- 하위 Key differences / Heterocognitive distinction / Factual vs evaluative / Formation distinction 등 키-차이 단락

영향 파일:
- `aitesis/skills/inquire/SKILL.md` (-24)
- `analogia/skills/ground/SKILL.md` (-28)
- `anamnesis/skills/recollect/SKILL.md` (-24)
- `elenchus/skills/sublate/SKILL.md` (-25)
- `epharmoge/skills/contextualize/SKILL.md` (-26)
- `euporia/skills/elicit/SKILL.md` (-27)
- `horismos/skills/bound/SKILL.md` (-25)
- `katalepsis/skills/grasp/SKILL.md` (-19)
- `periagoge/skills/induce/SKILL.md` (-24)
- `prosoche/skills/attend/SKILL.md` (-24)
- `prothesis/skills/frame/SKILL.md` (-19)
- `syneidesis/skills/gap/SKILL.md` (-19)

소계: SKILL.md에서 **-284 lines**

### 2. 정적 검사

- `static-checks.js` `structure` 검사의 `requiredSections`에서 `## Distinction from Other Protocols` 항목 제거
- `cross-ref-scan` Sub-check 4 (Distinction table consistency) 제거 — 표 자체가 없으므로 dead code
- 후속 Sub-check 번호 정리 (5→4, 6→5)

소계: `static-checks.js` **-29 lines**

### 3. 버전 bump (12개 plugin.json patch)

| Plugin | Old → New |
|---|---|
| aitesis | 4.3.32 → 4.3.33 |
| analogia | 1.6.32 → 1.6.33 |
| anamnesis | 0.4.34 → 0.4.35 |
| elenchus | 0.1.8 → 0.1.9 |
| epharmoge | 0.7.39 → 0.7.40 |
| euporia | 0.2.11 → 0.2.12 |
| horismos | 1.11.0 → 1.11.1 |
| katalepsis | 1.23.32 → 1.23.33 |
| periagoge | 0.1.27 → 0.1.28 |
| prosoche | 1.6.47 → 1.6.48 |
| prothesis | 5.17.29 → 5.17.30 |
| syneidesis | 2.21.41 → 2.21.42 |

**총합**: 25 files changed, +14 / -327

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — `fail: []`, 기존 warn 2건은 본 PR 무관 (Horizontverschmelzung, hermeneutic-cycle 한국어)
- `node --test scripts/package.test.js` — 48/48 pass
- `node scripts/package.js --dry-run` — 통과

## 후속 PR 계획

2차 PR (별도 — 본 PR 머지 후):
- SKILL.md 본문의 타-프로토콜 *이름 인용* 추상화 — `Routed(downstream_protocol: ProtocolId)`, `Advisory relationships` 절, `Protocol precedence` 단락 등

3차 PR (별도):
- `epistemic-cooperative` 허브 강화 — 카탈로그·합성 예시·응용 사례 큐레이션으로 디스커버리 책임 흡수

4차 (검증 정리): 작업 중 발견된 정적 검사 깨짐만 발견적 처리 (1차 PR에서 발생 없음)

## Test plan

- [x] static-checks fail 0
- [x] package tests 48/48
- [x] package dry-run 통과
- [ ] CI 통과 확인 (PR 등록 후)

https://claude.ai/code/session_012TPjTcMCN4LKGLUG9PzLxu

---
_Generated by [Claude Code](https://claude.ai/code/session_012TPjTcMCN4LKGLUG9PzLxu)_