### PR TITLE
Port Claude plugins to Codex plugin layout

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,164 @@
+{
+  "name": "epistemic-protocols",
+  "interface": {
+    "displayName": "Epistemic Protocols"
+  },
+  "plugins": [
+    {
+      "name": "prothesis",
+      "source": {
+        "source": "local",
+        "path": "./prothesis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "syneidesis",
+      "source": {
+        "source": "local",
+        "path": "./syneidesis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "katalepsis",
+      "source": {
+        "source": "local",
+        "path": "./katalepsis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "aitesis",
+      "source": {
+        "source": "local",
+        "path": "./aitesis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "analogia",
+      "source": {
+        "source": "local",
+        "path": "./analogia"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "periagoge",
+      "source": {
+        "source": "local",
+        "path": "./periagoge"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "euporia",
+      "source": {
+        "source": "local",
+        "path": "./euporia"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "prosoche",
+      "source": {
+        "source": "local",
+        "path": "./prosoche"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "epharmoge",
+      "source": {
+        "source": "local",
+        "path": "./epharmoge"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "elenchus",
+      "source": {
+        "source": "local",
+        "path": "./elenchus"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "horismos",
+      "source": {
+        "source": "local",
+        "path": "./horismos"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "epistemic-cooperative",
+      "source": {
+        "source": "local",
+        "path": "./epistemic-cooperative"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "anamnesis",
+      "source": {
+        "source": "local",
+        "path": "./anamnesis"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,33 +32,26 @@ Then run `/onboard` — start with a quick recommendation based on your recent s
 
 ### Codex
 
-Paste in Codex and run:
+This repository is also a Codex plugin marketplace. To add it from GitHub:
 
-```text
-$skill-installer install these skills from jongwony/epistemic-protocols:
-- prothesis/skills/frame
-- syneidesis/skills/gap
-- katalepsis/skills/grasp
-- aitesis/skills/inquire
-- horismos/skills/bound
-- analogia/skills/ground
-- periagoge/skills/induce
-- euporia/skills/elicit
-- prosoche/skills/attend
-- epharmoge/skills/contextualize
-- elenchus/skills/sublate
-- anamnesis/skills/recollect
-- epistemic-cooperative/skills/onboard
+```bash
+codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
 ```
 
-Restart Codex, then start with `$onboard`.
+For local development from a checkout:
+
+```bash
+codex plugin marketplace add /path/to/epistemic-protocols
+```
+
+The Codex marketplace preserves the same plugin boundaries as Claude Code: each protocol is its own plugin, and `epistemic-cooperative` carries the utility skills. Start with `onboard` for a quick recommendation, or install a specific protocol plugin when you already know which checkpoint you need.
 
 <details>
 <summary>Notes</summary>
 
-- This installs 12 protocols + `onboard`. `/report`, `/dashboard`, `/write` are not included.
-- To install a single skill, use the same `skill-installer` pattern with one path.
-- This README is the source of truth for the Codex-supported install set.
+- The Codex marketplace lives at [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json).
+- Each plugin keeps its Codex manifest beside the existing Claude manifest: `<plugin>/.codex-plugin/plugin.json`.
+- The marketplace includes the 12 protocol plugins plus `epistemic-cooperative`.
 
 </details>
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -32,33 +32,26 @@ curl -fsSL https://raw.githubusercontent.com/jongwony/epistemic-protocols/main/s
 
 ### Codex
 
-Codex에 붙여넣고 실행하세요:
+이 레포지토리는 Codex 플러그인 marketplace이기도 합니다. GitHub에서 추가하려면:
 
-```text
-$skill-installer jongwony/epistemic-protocols 에서 다음 스킬들을 설치해 주세요:
-- prothesis/skills/frame
-- syneidesis/skills/gap
-- katalepsis/skills/grasp
-- aitesis/skills/inquire
-- horismos/skills/bound
-- analogia/skills/ground
-- periagoge/skills/induce
-- euporia/skills/elicit
-- prosoche/skills/attend
-- epharmoge/skills/contextualize
-- elenchus/skills/sublate
-- anamnesis/skills/recollect
-- epistemic-cooperative/skills/onboard
+```bash
+codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
 ```
 
-재시작 후 `$onboard`부터 시작하세요.
+로컬 checkout으로 개발 중이라면:
+
+```bash
+codex plugin marketplace add /path/to/epistemic-protocols
+```
+
+Codex marketplace는 Claude Code와 같은 플러그인 경계를 유지합니다: 각 프로토콜은 독립 플러그인이고, `epistemic-cooperative`가 유틸리티 스킬을 담습니다. 빠른 추천은 `onboard`부터 시작하고, 필요한 체크포인트를 이미 알고 있다면 해당 프로토콜 플러그인을 설치하세요.
 
 <details>
 <summary>참고</summary>
 
-- 12개 프로토콜 + `onboard`를 설치합니다. `/report`, `/dashboard`, `/write`는 미포함.
-- 하나만 설치하려면 같은 `skill-installer` 패턴에 단일 path만 넣으세요.
-- Codex 지원 설치 세트의 소스 오브 트루스는 이 README입니다.
+- Codex marketplace는 [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json)에 있습니다.
+- 각 플러그인은 기존 Claude manifest 옆에 Codex manifest를 둡니다: `<plugin>/.codex-plugin/plugin.json`.
+- marketplace에는 12개 프로토콜 플러그인과 `epistemic-cooperative`가 포함됩니다.
 
 </details>
 

--- a/aitesis/.codex-plugin/plugin.json
+++ b/aitesis/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "aitesis",
+  "version": "4.3.34",
+  "description": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "aitesis"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Aitesis",
+    "shortDescription": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
+    "longDescription": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use aitesis for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/analogia/.codex-plugin/plugin.json
+++ b/analogia/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "analogia",
+  "version": "1.6.34",
+  "description": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "analogia"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Analogia",
+    "shortDescription": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
+    "longDescription": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use analogia for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "anamnesis",
+  "version": "0.4.36",
+  "description": "Resolve vague recall into recognized context — /recollect",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "anamnesis"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Anamnesis",
+    "shortDescription": "Resolve vague recall into recognized context — /recollect",
+    "longDescription": "Resolve vague recall into recognized context — /recollect",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use anamnesis for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/docs/mission-bridge.md
+++ b/docs/mission-bridge.md
@@ -18,7 +18,7 @@ Public-facing docs use a distilled version of that umbrella:
 - Make clear that the same checkpoint discipline also covers execution, verification, recall, and comprehension
 - Remain self-sufficient: a reader should not need contributor docs to understand what the project is for
 
-The README remains the source of truth for the Codex-supported install set. It is not the canonical source for the full machinery description.
+The README remains the source of truth for the Codex-supported distribution surfaces. It is not the canonical source for the full machinery description.
 
 ## Runtime Boundary
 

--- a/elenchus/.codex-plugin/plugin.json
+++ b/elenchus/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "elenchus",
+  "version": "0.1.10",
+  "description": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "elenchus"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Elenchus",
+    "shortDescription": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
+    "longDescription": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use elenchus for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/epharmoge/.codex-plugin/plugin.json
+++ b/epharmoge/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "epharmoge",
+  "version": "0.7.41",
+  "description": "Detect application-context mismatch after execution — /contextualize (ἐφαρμογή: an application)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "epharmoge"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Epharmoge",
+    "shortDescription": "Detect application-context mismatch after execution — /contextualize (ἐφαρμογή: an application)",
+    "longDescription": "Detect application-context mismatch after execution — /contextualize (ἐφαρμογή: an application)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use epharmoge for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "epistemic-cooperative",
+  "version": "2.17.19",
+  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "epistemic-cooperative"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Epistemic Cooperative",
+    "shortDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
+    "longDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use epistemic-cooperative for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/euporia/.codex-plugin/plugin.json
+++ b/euporia/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "euporia",
+  "version": "0.2.13",
+  "description": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "euporia"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Euporia",
+    "shortDescription": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
+    "longDescription": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use euporia for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/horismos/.codex-plugin/plugin.json
+++ b/horismos/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "horismos",
+  "version": "1.11.2",
+  "description": "Define epistemic boundaries per decision — /bound (ὁρισμός: a bounding)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "horismos"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Horismos",
+    "shortDescription": "Define epistemic boundaries per decision — /bound (ὁρισμός: a bounding)",
+    "longDescription": "Define epistemic boundaries per decision — /bound (ὁρισμός: a bounding)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use horismos for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/katalepsis/.codex-plugin/plugin.json
+++ b/katalepsis/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "katalepsis",
+  "version": "1.23.34",
+  "description": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "katalepsis"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Katalepsis",
+    "shortDescription": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
+    "longDescription": "Achieve certain comprehension of AI work — /grasp (κατάληψις: a grasping firmly)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use katalepsis for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "periagoge",
+  "version": "0.1.29",
+  "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "periagoge"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Periagoge",
+    "shortDescription": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+    "longDescription": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use periagoge for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/prosoche/.codex-plugin/plugin.json
+++ b/prosoche/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "prosoche",
+  "version": "1.6.49",
+  "description": "Route upstream epistemic deficits and evaluate execution-time risks — /attend (προσοχή: attention)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "prosoche"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prosoche",
+    "shortDescription": "Route upstream epistemic deficits and evaluate execution-time risks — /attend (προσοχή: attention)",
+    "longDescription": "Route upstream epistemic deficits and evaluate execution-time risks — /attend (προσοχή: attention)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use prosoche for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/prothesis/.codex-plugin/plugin.json
+++ b/prothesis/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "prothesis",
+  "version": "5.17.31",
+  "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "prothesis"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prothesis",
+    "shortDescription": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
+    "longDescription": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use prothesis for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/syneidesis/.codex-plugin/plugin.json
+++ b/syneidesis/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "syneidesis",
+  "version": "2.21.43",
+  "description": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "syneidesis"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Syneidesis",
+    "shortDescription": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
+    "longDescription": "Surface potential gaps at decision points — /gap (συνείδησις: knowing-together)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use syneidesis for this task"
+    ],
+    "brandColor": "#2563EB"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Codex marketplace alongside the existing Claude marketplace
- point Codex marketplace entries directly at the existing plugin roots, matching the learning-opportunities layout
- add real .codex-plugin/plugin.json manifests next to each existing .claude-plugin manifest
- update README and README_ko so Codex installation follows the current learning-opportunities style: marketplace add first, no long skill-installer paste block

## Validation
- Tavily extract checked DrCatHicks/learning-opportunities README current installation shape
- git diff --check
- node validation confirmed all 13 Codex marketplace entries use direct paths and resolve to matching manifests
- node .claude/skills/verify/scripts/static-checks.js .