### PR TITLE
Add Katalepsis loop continuation closure

### DIFF
--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/.codex-plugin/plugin.json
+++ b/katalepsis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "katalepsis",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
   "author": {
     "name": "Jongwon Choi",

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -48,14 +48,17 @@ P' = Updated phantasia (refined understanding)
 J_cov = CoverageRouting ∈ {sufficient, aspect(GapType), proposal}
 GT = Relevant gap types per entry point ⊆ {Expectation, Causality, Scope, Sequence} ∪ Emergent(E, B)
 Cursor = ContinuationCursor { task: TaskId, entry_point: EntryPoint, aspect: Optional(GapType), resume_target: String }
-BranchArtifact = { kind: String, reference: String, return_pointer: Cursor }
+       -- resume_target is a short user-facing phase label, not a serialized cursor; structural position is task × entry_point × aspect
+BranchKind = {Proposal} ∪ Emergent(BranchKind)
+BranchArtifact = { kind: BranchKind, reference: TaskId, return_pointer: Cursor }
 ContinuationClosure = { verified: String, status: String, branch: Optional(BranchArtifact), return_pointer: Cursor, next_moves: List<String> }
                      -- relay metadata after evaluated answers or side-branch ejection; not a new gate
+C(·) = emit ContinuationClosure (relay; → TextPresent+Proceed)
 
 ── PHASE TRANSITIONS ──
 Phase 0: (R, U) → Orient(R, U) → I → DeriveEntries(I, R) → E  -- intent orientation (silent)
 Phase 1: E → Qc(intent entry points) → Stop → Sₑ       -- entry point selection; default single, ordered multi when user names 2+ concerns [Tool]
-Phase 2: Sₑ → Materialize(Sₑ, R) → B → TaskCreate[selected] → Tᵣ  -- task registration [Tool]
+Phase 2: Sₑ → Materialize(Sₑ, R) → B → TaskCreate[selected] → Tᵣ  -- task registration; initialize Λ.cursor from first current task, entry point, and active aspect before Phase 3 [Tool]
 Phase 3: Tᵣ → TaskUpdate(current) → detect(E, B) → GT → P → Δ  -- comprehension check [Tool]
        → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Emergent [Tool]
        → TaskCreate[Proposal] if proposal(A)             -- proposal ejection (detected from Other) [Tool]
@@ -73,6 +76,7 @@ If correct: emit continuation closure, then Aspect summary — show probed vs un
   User selects "sufficient" → TaskUpdate completed, next pending task.
   User selects additional aspect → Resume with selected gap type.
   User provides proposal via Other → detected by Step 3b, ejected via TaskCreate, emit side-branch continuation closure, resume current loop position.
+Cursor lifecycle: Initialize `Λ.cursor` after Phase 2 task registration. Update it whenever the current task changes, the entry point changes, the active aspect changes, or the user-facing resume label changes. On proposal ejection, snapshot the pre-ejection cursor into the branch artifact; when a branch is present in the emitted closure, closure-level `return_pointer` equals `branch.return_pointer`.
 Continue until: all selected tasks completed OR user ESC.
 Convergence evidence: At all-tasks-completed, present transformation trace — for each t ∈ Λ.tasks, show (ResultUngrasped(t) → verified(t) with comprehension evidence). Convergence is demonstrated, not asserted.
 
@@ -111,7 +115,6 @@ converge    (extension)  → TextPresent+Proceed (convergence evidence trace; pr
   current: TaskId,
   cursor: ContinuationCursor,
   branchArtifacts: List<BranchArtifact>,
-  closure: Option(ContinuationClosure),
   phantasia: Understanding,
   detected: Map<TaskId, Set<GapType>>,
   probed: Map<TaskId, Set<GapType>>,
@@ -343,7 +346,7 @@ For each task (entry point):
        activeForm: "Archiving user proposal"
      })
      ```
-   - Append the created proposal to `Λ.branchArtifacts` with `return_pointer = Λ.cursor`.
+   - Append the created proposal to `Λ.branchArtifacts` with `kind = Proposal`, `reference = TaskId` returned by `TaskCreate[Proposal]`, and `return_pointer = Λ.cursor`.
    - Emit a continuation closure before resuming: side branch recorded, Katalepsis remains active, return pointer = current entry point/aspect, next move = resume the current comprehension check.
    - Return to comprehension loop immediately.
 
@@ -435,10 +438,10 @@ For each task (entry point):
 5. **Code grounding**: Reference specific code locations
 6. **User authority**: User's "I understand" is final
 7. **Proposal ejection**: When user answer `A` drifts from comprehension toward knowledge capture (suggesting changes/improvements to the system), acknowledge briefly, call TaskCreate to externalize the proposal, record only a branch reference for continuation, and return to verification. This preserves user-generated insights without converting the proposal into a comprehension task.
-7a. **Continuation cursor after side branches**: Proposal ejection and follow-up task creation do not close Katalepsis. After any side branch, emit a compact continuation closure: what was recorded, parent entry point/aspect, return pointer, and next comprehension move. Store the branch artifact outside the comprehension task set, but keep `Λ.cursor` visible enough for the user to recognize where verification resumes.
+7a. **Continuation cursor after side branches**: Proposal ejection and follow-up task creation do not close Katalepsis. After any side branch, emit a compact continuation closure: what was recorded, parent entry point/aspect, return pointer, and next comprehension move. Store the branch artifact outside the comprehension task set, but keep `Λ.cursor` visible enough for the user to recognize where verification resumes. Update `Λ.cursor` before every closure emission so the return pointer reflects the live resumption point.
 8. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via Cognitive Partnership Move (Constitution). The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 9. **Convergence evidence**: Present transformation trace before declaring all tasks completed; per-task evidence is required
-9a. **Post-answer closure**: After a correct answer or sufficient understanding signal, do not stop at bare acknowledgment. Emit verified aspect, current task status, and next available moves before coverage routing or task completion. This is relay metadata: it keeps the active loop legible without adding a new user gate.
+9a. **Post-answer closure**: Always emit verified aspect, current task status, and next available moves after a correct answer or sufficient understanding signal, before coverage routing or task completion. This is relay metadata: it keeps the active loop legible without adding a new user gate.
 10. **Zero-gap surfacing**: If Phase 3 analysis finds no comprehension gaps for an entry point, present this finding with reasoning for user confirmation before marking as self-evident
 11. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option while preserving the TYPES coproduct) is distinct from mutation
 12. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -47,6 +47,10 @@ Tᵤ = Task update (progress tracking)
 P' = Updated phantasia (refined understanding)
 J_cov = CoverageRouting ∈ {sufficient, aspect(GapType), proposal}
 GT = Relevant gap types per entry point ⊆ {Expectation, Causality, Scope, Sequence} ∪ Emergent(E, B)
+Cursor = ContinuationCursor { task: TaskId, entry_point: EntryPoint, aspect: Optional(GapType), resume_target: String }
+BranchArtifact = { kind: String, reference: String, return_pointer: Cursor }
+ContinuationClosure = { verified: String, status: String, branch: Optional(BranchArtifact), return_pointer: Cursor, next_moves: List<String> }
+                     -- relay metadata after evaluated answers or side-branch ejection; not a new gate
 
 ── PHASE TRANSITIONS ──
 Phase 0: (R, U) → Orient(R, U) → I → DeriveEntries(I, R) → E  -- intent orientation (silent)
@@ -55,18 +59,20 @@ Phase 2: Sₑ → Materialize(Sₑ, R) → B → TaskCreate[selected] → Tᵣ  
 Phase 3: Tᵣ → TaskUpdate(current) → detect(E, B) → GT → P → Δ  -- comprehension check [Tool]
        → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Emergent [Tool]
        → TaskCreate[Proposal] if proposal(A)             -- proposal ejection (detected from Other) [Tool]
+       → C(branch) if proposal(A)                         -- side-branch continuation closure [Tool]
        → Qᵣs(Aᵣ) → Stop if misconception(A)             -- reasoning inquiry [Tool]
        → Read(source) if eval(A, Aᵣ) requires           -- AI-determined reference [Tool]
+       → C(correct) if correct(A)                         -- verified-aspect continuation closure [Tool]
        → Qc(coverage) → Stop if correct(A)               -- aspect summary [Tool]
 
 ── LOOP ──
 After Phase 3 verification: Evaluate comprehension per gap type.
 If |GT| = 0 for current entry point: present self-evident finding with reasoning per Rule 10, mark task completed upon confirmation, proceed to next task.
 If gap detected: Continue questioning within current entry point.
-If correct: Aspect summary — show probed vs unprobed gap types.
+If correct: emit continuation closure, then Aspect summary — show probed vs unprobed gap types.
   User selects "sufficient" → TaskUpdate completed, next pending task.
   User selects additional aspect → Resume with selected gap type.
-  User provides proposal via Other → detected by Step 3b, ejected via TaskCreate, resume current loop position.
+  User provides proposal via Other → detected by Step 3b, ejected via TaskCreate, emit side-branch continuation closure, resume current loop position.
 Continue until: all selected tasks completed OR user ESC.
 Convergence evidence: At all-tasks-completed, present transformation trace — for each t ∈ Λ.tasks, show (ResultUngrasped(t) → verified(t) with comprehension evidence). Convergence is demonstrated, not asserted.
 
@@ -88,6 +94,7 @@ Phase 3 Qc  (constitution)   → present (aspect coverage: sufficient/aspect)
 Phase 3 Ref (observe) → Read (source artifact, AI-determined)
 Phase 3 Tᵤ  (track)  → TaskUpdate (progress tracking)
 Phase 3 Prop (track)  → TaskCreate (proposal ejection)
+Phase 3 C    (extension)  → TextPresent+Proceed (continuation closure: verified status + side branch if any + return pointer + next moves)
 converge    (extension)  → TextPresent+Proceed (convergence evidence trace; proceed with verified understanding)
 -- Interpretive transparency (Basis:) intentionally absent: Socratic verification requires AI judgment opacity — surfacing reasoning would compromise probe authenticity
 
@@ -102,6 +109,9 @@ converge    (extension)  → TextPresent+Proceed (convergence evidence trace; pr
   artifactBasis: Map<EntryPoint, ArtifactBasis>,
   tasks: Map<TaskId, Task>,
   current: TaskId,
+  cursor: ContinuationCursor,
+  branchArtifacts: List<BranchArtifact>,
+  closure: Option(ContinuationClosure),
   phantasia: Understanding,
   detected: Map<TaskId, Set<GapType>>,
   probed: Map<TaskId, Set<GapType>>,
@@ -333,7 +343,9 @@ For each task (entry point):
        activeForm: "Archiving user proposal"
      })
      ```
-   - Return to comprehension loop immediately
+   - Append the created proposal to `Λ.branchArtifacts` with `return_pointer = Λ.cursor`.
+   - Emit a continuation closure before resuming: side branch recorded, Katalepsis remains active, return pointer = current entry point/aspect, next move = resume the current comprehension check.
+   - Return to comprehension loop immediately.
 
    **Detection criteria**:
    - **Required**: Suggests changes or improvements to the discussed system (direction toward knowledge capture, not comprehension)
@@ -346,7 +358,7 @@ For each task (entry point):
 
    | Evaluation | Action | Tool |
    |------------|--------|------|
-   | Correct (P' ≅ R) | Confirm, proceed to next aspect or entry point | TaskUpdate |
+   | Correct (P' ≅ R) | Confirm, emit continuation closure, proceed to next aspect or entry point | TaskUpdate |
    | Partial gap | Targeted followup probe on the gap area | Gate interaction |
    | Misconception | Reasoning inquiry → targeted correction | Gate interaction, Read (AI-determined) |
 
@@ -363,10 +375,13 @@ For each task (entry point):
    When step 3c evaluates as Correct for the current gap type:
 
    1. Compare probed vs. unprobed detected relevant gap types (canonical + Emergent) for this entry point
-   2. If unprobed aspects exist, output a brief text nudge reminding the user they can share improvement ideas or unlisted comprehension gaps via the "Other" option (adapt wording to context, no fixed template).
+   2. Emit continuation closure as relay text: verified aspect, current task/aspect status, branch artifact if one was just ejected, return pointer, and next available moves.
+   3. If unprobed aspects exist, output a brief text nudge reminding the user they can share improvement ideas or unlisted comprehension gaps via the "Other" option (adapt wording to context, no fixed template).
 
    Present progress as text output:
    - Verified [probed aspects] in [entry point]
+   - Current position: [entry point] / [current or next aspect]
+   - Next: [coverage check, next pending task, convergence, or explicit exit]
 
    Then **present**:
 
@@ -419,9 +434,11 @@ For each task (entry point):
 4. **Task tracking**: Call TaskCreate/TaskUpdate for progress visibility
 5. **Code grounding**: Reference specific code locations
 6. **User authority**: User's "I understand" is final
-7. **Proposal ejection**: When user answer `A` drifts from comprehension toward knowledge capture (suggesting changes/improvements to the system), acknowledge briefly, call TaskCreate to externalize the proposal, and return to verification. This preserves user-generated insights without disrupting the comprehension loop. The protocol does not track ejected proposals in its own state.
+7. **Proposal ejection**: When user answer `A` drifts from comprehension toward knowledge capture (suggesting changes/improvements to the system), acknowledge briefly, call TaskCreate to externalize the proposal, record only a branch reference for continuation, and return to verification. This preserves user-generated insights without converting the proposal into a comprehension task.
+7a. **Continuation cursor after side branches**: Proposal ejection and follow-up task creation do not close Katalepsis. After any side branch, emit a compact continuation closure: what was recorded, parent entry point/aspect, return pointer, and next comprehension move. Store the branch artifact outside the comprehension task set, but keep `Λ.cursor` visible enough for the user to recognize where verification resumes.
 8. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via Cognitive Partnership Move (Constitution). The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
 9. **Convergence evidence**: Present transformation trace before declaring all tasks completed; per-task evidence is required
+9a. **Post-answer closure**: After a correct answer or sufficient understanding signal, do not stop at bare acknowledgment. Emit verified aspect, current task status, and next available moves before coverage routing or task completion. This is relay metadata: it keeps the active loop legible without adding a new user gate.
 10. **Zero-gap surfacing**: If Phase 3 analysis finds no comprehension gaps for an entry point, present this finding with reasoning for user confirmation before marking as self-evident
 11. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option while preserving the TYPES coproduct) is distinct from mutation
 12. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.


### PR DESCRIPTION
## Summary
- Closes #423 by adding a Katalepsis continuation cursor and continuation closure for verified answers and side-branch proposal ejection.
- Closes #425 by hardening the continuation closure contract after review: cursor lifecycle, `C(·)` anchoring, branch artifact typing/reference, pointer invariants, and positive post-answer wording.
- Preserves the terminal output name `VerifiedUnderstanding`; this compiles loop-continuity invariants into Katalepsis without renaming the protocol result.
- Records side-branch proposal artifacts outside the comprehension task set while surfacing the return pointer and next comprehension move.
- Keeps Phase 3 C as relay metadata, not a new user gate or additional user-facing burden.
- Bumps Katalepsis plugin metadata from 2.0.0 to 2.1.0.

## Review Disposition
- Treated cursor initialization/update, branch reference content, `C(·)` anchoring, `Λ.closure` lifecycle, pointer equality, and positive Rule 9a wording as real contract gaps.
- Resolved the `Optional`/`Option` recommendation conflict by removing stateful `Λ.closure`; the remaining Katalepsis continuation option notation is consistently `Optional`.
- Removed `Λ.closure` from MODE STATE because closure is ephemeral relay metadata, not durable state or a new gate.

## Verification
- `node .claude/skills/verify/scripts/static-checks.js .`
- `git diff --check`
- pre-commit runtime-contract tests, static checks, and packaging dry-run

Notes: static verification still reports existing warnings for Prothesis `Horizontverschmelzung`, Korean text in `.claude/principles/hermeneutic-cycle.md`, and Korean text in the built dist asset. The version-staleness check is skipped because existing `.git/REBASE_HEAD` is present, so Katalepsis manifest versions were separately checked.

Closes #423
Closes #425
