### PR TITLE
feat(periagoge): add calibrative induction morphism

### DIFF
--- a/docs/analysis/periagoge-calibrative-induction-morphism.md
+++ b/docs/analysis/periagoge-calibrative-induction-morphism.md
@@ -44,7 +44,7 @@ materialized into lower-load labels, but the answer type is unchanged:
 | Use this | Confirm |
 | Broaden it | Widen |
 | Tighten it | Narrow |
-| Merge it with another concept | Fuse |
+| Fuse / Merge it | Fuse |
 | Change the axis | Reorient |
 | Drop this candidate | Dismiss |
 

--- a/docs/analysis/periagoge-calibrative-induction-morphism.md
+++ b/docs/analysis/periagoge-calibrative-induction-morphism.md
@@ -1,0 +1,53 @@
+# Periagoge Calibrative Induction Morphism
+
+Periagoge keeps its endpoint fixed:
+
+```
+AbstractionInProcess -> CrystallizedAbstraction
+```
+
+The morphism change is not a new protocol type. It is a lower-load path to the
+same endpoint: before asking the user to shape a candidate, the runtime should
+show how the observed instances calibrate the user's in-process concept.
+
+The current type frame is stable. `A` already carries an abstraction seed:
+instances, essence intuition, and optional label. The missing runtime surface is
+the calibration relation between the seed and the candidate:
+
+```
+A
+  -> detect instances, essence, locator
+  -> calibrate the in-process concept against the instance set
+  -> propose candidate plus grounding plus calibration map
+  -> triangulate with type-preserving user moves
+  -> CrystallizedAbstraction
+```
+
+Calibration has four user-facing fields:
+
+| Field | Function |
+|---|---|
+| Keeps | What the instance set repeatedly supports and should be preserved |
+| Sharpens | What must become clearer for the concept to be usable |
+| Prunes | What the instance set does not support or overextends |
+| Open | What remains unresolved without blocking crystallization |
+
+This keeps user correction substrate-mediated. AI does not override the user's
+concept from above; the instance set pressures the candidate, and AI surfaces
+that pressure in a compact map the user can recognize.
+
+The Phase 2 options remain the existing `UserMove` coproduct. They may be
+materialized into lower-load labels, but the answer type is unchanged:
+
+| Lower-load label | UserMove constructor |
+|---|---|
+| Use this | Confirm |
+| Broaden it | Widen |
+| Tighten it | Narrow |
+| Merge it with another concept | Fuse |
+| Change the axis | Reorient |
+| Drop this candidate | Dismiss |
+
+The soundness constraint is therefore: add `CalibrationMap` as an intermediate
+artifact, not as a new terminal resolution; keep `CrystallizedAbstraction` as the
+only convergence object; keep user crystallization constitutive.

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "0.1.30",
+  "version": "0.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+  "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "version": "0.1.30",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "version": "0.1.30",
+  "version": "0.2.0",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "version": "0.1.30",
-  "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+  "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
@@ -17,8 +17,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Periagoge",
-    "shortDescription": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-    "longDescription": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+    "shortDescription": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
+    "longDescription": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
     "developerName": "Jongwon Choi",
     "category": "Productivity",
     "capabilities": [

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -16,35 +16,42 @@ Crystallize in-process abstraction through AI-proposed candidate plus user diale
 ```
 ── FLOW ──
 Periagoge(A) → Detect(A) → in_process? →
-  true:  (Iᵢ, E, L?) → Propose(Iᵢ, E, ctx) → (P, G) →
-         Qs(P, G, progress) → Stop → V → integrate(V, candidate) → candidate' →
+  true:  (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K →
+         Propose(Iᵢ, E, K, ctx) → (P, G, K) →
+         Qs(P, G, K, progress) → Stop → V → integrate(V, candidate) → candidate' →
          loop until crystallized(A) ∨ user_esc ∨ attempts_exhausted
   false: deactivate
 
 ── MORPHISM ──
 A
   → detect(instances, essence, locator)   -- verify in-process abstraction exists
-  → propose(candidate, grounding)         -- AI generates candidate + personalized example
-  → triangulate(candidate, user_move)     -- user shapes via widen/narrow/fuse/reorient
+  → calibrate(user_concept, instances)    -- surface what instances preserve, sharpen, prune, and leave open
+  → propose(candidate, grounding, calibration)  -- AI generates candidate + personalized example + calibration map
+  → triangulate(candidate, user_move)     -- user shapes via type-preserving materialized moves
   → integrate(V, candidate)               -- update candidate per user response
   → crystallize(abstraction)              -- convergence when confirmed
   → CrystallizedAbstraction
 requires: in_process(A)                    -- runtime checkpoint (Phase 0)
 deficit:  AbstractionInProcess              -- activation precondition (Layer 1/2)
-preserves: instance_set(A)                  -- Iᵢ read-only; candidate mutates across loop
-invariant: Dialectical Triangulation over Unilateral Proposal
+preserves: instance_set(A)                  -- Iᵢ read-only; calibration and candidate mutate across loop
+invariant: Calibrative Induction over Unilateral Correction
 
 ── TYPES ──
-A              = AbstractionSeed (in-process state: instances + essence intuition + optional label)
+A              = AbstractionSeed (in-process state: instances + essence intuition + optional user concept label)
 Detect         = A → (Bool, (Iᵢ, E, L?) if true)
 Iᵢ             = Set(Instance)                             -- instance set observed; cardinality unconstrained (any N ≥ 1 qualifies when essence is sensed; richer sets provide stronger triangulation material)
 Instance       = { content: String, context: String }       -- concrete case observed
 E              = EssenceIntuition                           -- variation-stable core signal from conversation
-L              = Option(TentativeLabel)                     -- user-provided provisional name, if any
+L              = Option(TentativeLabel)                     -- user-provided provisional name or concept, if any
+K              = CalibrationMap { keeps, sharpens, prunes, open }
+                 keeps     = supported core to preserve
+                 sharpens  = under-specified decision-relevant structure
+                 prunes    = overextended or unsupported scope to release
+                 open      = residual uncertainty that does not block crystallization
 P              = CandidateAbstraction { name, structure, instance_map, provenance }
 G              = GroundingExample { scenario: String, domain: String, mapping: String }
                                                              -- personalized to user's own domain context
-Propose        = (Iᵢ, E, ctx) → (P, G)
+Propose        = (Iᵢ, E, K, ctx) → (P, G, K)
 V              = UserMove ∈ {Confirm, Widen(direction), Narrow(specializer), Fuse(adjacent), Reorient(axis), Dismiss}
                  direction    ∈ {upward, lateral}           -- Synagoge family; AI-proposed broadening (user Recognition mode)
                  specializer  = dimension to constrain      -- Diairesis family (user-directed specialization)
@@ -66,8 +73,8 @@ If no essence signal is detectable (neither user sensing language nor AI-inferra
 
 ── PHASE TRANSITIONS ──
 Phase 0: A → Detect(A) → in_process?                                       -- detection checkpoint (silent)
-Phase 1: (Iᵢ, E, L?) → Propose(Iᵢ, E, ctx) → (P, G)                        -- candidate + grounding construction [Tool]
-Phase 2: (P, G) → Qs(P, G, progress) → Stop → V                            -- triangulation Constitution interaction [Tool]
+Phase 1: (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K → Propose(Iᵢ, E, K, ctx) → (P, G, K)  -- calibration + candidate + grounding construction [Tool]
+Phase 2: (P, G, K) → Qs(P, G, K, progress) → Stop → V                      -- triangulation Constitution interaction [Tool]
 Phase 3: V → integrate(V, candidate) → candidate'                          -- candidate update (track)
 
 ── LOOP ──
@@ -80,7 +87,7 @@ If V = Reorient(axis): candidate' = orthogonal(axis) → return to Phase 1 (full
 If V = Dismiss: abandon candidate; if essence still sensed, return to Phase 1 with fresh candidate; else deactivate.
 Max 5 triangulation attempts per abstraction seed.
 Continue until: crystallized(A) ∨ user_esc ∨ attempts_exhausted.
-Convergence evidence: At crystallized(A), present transformation trace — for each step ∈ history, show (candidate → user_move → candidate'). Convergence is demonstrated, not asserted.
+Convergence evidence: At crystallized(A), present transformation trace — for each step ∈ history, show (calibration → candidate → user_move → candidate'). Convergence is demonstrated, not asserted.
 
 ── CONVERGENCE ──
 crystallized(A): see TYPES (V = Confirm in history)
@@ -90,15 +97,15 @@ early_exit = user_esc ∨ attempts_exhausted
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Phase 0 Detect     (sense)   → Internal analysis (no external tool)
-Phase 1 Propose    (observe) → Read, Grep (user's domain context for personalized grounding); WebSearch (conditional: cross-domain adjacent abstractions)
-Phase 2 Qs         (constitution)    → present (mandatory; Esc key → loop termination at LOOP level, not a UserMove)
+Phase 1 Calibrate+Propose (observe) → Read, Grep (user's domain context for personalized grounding); WebSearch (conditional: cross-domain adjacent abstractions)
+Phase 2 Qs         (constitution)    → present calibration map + candidate + grounding (mandatory; Esc key → loop termination at LOOP level, not a UserMove)
 Phase 3            (track)   → Internal state update
 converge           (extension)   → TextPresent+Proceed (convergence evidence trace; proceed with crystallized abstraction)
 
 ── MODE STATE ──
 Λ = { phase: Phase, A: AbstractionSeed, Iᵢ: Set(Instance), E: EssenceIntuition,
-      candidate: Option(P), grounding: Option(G),
-      history: List<(P, G, V)>, attempts: Nat, crystallized: Option(P),
+      calibration: Option(K), candidate: Option(P), grounding: Option(G),
+      history: List<(P, G, K, V)>, attempts: Nat, crystallized: Option(P),
       active: Bool, cause_tag: String }
 
 ── COMPOSITION ──
@@ -107,7 +114,7 @@ converge           (extension)   → TextPresent+Proceed (convergence evidence t
 
 ## Core Principle
 
-**Dialectical Triangulation over Unilateral Proposal**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI proposes a candidate paired with a personalized grounding example drawn from the user's own domain; the user shapes through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI assertion.
+**Calibrative Induction through Dialectical Triangulation**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI first shows how the instance set calibrates the user's in-process concept — what it preserves, sharpens, prunes, and leaves open — then proposes a candidate paired with a personalized grounding example drawn from the user's own domain. The user shapes the candidate through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI assertion.
 
 ## Mode Activation
 
@@ -138,7 +145,7 @@ When Periagoge is active:
 
 **Retained**: Safety boundaries, tool restrictions, user explicit instructions
 
-**Action**: At Phase 2, present candidate abstraction plus personalized grounding example via Cognitive Partnership Move (Constitution).
+**Action**: At Phase 2, present calibration map plus candidate abstraction and personalized grounding example via Cognitive Partnership Move (Constitution).
 </system-reminder>
 
 - Periagoge completes before output dependent on the crystallized abstraction proceeds
@@ -207,25 +214,30 @@ Analyze conversation state for in-process abstraction. This phase is **silent** 
 
 **Scope restriction**: Detection is silent. Does NOT modify files or call external services.
 
-### Phase 1: Candidate Proposal + Grounding Construction
+### Phase 1: Calibration + Candidate Proposal + Grounding Construction
 
-Generate candidate abstraction with a personalized grounding example.
+Generate a calibration map, candidate abstraction, and personalized grounding example.
 
-1. **Synthesize candidate** `P`: from `(Iᵢ, E)`, construct a named abstraction with structure and instance-to-abstraction mapping. The candidate is a working hypothesis, not a claim.
-2. **Construct personalized grounding** `G`: call Read/Grep to collect evidence about the user's own domain context (codebase, configs, session history). The grounding example must be drawn from the user's domain — a scenario they recognize as theirs — not a generic textbook case.
+1. **Calibrate the seed** `K`: compare `(Iᵢ, E, L?)` against the user's context and sort the concept pressure into four fields: `keeps` (supported core to preserve), `sharpens` (decision-relevant structure needing clarity), `prunes` (unsupported overextension to release), and `open` (residual uncertainty that does not block crystallization).
+2. **Synthesize candidate** `P`: from `(Iᵢ, E, K)`, construct a named abstraction with structure and instance-to-abstraction mapping. The candidate is a working hypothesis, not a claim.
+3. **Construct personalized grounding** `G`: call Read/Grep to collect evidence about the user's own domain context (codebase, configs, session history). The grounding example must be drawn from the user's domain — a scenario they recognize as theirs — not a generic textbook case.
    - When the user's domain is outside the current codebase (external API, academic field, professional practice), extend context collection to web search (WebSearch). Tag web evidence with `source: "web:{url}"` for traceability.
-3. **Check adjacent abstractions**: if recall (Anamnesis hypomnesis store or in-session history) surfaces neighboring abstractions, note them as Fuse candidates for Phase 2.
-4. Package `(P, G)` with Fuse candidates and proceed to Phase 2.
+4. **Check adjacent abstractions**: if recall (Anamnesis hypomnesis store or in-session history) surfaces neighboring abstractions, note them as Fuse candidates for Phase 2.
+5. Package `(P, G, K)` with Fuse candidates and proceed to Phase 2.
 
 **Scope restriction**: Read-only investigation (Read, Grep, WebSearch). No test execution or file modifications.
 
 ### Phase 2: Dialectical Triangulation (Constitution)
 
-**Present** the candidate and grounding example via Cognitive Partnership Move (Constitution).
+**Present** the calibration map, candidate, and grounding example via Cognitive Partnership Move (Constitution).
 
 **Surfacing format**:
 
-Present the candidate as text output:
+Present the calibration map and candidate as text output:
+- **Keeps**: [what the instance set repeatedly supports and the candidate preserves]
+- **Sharpens**: [what must become clearer for the abstraction to be usable]
+- **Prunes**: [what the instance set does not support or overextends]
+- **Open**: [what remains unresolved without blocking crystallization]
 - **Candidate**: [name] — [structural description]
 - **Instance map**: [how Iᵢ maps to the candidate's structure]
 - **Grounding example**: [scenario drawn from user's domain, with mapping to the candidate]
@@ -235,21 +247,22 @@ Present the candidate as text output:
 Then **present**:
 
 ```
-Does this candidate crystallize the abstraction you were forming?
+Does this make the concept usable?
 
 Options:
-1. **Confirm** — [what the crystallized abstraction enables downstream]
-2. **Widen** — AI-proposed broadening (Recognition mode) — [how upward or lateral scope expansion from AI's domain knowledge reshapes the candidate]
-3. **Narrow** — [what dimension specializes or what to exclude]
-4. **Fuse** — user-named adjacent reference (Production mode) — [which adjacent abstraction to explicitly pull in for merge] *(presented only when Phase 1 surfaces adjacent candidates; otherwise omitted)*
-5. **Reorient** — [what orthogonal axis to pursue instead]
-6. **Dismiss** — [what assumption about this essence is released]
+1. **Confirm / Use this** — [what the crystallized abstraction enables downstream]
+2. **Widen / Broaden it** — [how upward or lateral scope expansion reshapes the candidate]
+3. **Narrow / Tighten it** — [what dimension specializes or what to exclude]
+4. **Fuse / Merge it** — [which adjacent abstraction to explicitly pull in for merge] *(presented only when Phase 1 surfaces adjacent candidates; otherwise omitted)*
+5. **Reorient / Change the axis** — [what orthogonal axis to pursue instead]
+6. **Dismiss / Drop this candidate** — [what assumption about this essence is released]
 ```
 
 When Phase 1 surfaces no adjacent candidates, omit the Fuse option — dead signal suppression. Free response is always available — the user may name an adjacent abstraction for fusion, propose an alternative abstraction, specify a dimension not captured by the presented moves, or describe a shape the options do not cover.
 
 **Design principles**:
 - **Personalized grounding**: Never use a generic example. The grounding must be drawn from the user's domain context so they can recognize it as theirs.
+- **Calibration before choice**: Show the preservation/sharpening/pruning/open map before the gate so the user evaluates the concept pressure, not just an AI label.
 - **Socratic shaping**: Each move (widen/narrow/fuse/reorient) is a recognized dialectical turn, not a free-form revision request.
 - **Progress visible**: Display attempt counter; attempt cap bounds generative refinement.
 - **Free response honored**: When the presented moves do not capture the user's shape, parse free response as candidate redirection.
@@ -266,7 +279,7 @@ After user response:
 6. **Dismiss**: Release the candidate. If essence is still sensed, return to Phase 1 with fresh candidate proposal; else deactivate.
 
 After integration:
-- Log `(P, G, V)` to history
+- Log `(P, G, K, V)` to history
 - Increment attempts counter
 - Check attempt cap (max 5) — if exceeded, surface unresolved candidate with explicit status and deactivate
 
@@ -283,6 +296,7 @@ After integration:
 | Rule | Structure | Effect |
 |------|-----------|--------|
 | Gate specificity | `activate(Periagoge) only if essence_sensed ∧ ¬located` | Prevents false activation on settled abstractions or essence-less inputs; instance count is evidence-for-essence, not a gate |
+| Calibration map | Phase 1 sorts concept pressure into Keeps / Sharpens / Prunes / Open | Lets instances correct the concept without AI overriding the user |
 | Personalized grounding | Phase 1 requires grounding drawn from user's own domain context | Prevents generic textbook examples that fail to trigger recognition |
 | Socratic moves preserved | Phase 2 options map to dialectical families (Synagoge/Diairesis/Fuse/Reorient) | Each move has a recognized shape, not open-ended revision |
 | Session immunity | Crystallized or dismissed (Iᵢ, E) pair → skip for session | Respects user's crystallization or release |
@@ -295,8 +309,8 @@ After integration:
 
 1. **AI-guided, user-triangulated**: AI detects in-process abstraction and proposes candidates; crystallization requires user move via Cognitive Partnership Move (Constitution) (Phase 2).
 2. **Recognition over Recall**: Present structured options via Cognitive Partnership Move (Constitution) — structured content reaches the user with response opportunity; Constitution interaction requires turn yield before proceeding.
-3. **Candidate plus grounding required**: Every Phase 2 surfacing pairs a candidate abstraction with a personalized grounding example drawn from the user's own domain context.
-4. **Dialectical Triangulation over Unilateral Proposal**: AI candidate is a working hypothesis, not a claim. Crystallization belongs to the user's move.
+3. **Calibration plus candidate plus grounding required**: Every Phase 2 surfacing pairs a calibration map, candidate abstraction, and personalized grounding example drawn from the user's own domain context.
+4. **Calibrative Induction over Unilateral Correction**: AI candidate is a working hypothesis, not a claim. Concept correction is mediated by the instance set surfaced through `K`; crystallization belongs to the user's move.
 5. **Personalized grounding**: The grounding example must be recognizable to the user as theirs — drawn from their codebase, configs, session history, or stated domain. Generic textbook examples fail the personalization requirement.
 6. **Socratic move preservation**: Phase 2 options map to recognized dialectical families. Widen = Synagoge (upward or lateral). Narrow = Diairesis. Fuse = lateral Synagoge with adjacent abstraction. Reorient = orthogonal redirection. The vocabulary is operational, not ornamental.
 7. **Free response honored**: When presented moves do not capture the user's shape, free response routes the candidate to reorient or fresh proposal. The user may also name an adjacent abstraction via free response when Fuse is not presented (because Phase 1 surfaced no candidates) and they hold one in mind.
@@ -307,9 +321,9 @@ After integration:
 11. **Progress visibility**: Every Phase 2 surfacing includes attempt counter.
 12. **Cross-protocol awareness**: Defer to Analogia when a pre-existing abstract structure needs validation against a target.
 13. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via Cognitive Partnership Move (Constitution). The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields violates this separation.
-14. **Convergence evidence**: At crystallization, present transformation trace — for each step in history, show (candidate → user_move → candidate'). Per-step evidence is required.
+14. **Convergence evidence**: At crystallization, present transformation trace — for each step in history, show (calibration → candidate → user_move → candidate'). Per-step evidence is required.
 15. **Absorb Analogia misfit**: When `/ground` Phase 0 detects colimit-shaped input (`essence_sensed` + `locator_absent(A)`) and nudges here, absorb the misfit as valid Periagoge trigger. Before Phase 1, surface the routing rationale with the cited `/ground` detection basis ("colimit-shaped input detected: essence_sensed(A), locator_absent(A), [N supporting instances] — redirecting to abstraction crystallization") so the user can recognize the evidence that justified the redirect; the concrete instance count makes the routing rationale verifiable rather than vague.
 16. **Option-set relay test (Extension classification)**: If AI analysis converges to a single dominant move (option-level entropy → 0 — Extension mode of the Cognitive Partnership Move), present the finding directly. Each Constitution option must be genuinely viable under different user value weightings. Options sharing a downstream trajectory collapse to one; options lacking an on-axis trajectory surface as free-response pathways rather than peer options. **Exception**: The Confirm/Dismiss pair is excluded from the entire preceding test (Extension resolution, cost-symmetric collapse, and off-axis pathway demotion) — user crystallization judgment is constitutive regardless of AI analysis entropy. Phase 2 remains Constitution even when only one shaping move appears analytically viable.
-17. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option like "Widen" into a concrete direction while preserving the UserMove coproduct) is distinct from mutation.
+17. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option like "Widen" into a concrete direction or pairing "Confirm" with "Use this" while preserving the UserMove coproduct) is distinct from mutation.
 18. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 19. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: induce
-description: "Crystallize in-process abstraction through dialectical triangulation. Proposes candidate abstractions with personalized grounding examples and shapes them via user widen/narrow/fuse/reorient moves when an instance set has converged toward an unnamed essence, producing crystallized abstraction. Type: (AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction. Alias: Periagoge(περιαγωγή)."
+description: "Calibrate and crystallize in-process abstraction through dialectical triangulation. Proposes calibrated candidate abstractions with personalized grounding examples and shapes them via user widen/narrow/fuse/reorient moves when an instance set has converged toward an unnamed essence, producing crystallized abstraction. Type: (AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction. Alias: Periagoge(περιαγωγή)."
 ---
 
 # Periagoge Protocol
 
-Crystallize in-process abstraction through AI-proposed candidate plus user dialectical triangulation. Type: `(AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction`.
+Calibrate and crystallize in-process abstraction through AI-proposed candidate plus user dialectical triangulation. Type: `(AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction`.
 
 ## Definition
 
-**Periagoge** (περιαγωγή): A dialogical act of turning an in-process abstraction toward its crystallized form, where AI detects when an instance set has converged toward an unnamed essence, proposes a candidate abstraction paired with a personalized grounding example drawn from the user's own domain, and shapes the candidate through the user's response — accept the candidate, broaden its scope, narrow it along a specific dimension, fuse it with an adjacent abstraction, or redirect onto an orthogonal axis — until the abstraction locates itself (the Greek dialectical vocabulary supplies the source terms, attributed in the footnote).[^1]
+**Periagoge** (περιαγωγή): A dialogical act of turning an in-process abstraction toward its crystallized form, where AI detects when an instance set has converged toward an unnamed essence, calibrates the user's in-process concept against that instance set, proposes a calibrated candidate abstraction paired with a personalized grounding example drawn from the user's own domain, and shapes the candidate through the user's response — accept the candidate, broaden its scope, narrow it along a specific dimension, fuse it with an adjacent abstraction, or redirect onto an orthogonal axis — until the abstraction locates itself (the Greek dialectical vocabulary supplies the source terms, attributed in the footnote).[^1]
 
 [^1]: The name draws a structural analogy from Plato *Republic* VII.518d, where περιαγωγή names the soul's turning-around toward the intelligible. The protocol borrows the turning-toward structure; it does not claim Platonic paideia. Synagoge (συναγωγή, collection) and Diairesis (διαίρεσις, division) are the twin dialectical moves described in *Phaedrus* 265d–266a; here they name user response families, not a claim to Platonic method.
 
@@ -17,7 +17,7 @@ Crystallize in-process abstraction through AI-proposed candidate plus user diale
 ── FLOW ──
 Periagoge(A) → Detect(A) → in_process? →
   true:  (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K →
-         Propose(Iᵢ, E, K, ctx) → (P, G, K) →
+         Propose(Iᵢ, E, K, ctx) → (P, G) →
          Qs(P, G, K, progress) → Stop → V → integrate(V, candidate) → candidate' →
          loop until crystallized(A) ∨ user_esc ∨ attempts_exhausted
   false: deactivate
@@ -25,7 +25,7 @@ Periagoge(A) → Detect(A) → in_process? →
 ── MORPHISM ──
 A
   → detect(instances, essence, locator)   -- verify in-process abstraction exists
-  → calibrate(user_concept, instances)    -- surface what instances preserve, sharpen, prune, and leave open
+  → calibrate(E, L?, Iᵢ, ctx)             -- surface what instances preserve, sharpen, prune, and leave open
   → propose(candidate, grounding, calibration)  -- AI generates candidate + personalized example + calibration map
   → triangulate(candidate, user_move)     -- user shapes via type-preserving materialized moves
   → integrate(V, candidate)               -- update candidate per user response
@@ -33,8 +33,8 @@ A
   → CrystallizedAbstraction
 requires: in_process(A)                    -- runtime checkpoint (Phase 0)
 deficit:  AbstractionInProcess              -- activation precondition (Layer 1/2)
-preserves: instance_set(A)                  -- Iᵢ read-only; calibration and candidate mutate across loop
-invariant: Calibrative Induction over Unilateral Correction
+preserves: instance_set(A)                  -- Iᵢ read-only; K computed per Phase 1 entry and recomputed on Phase 1 re-entry; candidate mutates per user move
+invariant: Calibrative Induction through Dialectical Triangulation over Unilateral Correction
 
 ── TYPES ──
 A              = AbstractionSeed (in-process state: instances + essence intuition + optional user concept label)
@@ -43,6 +43,8 @@ Iᵢ             = Set(Instance)                             -- instance set obs
 Instance       = { content: String, context: String }       -- concrete case observed
 E              = EssenceIntuition                           -- variation-stable core signal from conversation
 L              = Option(TentativeLabel)                     -- user-provided provisional name or concept, if any
+ctx            = DomainContext                              -- user's domain context gathered via Read, Grep, and conditional WebSearch in Phase 1
+Calibrate      = (Iᵢ, E, L?, ctx) → K
 K              = CalibrationMap { keeps, sharpens, prunes, open }
                  keeps     = supported core to preserve
                  sharpens  = under-specified decision-relevant structure
@@ -51,7 +53,7 @@ K              = CalibrationMap { keeps, sharpens, prunes, open }
 P              = CandidateAbstraction { name, structure, instance_map, provenance }
 G              = GroundingExample { scenario: String, domain: String, mapping: String }
                                                              -- personalized to user's own domain context
-Propose        = (Iᵢ, E, K, ctx) → (P, G, K)
+Propose        = (Iᵢ, E, K, ctx) → (P, G)
 V              = UserMove ∈ {Confirm, Widen(direction), Narrow(specializer), Fuse(adjacent), Reorient(axis), Dismiss}
                  direction    ∈ {upward, lateral}           -- Synagoge family; AI-proposed broadening (user Recognition mode)
                  specializer  = dimension to constrain      -- Diairesis family (user-directed specialization)
@@ -73,7 +75,7 @@ If no essence signal is detectable (neither user sensing language nor AI-inferra
 
 ── PHASE TRANSITIONS ──
 Phase 0: A → Detect(A) → in_process?                                       -- detection checkpoint (silent)
-Phase 1: (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K → Propose(Iᵢ, E, K, ctx) → (P, G, K)  -- calibration + candidate + grounding construction [Tool]
+Phase 1: (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K → Propose(Iᵢ, E, K, ctx) → (P, G); carry (P, G, K)  -- calibration + candidate + grounding construction [Tool]
 Phase 2: (P, G, K) → Qs(P, G, K, progress) → Stop → V                      -- triangulation Constitution interaction [Tool]
 Phase 3: V → integrate(V, candidate) → candidate'                          -- candidate update (track)
 
@@ -114,7 +116,7 @@ converge           (extension)   → TextPresent+Proceed (convergence evidence t
 
 ## Core Principle
 
-**Calibrative Induction through Dialectical Triangulation**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI first shows how the instance set calibrates the user's in-process concept — what it preserves, sharpens, prunes, and leaves open — then proposes a candidate paired with a personalized grounding example drawn from the user's own domain. The user shapes the candidate through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI assertion.
+**Calibrative Induction through Dialectical Triangulation over Unilateral Correction**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI first shows how the instance set calibrates the user's in-process concept — what it preserves, sharpens, prunes, and leaves open — then proposes a candidate paired with a personalized grounding example drawn from the user's own domain. The user shapes the candidate through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI correction.
 
 ## Mode Activation
 
@@ -218,7 +220,7 @@ Analyze conversation state for in-process abstraction. This phase is **silent** 
 
 Generate a calibration map, candidate abstraction, and personalized grounding example.
 
-1. **Calibrate the seed** `K`: compare `(Iᵢ, E, L?)` against the user's context and sort the concept pressure into four fields: `keeps` (supported core to preserve), `sharpens` (decision-relevant structure needing clarity), `prunes` (unsupported overextension to release), and `open` (residual uncertainty that does not block crystallization).
+1. **Calibrate the seed** `K`: compare `(Iᵢ, E, L?)` against the user's context and sort the concept pressure into four fields: `keeps` (supported core to preserve), `sharpens` (decision-relevant structure needing clarity), `prunes` (unsupported overextension to release), and `open` (residual uncertainty that does not block crystallization). When `L?` is absent, calibrate on `E` alone: `sharpens` and `prunes` are relative to the inferred essence rather than to a user-named concept.
 2. **Synthesize candidate** `P`: from `(Iᵢ, E, K)`, construct a named abstraction with structure and instance-to-abstraction mapping. The candidate is a working hypothesis, not a claim.
 3. **Construct personalized grounding** `G`: call Read/Grep to collect evidence about the user's own domain context (codebase, configs, session history). The grounding example must be drawn from the user's domain — a scenario they recognize as theirs — not a generic textbook case.
    - When the user's domain is outside the current codebase (external API, academic field, professional practice), extend context collection to web search (WebSearch). Tag web evidence with `source: "web:{url}"` for traceability.
@@ -247,7 +249,7 @@ Present the calibration map and candidate as text output:
 Then **present**:
 
 ```
-Does this make the concept usable?
+Does this crystallize the concept enough to use?
 
 Options:
 1. **Confirm / Use this** — [what the crystallized abstraction enables downstream]
@@ -265,7 +267,7 @@ When Phase 1 surfaces no adjacent candidates, omit the Fuse option — dead sign
 - **Calibration before choice**: Show the preservation/sharpening/pruning/open map before the gate so the user evaluates the concept pressure, not just an AI label.
 - **Socratic shaping**: Each move (widen/narrow/fuse/reorient) is a recognized dialectical turn, not a free-form revision request.
 - **Progress visible**: Display attempt counter; attempt cap bounds generative refinement.
-- **Free response honored**: When the presented moves do not capture the user's shape, parse free response as candidate redirection.
+- **Free response honored**: When the presented moves do not capture the user's shape, parse free response as candidate redirection. If the user disputes `K` itself, absorb the correction through the existing UserMove/free-response path rather than adding a separate calibration-review constructor.
 
 ### Phase 3: Integration
 
@@ -310,7 +312,7 @@ After integration:
 1. **AI-guided, user-triangulated**: AI detects in-process abstraction and proposes candidates; crystallization requires user move via Cognitive Partnership Move (Constitution) (Phase 2).
 2. **Recognition over Recall**: Present structured options via Cognitive Partnership Move (Constitution) — structured content reaches the user with response opportunity; Constitution interaction requires turn yield before proceeding.
 3. **Calibration plus candidate plus grounding required**: Every Phase 2 surfacing pairs a calibration map, candidate abstraction, and personalized grounding example drawn from the user's own domain context.
-4. **Calibrative Induction over Unilateral Correction**: AI candidate is a working hypothesis, not a claim. Concept correction is mediated by the instance set surfaced through `K`; crystallization belongs to the user's move.
+4. **Calibrative Induction through Dialectical Triangulation over Unilateral Correction**: AI candidate is a working hypothesis, not a claim. Concept correction is mediated by the instance set surfaced through `K`; crystallization belongs to the user's move.
 5. **Personalized grounding**: The grounding example must be recognizable to the user as theirs — drawn from their codebase, configs, session history, or stated domain. Generic textbook examples fail the personalization requirement.
 6. **Socratic move preservation**: Phase 2 options map to recognized dialectical families. Widen = Synagoge (upward or lateral). Narrow = Diairesis. Fuse = lateral Synagoge with adjacent abstraction. Reorient = orthogonal redirection. The vocabulary is operational, not ornamental.
 7. **Free response honored**: When presented moves do not capture the user's shape, free response routes the candidate to reorient or fresh proposal. The user may also name an adjacent abstraction via free response when Fuse is not presented (because Phase 1 surfaced no candidates) and they hold one in mind.

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -37,7 +37,7 @@ const DESCRIPTION_OVERRIDES = {
   inquire: 'Infer context insufficiency before execution — (ContextInsufficient, AI, INQUIRE, Prospect) → InformedExecution',
   attend: 'Evaluate execution-time risks — (ExecutionBlind, User, EVALUATE, ExecutionContext) → SituatedExecution',
   ground: 'Validate structural mapping between domains — (MappingUncertain, AI, GROUND, Text) → ValidatedMapping',
-  induce: 'Crystallize in-process abstraction via dialectical triangulation — (AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction',
+  induce: 'Calibrate and crystallize abstraction — (AbstractionInProcess, AI, INDUCE, A) → CrystallizedAbstraction',
   elicit: 'Resolve via Extended-Mind reverse induction — (AbstractAporia, Hybrid, REVERSE-INDUCE-CYCLE, IntentSeed × Substrate) → ResolvedEndpoint',
   bound: 'Epistemic boundary definition — (BoundaryUndefined, AI, DEFINE, TaskScope) → DefinedBoundary',
   contextualize: 'Detect application-context mismatch — (ApplicationDecontextualized, AI, CONTEXTUALIZE, Result) → ContextualizedExecution',


### PR DESCRIPTION
## Summary
- keep Periagoge endpoint fixed as `AbstractionInProcess -> CrystallizedAbstraction`
- add `CalibrationMap` as an intermediate artifact: Keeps / Sharpens / Prunes / Open
- update Phase 1/2 surfacing so user concept correction is instance-mediated before the existing UserMove gate
- bump Periagoge plugin metadata to 0.1.30

## Verification
- `node .claude/skills/verify/scripts/static-checks.js .`
- `node scripts/package.js --dry-run`
- `git diff --check`

Note: existing unstaged `.gitignore` change was left out of this PR.
