### PR TITLE
fix(goal-research): extend Tavily research timeout

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /dispatch. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/goal-research/SKILL.md
+++ b/epistemic-cooperative/skills/goal-research/SKILL.md
@@ -51,13 +51,23 @@ Report:
 - Residual uncertainty when sources contradict or coverage is incomplete
 ```
 
-Launch via `Bash(run_in_background: true, timeout: 600000)`:
+Launch via `Bash(run_in_background: true, timeout: 1000000)`:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" < /tmp/goal_research_${SUFFIX}.txt
+codex exec --skip-git-repo-check -m gpt-5.5 \
+  --config model_reasoning_effort="high" \
+  --config mcp_servers.tavily.tool_timeout_sec=900 \
+  < /tmp/goal_research_${SUFFIX}.txt
 ```
 
 Sandbox flag is omitted intentionally — Tavily verification requires network access, so the read-only sandbox used by `review-ensemble` does not apply here.
+
+The background Bash timeout controls the delegated Codex session envelope and
+must exceed the Tavily MCP per-call budget. The
+`mcp_servers.tavily.tool_timeout_sec=900` override controls the per-call MCP
+timeout for Tavily tools inside that delegated session, allowing long-form
+`tavily_research` calls to run for up to 15 minutes while still surfacing the
+raw timeout error if the call exceeds that limit.
 
 ## Phase 3: Collection
 
@@ -89,6 +99,6 @@ Acceptance criterion: a real Codex session was launched, its trace was returned 
 
 - Research question is embedded verbatim — no paraphrasing before passing to Codex.
 - Codex runs in background — main session is free until the completion notification arrives.
-- Failure modes (Codex missing, network failure, Tavily unavailable, timeout) are exposed as raw errors. The skill does not mask, retry, or fall back.
+- Failure modes (Codex missing, network failure, Tavily unavailable, delegated-session timeout, or Tavily MCP per-call timeout) are exposed as raw errors. The skill does not mask, retry, or fall back.
 - Always clean up the temp prompt file after reading the Codex output.
 - The skill is a delegation channel only — interpretation, follow-up questions, and downstream protocol routing belong to the main session after the trace returns.

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -222,6 +222,27 @@ describe('runtime contract view', () => {
 });
 
 // ============================================================
+// goal-research runtime contract
+// ============================================================
+
+describe('goal-research runtime contract', () => {
+  const REPO_ROOT = path.join(__dirname, '..');
+  const skillPath = path.join(REPO_ROOT, 'epistemic-cooperative', 'skills', 'goal-research', 'SKILL.md');
+
+  it('extends Tavily MCP tool-call timeout separately from the Codex session timeout', () => {
+    const skill = fs.readFileSync(skillPath, 'utf8');
+    const bashMs = Number(skill.match(/Bash\(run_in_background: true, timeout: (\d+)\)/)?.[1]);
+    const mcpSec = Number(skill.match(/--config mcp_servers\.tavily\.tool_timeout_sec=(\d+)/)?.[1]);
+    assert.ok(Number.isFinite(bashMs), 'Bash session timeout must be documented');
+    assert.ok(Number.isFinite(mcpSec), 'Tavily MCP per-call timeout must be configured');
+    assert.ok(bashMs > mcpSec * 1000, 'Bash envelope must exceed MCP per-call budget');
+    assert.equal(mcpSec, 900);
+    assert.match(skill, /per-call MCP\s+timeout/i);
+    assert.match(skill, /tavily_research/);
+  });
+});
+
+// ============================================================
 // artifact-self-containment detector liveness
 // ============================================================
 


### PR DESCRIPTION
## Summary
- pass `mcp_servers.tavily.tool_timeout_sec=900` into delegated Codex `/goal-research` runs
- document the distinction between the 600s Codex session envelope and the 900s Tavily MCP per-call timeout
- add a regression test for the goal-research timeout contract and bump `epistemic-cooperative` to 2.18.1

## Verification
- `node --test scripts/package.test.js`
- `node .claude/skills/verify/scripts/static-checks.js .`
- `node scripts/package.js --dry-run` via pre-commit runtime-contract hook
- Manual short-timeout probe: `codex exec ... --config mcp_servers.tavily.tool_timeout_sec=1 ...` produced `timed out awaiting tools/call after 1s` for `tavily_research`

Closes #414