### PR TITLE
refactor(core): SKILL.md 본문 타-프로토콜 이름 인용 추상화 — Unix 철학 격리 2차

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -35,31 +35,6 @@ const PROTOCOL_FILES = protocolFiles({ projectRoot });
 const CANONICAL_PRECEDENCE = CANONICAL_PRECEDENCE_ARR.join(' → ');
 const CANONICAL_CLUSTERS = 'Planning (`/inquire`, `/elicit`) · Analysis (`/frame`, `/ground`, `/induce`) · Decision (`/gap`) · Execution (`/attend`) · Verification (`/contextualize`, `/sublate`) · Cross-cutting (`/bound`, `/recollect`, `/grasp`)';
 
-// PRECEDENCE_FILES = protocols listed in CANONICAL_PRECEDENCE (linear order)
-// + Katalepsis appended (structurally last). Anamnesis is excluded — recall
-// stands outside the precedence partial order. Order matches the canonical
-// presentation used by checkPrecedenceLinearExtension.
-//
-// Loud-fail: a missing protocol record yields an `undefined` skill segment,
-// producing paths like `horismos/skills/undefined/SKILL.md` that fs.existsSync
-// silently rejects. Throw at construction so the failure is attributable to
-// graph.json (which is the upstream input that decides isProtocol) rather
-// than surfacing later as "all checks pass on zero files" (PR #351 review H1).
-function _precedenceFile(dir) {
-  const rec = _protocolRecords.find(r => r.dir === dir);
-  if (!rec) {
-    throw new Error(
-      `[static-checks] PRECEDENCE_FILES: no protocol record for "${dir}". ` +
-      `Likely cause: graph.json failed to parse or "${dir}" missing from nodes.`
-    );
-  }
-  return `${dir}/skills/${rec.skill}/SKILL.md`;
-}
-const PRECEDENCE_FILES = [
-  ...CANONICAL_PRECEDENCE_ARR.map(name => _precedenceFile(name.toLowerCase())),
-  _precedenceFile('katalepsis'),
-];
-
 // Authoritative edge type allowlist — used by both graph-integrity and cross-ref-scan checks
 const VALID_EDGE_TYPES = new Set(['precondition', 'advisory', 'suppression']);
 
@@ -1296,65 +1271,7 @@ function checkCrossRefScan() {
     }
   }
 
-  // Sub-check 3: Verify precedence template in **Protocol precedence** line
-  const precedenceList = CANONICAL_PRECEDENCE.split(' → ');
-  const precedenceCount = precedenceList.length;
-  for (const relPath of PRECEDENCE_FILES) {
-    const fullPath = path.join(projectRoot, relPath);
-    if (!fs.existsSync(fullPath)) continue;
-
-    const content = fs.readFileSync(fullPath, 'utf8');
-    const precedenceMatch = content.match(/\*\*Protocol precedence\*\*:(.+)/);
-    if (!precedenceMatch) {
-      results.fail.push({
-        check: 'cross-ref-scan',
-        file: relPath,
-        message: 'Missing **Protocol precedence** line in SKILL.md'
-      });
-      subCheckFailed = true;
-      continue;
-    }
-    const pLine = precedenceMatch[1];
-
-    // Derive expected position from CANONICAL_PRECEDENCE index
-    const dirName = relPath.split('/')[0];
-    const expectedIndex = precedenceList.findIndex(
-      name => name.toLowerCase() === dirName
-    );
-
-    if (expectedIndex >= 0) {
-      const expectedPosition = `position ${expectedIndex + 1}/${precedenceCount}`;
-      if (!pLine.includes(expectedPosition)) {
-        results.fail.push({
-          check: 'cross-ref-scan',
-          file: relPath,
-          message: `Wrong precedence position (expected: "${expectedPosition}")`
-        });
-        subCheckFailed = true;
-      }
-    } else {
-      // Cross-cutting protocol (not in CANONICAL_PRECEDENCE)
-      const hasCrossCutting = pLine.includes('Cross-cutting:') || pLine.includes('Structural constraint');
-      if (!hasCrossCutting) {
-        results.fail.push({
-          check: 'cross-ref-scan',
-          file: relPath,
-          message: 'Protocol not in CANONICAL_PRECEDENCE and missing Cross-cutting/Structural constraint marker'
-        });
-        subCheckFailed = true;
-      }
-    }
-
-    if (!pLine.includes('graph.json')) {
-      results.fail.push({
-        check: 'cross-ref-scan',
-        file: relPath,
-        message: 'Missing graph.json reference in **Protocol precedence** line'
-      });
-      subCheckFailed = true;
-    }
-  }
-
+  // Sub-check 3: Verify README workflow + CLAUDE.md cross-doc invariants
   for (const relPath of ['README.md', 'README_ko.md']) {
     const fullPath = path.join(projectRoot, relPath);
     if (!fs.existsSync(fullPath)) continue;

--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution \u2014 /inquire (\u03b1\u1f34\u03c4\u03b7\u03c3\u03b9\u03c2: a requesting)",
-  "version": "4.3.33",
+  "version": "4.3.34",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -217,10 +217,6 @@ When Aitesis is active:
 - Aitesis completes before execution proceeds
 - Loaded instructions resume after context is resolved or dismissed
 
-**Protocol precedence**: Activation order position 2/10 (graph.json is authoritative source for information flow). Concern cluster: Planning.
-
-**Advisory relationships**: Receives from Horismos (advisory: BoundaryMap narrows context inference scope), Prothesis (advisory: perspective simulation provides context inference recommendations), Euporia (advisory: traced coordinates narrow context inference), Syneidesis (suppression: same scope suppression). Provides to Prosoche (advisory: inferred context narrows execution risk assessment), Analogia (advisory: inferred context narrows mapping domain identification), Elenchus (advisory: collected context provides dialectical audit substrate); Epharmoge (suppression: pre+post stacking prevention). Katalepsis is structurally last.
-
 ### Trigger Signals
 
 Heuristic signals for context insufficiency inference (not hard gates):

--- a/analogia/.claude-plugin/plugin.json
+++ b/analogia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "analogia",
   "description": "Validate structural mapping between domains \u2014 /ground (\u1f00\u03bd\u03b1\u03bb\u03bf\u03b3\u03af\u03b1: a proportion)",
-  "version": "1.6.33",
+  "version": "1.6.34",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -136,10 +136,6 @@ When Analogia is active:
 - Analogia completes before output dependent on mapping validity proceeds
 - Loaded instructions resume after mapping status is made explicit
 
-**Protocol precedence**: Activation order position 4/10 (graph.json is authoritative source for information flow). Concern cluster: Analysis.
-
-**Advisory relationships**: Receives from Prothesis (advisory: perspective simulation provides mapping construction context), Aitesis (advisory: inferred context narrows mapping domain identification), Horismos (advisory: BoundaryMap narrows mapping domain identification). Provides to Syneidesis (advisory: validated mapping improves gap detection accuracy). Katalepsis is structurally last.
-
 ### Trigger Signals
 
 Heuristic signals for mapping uncertainty detection (not hard gates):

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -287,10 +287,6 @@ When Anamnesis is active:
 
 Anamnesis completes before context-dependent work; loaded instructions resume after recall resolves or dismisses.
 
-**Protocol precedence**: graph.json is authoritative. Anamnesis is an advisory hub (Aitesis, Prothesis, Syneidesis, Horismos, Prosoche, Analogia, Periagoge, Epharmoge, Euporia, Elenchus) with no incoming advisory edges; Katalepsis is structurally last. Elenchus receives recalled prior context as audit-candidate substrate.
-
-**Temporal ordering**: Advisory edges do not enforce activation ordering. `/recollect` should be invoked early for advisory flow to materialize. If downstream protocols activate first, advisory enrichment is unreachable in that session (not an error); user awareness of session-start recall is the ordering mechanism.
-
 ### Trigger Signals
 
 Heuristic signals for empty intention detection (not hard gates):

--- a/elenchus/.claude-plugin/plugin.json
+++ b/elenchus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "elenchus",
   "description": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -51,7 +51,7 @@ Disposition    = Confirmed                                   -- assumption survi
                | Deferred(re_trigger_condition: String)      -- next iteration on trigger
                | Conditional(measurement: String)            -- pending external measurement
                | Bounded(external_reference: String)         -- routed to other source-of-truth
-               | Routed(downstream_protocol: ProtocolId)     -- handed to /gap, /attend, /epharmoge, /bound
+               | Routed(downstream_protocol: ProtocolId)     -- handed off to a different protocol
 Qs             = Per-source disposition gate
 J              = Map(Source, Disposition)
 V              = VettedContext { dispositions: J, trace: Map(Source, Antithesis) }
@@ -137,10 +137,6 @@ When Elenchus is active:
 
 - Elenchus completes before action dependent on the vetted context proceeds
 - Loaded instructions resume after vetting or Esc
-
-**Protocol precedence**: Activation order position 10/10 (graph.json is authoritative source for information flow). Concern cluster: Verification (pre-execution posture; orthogonal to `/contextualize` which is post-execution). The `* → katalepsis` precondition wildcard automatically covers Elenchus.
-
-**Advisory relationships**: Receives from Aitesis (advisory: collected context provides audit substrate), Anamnesis (advisory: recalled prior context contributes audit candidates), Horismos (advisory: BoundaryMap narrows audit scope to in-scope sources). Provides to Syneidesis (advisory: vetted context sharpens gap detection), Prosoche (advisory: vetted context narrows risk-evaluation focus), Epharmoge (advisory: vetted pre-state contextualizes post-execution applicability check), Horismos (advisory: vetting findings inform downstream boundary definition).
 
 ### Triggers
 
@@ -265,7 +261,7 @@ options:
   - label: "Bounded([external_reference])"
     description: "The authoritative answer lives outside this session; downstream usage cites the external reference rather than the in-session source."
   - label: "Routed([downstream_protocol])"
-    description: "The challenge belongs to a different protocol family — handed to /gap, /attend, /epharmoge, or /bound for resolution."
+    description: "The challenge belongs to a different protocol family — handed off to the appropriate downstream protocol for resolution."
 Other: user composes a free-response disposition; AI maps the response to the closest coproduct variant or surfaces an Emergent disposition candidate.
 ```
 

--- a/epharmoge/.claude-plugin/plugin.json
+++ b/epharmoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epharmoge",
   "description": "Detect application-context mismatch after execution \u2014 /contextualize (\u1f10\u03c6\u03b1\u03c1\u03bc\u03bf\u03b3\u03ae: an application)",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -131,10 +131,6 @@ When Epharmoge is active:
 - Epharmoge completes before proceeding to next task
 - Loaded instructions resume after applicability is verified or dismissed
 
-**Protocol precedence**: Activation order position 9/10 (graph.json is authoritative source for information flow). Concern cluster: Verification.
-
-**Advisory relationships**: Receives from Prosoche (advisory: execution-time attention provides post-execution applicability context), Elenchus (advisory: vetted pre-state contextualizes post-execution applicability check); Aitesis (suppression: pre+post stacking prevention). Katalepsis is structurally last.
-
 ### Trigger Signals
 
 Heuristic signals for applicability mismatch detection (not hard gates):

--- a/euporia/.claude-plugin/plugin.json
+++ b/euporia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "euporia",
   "description": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/euporia/skills/elicit/SKILL.md
+++ b/euporia/skills/elicit/SKILL.md
@@ -177,10 +177,6 @@ When Euporia is active:
 - Euporia completes before action dependent on the resolved endpoint proceeds
 - Loaded instructions resume after resolution or Esc
 
-**Protocol precedence**: Activation order position 6/10 (graph.json is authoritative source for information flow). Concern cluster: Planning.
-
-**Advisory relationships**: Receives from Anamnesis (advisory: recalled session history enriches substrate scan), Horismos (advisory: BoundaryMap narrows substrate scope). Provides to Aitesis (advisory: traced coordinates narrow context inference), Periagoge (advisory: resolved endpoint may seed downstream abstraction), Horismos (advisory: resolved coordinates inform downstream boundary definition). Same-session re-entry between Euporia and Horismos is permitted but treated as distinct activation — each invocation produces a fresh ResolvedEndpoint or BoundaryMap, with the prior instance becoming session evidence rather than auto-cycling input. Katalepsis is structurally last.
-
 ### Trigger Signals
 
 | Signal | Detection |

--- a/horismos/.claude-plugin/plugin.json
+++ b/horismos/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "horismos",
   "description": "Define epistemic boundaries per decision \u2014 /bound (\u1f41\u03c1\u03b9\u03c3\u03bc\u03cc\u03c2: a bounding)",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/horismos/skills/bound/SKILL.md
+++ b/horismos/skills/bound/SKILL.md
@@ -229,10 +229,6 @@ When Horismos is active:
 - Horismos completes before execution proceeds
 - Loaded instructions resume after all domains are bounded or dismissed
 
-**Protocol precedence**: Activation order position 1/10 (graph.json is authoritative source for information flow). Cross-cutting: BoundaryMap is consumed by 5 downstream protocols.
-
-**Advisory relationships**: Provides to Aitesis, Prothesis, Prosoche, Analogia, Syneidesis, Euporia, Elenchus (all advisory: BoundaryMap narrows scope; for Elenchus, narrows high-leverage source range). Receives from Euporia (advisory: resolved coordinates inform downstream boundary definition), Elenchus (advisory: vetting findings inform downstream boundary definition). Katalepsis is structurally last.
-
 ### Trigger Signals
 
 Heuristic signals for boundary-undefined domain detection (not hard gates):

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
-  "version": "1.23.33",
+  "version": "1.23.34",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -134,10 +134,6 @@ At Phase 3, present comprehension verification via Cognitive Partnership Move (C
 - Katalepsis provides structured comprehension path
 - Loaded instructions resume after mode deactivation
 
-**Protocol precedence**: Structural constraint — always executes last (graph.json is authoritative source for information flow). Cross-cutting: requires all protocols to complete before verification.
-
-**Advisory relationships**: Receives from * (precondition: all protocol output required for comprehension verification). Katalepsis is structurally last.
-
 ### Triggers
 
 | Signal | Examples |

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -144,10 +144,6 @@ When Periagoge is active:
 - Periagoge completes before output dependent on the crystallized abstraction proceeds
 - Loaded instructions resume after crystallization or Esc
 
-**Protocol precedence**: Activation order position 5/10 (graph.json is authoritative source for information flow). Concern cluster: Analysis.
-
-**Advisory relationships**: Receives from Anamnesis (advisory: recalled adjacent abstractions provide Fuse candidates), Euporia (advisory: resolved endpoint may seed downstream abstraction). Provides to Katalepsis (precondition via wildcard: crystallized abstraction enables comprehension verification). Katalepsis is structurally last.
-
 ### Trigger Signals
 
 Heuristic evidence signals for in-process abstraction detection:

--- a/prosoche/.claude-plugin/plugin.json
+++ b/prosoche/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prosoche",
   "description": "Route upstream epistemic deficits and evaluate execution-time risks \u2014 /attend (\u03c0\u03c1\u03bf\u03c3\u03bf\u03c7\u03ae: attention)",
-  "version": "1.6.48",
+  "version": "1.6.49",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prosoche/skills/attend/SKILL.md
+++ b/prosoche/skills/attend/SKILL.md
@@ -274,10 +274,6 @@ When Prosoche is active:
 - Loaded instructions and other protocol behaviors are retained
 - Prosoche adds a risk assessment layer, does not modify protocol logic
 
-**Protocol precedence**: Activation order position 8/10 (graph.json is authoritative source for information flow). Concern cluster: Execution.
-
-**Advisory relationships**: Receives from Aitesis (advisory: inferred context narrows execution risk assessment), Horismos (advisory: BoundaryMap adjusts risk assessment threshold), Elenchus (advisory: vetted context narrows risk-evaluation focus). Provides to Epharmoge (advisory: execution-time attention provides post-execution applicability context). Katalepsis is structurally last.
-
 ### Skip Conditions
 
 - Read-only / exploratory actions (Read, Grep, Glob, LS)

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.30",
+  "version": "5.17.31",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -214,10 +214,6 @@ When Prothesis is active:
 - Prothesis completes before other workflows begin
 - Loaded instructions resume after perspective is established
 
-**Protocol precedence**: Activation order position 3/10 (graph.json is authoritative source for information flow). Concern cluster: Analysis.
-
-**Advisory relationships**: Receives from Horismos (advisory: BoundaryMap narrows framework selection scope). Provides to Syneidesis (advisory: perspective simulation provides gap detection context), Aitesis (advisory: perspective simulation provides context inference recommendations), Analogia (advisory: perspective simulation provides mapping construction context). Katalepsis is structurally last.
-
 Consult `references/conceptual-foundations.md` for design rationale (Plan Mode Integration, Distinction from Socratic Method, Parametric Nature, Specialization) and activation edge cases (per-message application rules, mode deactivation triggers, trigger/skip heuristics).
 
 ## Protocol

--- a/syneidesis/.claude-plugin/plugin.json
+++ b/syneidesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "syneidesis",
   "description": "Surface potential gaps at decision points \u2014 /gap (\u03c3\u03c5\u03bd\u03b5\u03af\u03b4\u03b7\u03c3\u03b9\u03c2: knowing-together)",
-  "version": "2.21.42",
+  "version": "2.21.43",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/syneidesis/skills/gap/SKILL.md
+++ b/syneidesis/skills/gap/SKILL.md
@@ -113,10 +113,6 @@ When Syneidesis is active:
 - All decision points become candidates for interactive confirmation
 - Loaded instructions resume after mode deactivation
 
-**Protocol precedence**: Activation order position 7/10 (graph.json is authoritative source for information flow). Concern cluster: Decision.
-
-**Advisory relationships**: Receives from Prothesis (advisory: perspective simulation provides gap detection context), Analogia (advisory: validated mapping improves gap detection accuracy), Horismos (advisory: BoundaryMap narrows gap detection scope), Elenchus (advisory: vetted context sharpens gap detection accuracy). Provides to Aitesis (suppression: same scope suppression). Katalepsis is structurally last.
-
 ### Mode Deactivation
 
 | Trigger | Effect |


### PR DESCRIPTION
## 배경 — 격리 방향 2차 PR

1차 PR(#404)에서 12개 코어 SKILL.md의 *Distinction from Other Protocols* 표를 일괄 제거. 본 2차 PR은 잔존한 *cross-protocol 이름 인용*을 추상화/제거하여 SKILL.md가 *타 프로토콜에 무지한 자기 충족 계약 표면*이 되도록 합니다.

`/sublate` 세션에서 합의된 합성 모델:

> 컨텍스트를 가지고 호출되면 다른 프로토콜에서도 창의적인 합성이 가능 — graph.json은 검증 보조로만 잔존, SKILL.md는 타 프로토콜을 신경쓰지 않음.

## 변경 내역

### 1. `**Advisory relationships**` 단락 제거 (12개 코어 SKILL.md)

각 단락은 *"Receives from X (rationale), Provides to Y (rationale), Katalepsis structurally last"* 형식으로 graph.json 엣지를 redundant 인스크라이브하던 prose. graph.json이 정적 검사 보조의 인증 출처이므로 SKILL.md 인용은 폐기.

영향 파일 — 단락 1개씩 (각 2~3행 + 빈 줄):
- `aitesis/skills/inquire/SKILL.md`
- `analogia/skills/ground/SKILL.md`
- `anamnesis/skills/recollect/SKILL.md` (Protocol precedence에 hub 리스트 임베드된 형태)
- `elenchus/skills/sublate/SKILL.md`
- `epharmoge/skills/contextualize/SKILL.md`
- `euporia/skills/elicit/SKILL.md`
- `horismos/skills/bound/SKILL.md`
- `katalepsis/skills/grasp/SKILL.md`
- `periagoge/skills/induce/SKILL.md`
- `prosoche/skills/attend/SKILL.md`
- `prothesis/skills/frame/SKILL.md`
- `syneidesis/skills/gap/SKILL.md`

### 2. `**Protocol precedence**` 단락 제거 (12개 코어 SKILL.md)

각 단락은 *"Activation order position N/10 (graph.json is authoritative source for information flow). Concern cluster: ..."* 형식. coordination metadata + graph.json 컨트리뷰터 doc 참조 leak이 결합된 prose. 책임은 `epistemic-cooperative` 허브 + `CLAUDE.md`로 이전 (3차 PR 예정).

Anamnesis의 경우 hub 리스트가 단락에 임베드 + `**Temporal ordering**` 보조 단락도 동시 제거 (graph.json `advisory edges` 시맨틱을 직접 인용하던 prose).

### 3. Elenchus `Routed` disposition 추상화

`Disposition` 변형의 type 시그니처는 보존, 특정 프로토콜 이름만 일반화:

```diff
- | Routed(downstream_protocol: ProtocolId)     -- handed to /gap, /attend, /epharmoge, /bound
+ | Routed(downstream_protocol: ProtocolId)     -- handed off to a different protocol
```

```diff
- description: "The challenge belongs to a different protocol family — handed to /gap, /attend, /epharmoge, or /bound for resolution."
+ description: "The challenge belongs to a different protocol family — handed off to the appropriate downstream protocol for resolution."
```

### 4. 정적 검사 정리

- `cross-ref-scan` Sub-check 3 (precedence template 검사) 제거 — SKILL.md에 `**Protocol precedence**` 줄이 없으므로 검사 자체가 dead
- `PRECEDENCE_FILES` / `_precedenceFile` 상수 제거 (Sub-check 3 전용 dead code)
- Sub-check 번호 정리
- `precedence-linear-extension` 검사 (1780행~)는 *graph.json 구조 검증*이므로 그대로 유지

### 5. 버전 bump (12개 plugin.json patch)

| Plugin | Old → New |
|---|---|
| aitesis | 4.3.33 → 4.3.34 |
| analogia | 1.6.33 → 1.6.34 |
| anamnesis | 0.4.35 → 0.4.36 |
| elenchus | 0.1.9 → 0.1.10 |
| epharmoge | 0.7.40 → 0.7.41 |
| euporia | 0.2.12 → 0.2.13 |
| horismos | 1.11.1 → 1.11.2 |
| katalepsis | 1.23.33 → 1.23.34 |
| periagoge | 0.1.28 → 0.1.29 |
| prosoche | 1.6.48 → 1.6.49 |
| prothesis | 5.17.30 → 5.17.31 |
| syneidesis | 2.21.42 → 2.21.43 |

**총합**: 25 files changed, +15 / -146

## 잔존 cross-protocol 참조 (의도된 미처리)

다음은 본 PR 범위에서 의도적으로 제외 — 운영 시맨틱 또는 user-facing verb 합법 인터페이스:

- **`**Cross-session enrichment**` 단락** — `/recollect` user-facing verb를 합법적 인터페이스로 사용 (Unix-style composition: user가 invocation으로 wire)
- **Aitesis classify 라우팅 taxonomy** (`MappingUncertain→/ground` 등) — deficit-matched routing은 Aitesis의 자체 시맨틱
- **Aitesis Cross-protocol fatigue suppression** — graph.json suppression 엣지의 자기 인용
- **Anamnesis NullMatch → Aitesis seeding** — `*: /recollect ∘ /inquire` 합성 메커니즘 (Anamnesis 자체 시맨틱)
- **Periagoge → Katalepsis precondition 인용** — 구조적 관계 (graph.json 명시)

이 항목들은 *3차 PR* 또는 *추가 dispositioning* 후 처리 — 단순 표면 prose가 아닌 operational mechanism 인스크립션.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — `fail: []`, 기존 warn 2건은 본 PR 무관
- `node --test scripts/package.test.js` — 48/48 pass
- `node scripts/package.js --dry-run` — 통과

## 후속 PR

- **3차 PR**: `epistemic-cooperative` 허브 강화 — `/catalog`·`/onboard`에 합성 예시·응용 사례 큐레이션, 본 PR에서 SKILL.md가 잃은 디스커버리 기능 흡수
- **추가 (조건부)**: 잔존 cross-protocol 참조 중 필요한 항목 추상화

## Test plan

- [x] static-checks fail 0
- [x] package tests 48/48 pass
- [x] package dry-run 통과
- [ ] CI 통과 확인 (PR 등록 후)

https://claude.ai/code/session_012TPjTcMCN4LKGLUG9PzLxu

---
_Generated by [Claude Code](https://claude.ai/code/session_012TPjTcMCN4LKGLUG9PzLxu)_