### PR TITLE
Add Analogia correspondence fit map

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -181,21 +181,34 @@ jobs:
             </review>
 
             For each review finding that references a specific file path and line number,
-            post it as an inline PR review comment. Use jq to construct JSON and pipe via --input -
-            to avoid shell escaping issues:
+            post it as an inline PR review comment. Write Markdown bodies through a
+            single-quoted heredoc and load them with jq --rawfile; do not place Markdown
+            review text inside a double-quoted shell argument, because backticks in
+            Markdown trigger shell command substitution:
 
-            jq -n --arg body "<comment body>" --arg path "<file path>" \
+            body_file="$(mktemp)"
+            cat > "$body_file" <<'COMMENT_BODY_EOF'
+            <comment body>
+            COMMENT_BODY_EOF
+            jq -n --rawfile body "$body_file" --arg path "<file path>" \
               --arg commit_id "${{ steps.pr.outputs.sha }}" \
               --argjson line <line number> \
               '{body: $body, path: $path, commit_id: $commit_id, line: $line}' \
             | gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments --input -
+            rm -f "$body_file"
 
             Rules:
             - jq output MUST be a JSON object {}, never an array []
+            - Never pass Markdown review text via `--arg body "<...>"`
             - Only post findings whose line numbers appear in the PR diff
             - If a finding references a line outside the diff, include it in the summary comment instead
             - Preserve severity tags (Critical / Important / Suggestion)
             - Skip duplicate or near-duplicate findings
             - Always post a summary comment at the end (even if inline comments were posted):
-              jq -n --arg body "<summary>" '{body: $body}' \
+              summary_file="$(mktemp)"
+              cat > "$summary_file" <<'SUMMARY_BODY_EOF'
+              <summary>
+              SUMMARY_BODY_EOF
+              jq -n --rawfile body "$summary_file" '{body: $body}' \
               | gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments --input -
+              rm -f "$summary_file"

--- a/.github/workflows/claude-epistemic-review.yml
+++ b/.github/workflows/claude-epistemic-review.yml
@@ -225,22 +225,35 @@ jobs:
             </review>
 
             For each review finding that references a specific file path and line number,
-            post it as an inline PR review comment. Use jq to construct JSON and pipe via --input -
-            to avoid shell escaping issues:
+            post it as an inline PR review comment. Write Markdown bodies through a
+            single-quoted heredoc and load them with jq --rawfile; do not place Markdown
+            review text inside a double-quoted shell argument, because backticks in
+            Markdown trigger shell command substitution:
 
-            jq -n --arg body "<comment body>" --arg path "<file path>" \
+            body_file="$(mktemp)"
+            cat > "$body_file" <<'COMMENT_BODY_EOF'
+            <comment body>
+            COMMENT_BODY_EOF
+            jq -n --rawfile body "$body_file" --arg path "<file path>" \
               --arg commit_id "${{ steps.pr.outputs.sha }}" \
               --argjson line <line number> \
               '{body: $body, path: $path, commit_id: $commit_id, line: $line}' \
             | gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments --input -
+            rm -f "$body_file"
 
             Rules:
             - jq output MUST be a JSON object {}, never an array []
+            - Never pass Markdown review text via `--arg body "<...>"`
             - Only post findings whose line numbers appear in the PR diff
             - If a finding references a line outside the diff, include it in the summary comment instead
             - Preserve tags: [Category Theory], [Type Theory], [OpSem], [Gap: Type]
             - Preserve severity: Critical / Important / Suggestion
             - Skip duplicate or near-duplicate findings
             - Always post a summary comment at the end (even if inline comments were posted):
-              jq -n --arg body "<overview summary>" '{body: $body}' \
+              summary_file="$(mktemp)"
+              cat > "$summary_file" <<'SUMMARY_BODY_EOF'
+              <overview summary>
+              SUMMARY_BODY_EOF
+              jq -n --rawfile body "$summary_file" '{body: $body}' \
               | gh api repos/${{ github.repository }}/issues/${{ steps.pr.outputs.number }}/comments --input -
+              rm -f "$summary_file"

--- a/analogia/.claude-plugin/plugin.json
+++ b/analogia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "analogia",
   "description": "Validate structural mapping between domains \u2014 /ground (\u1f00\u03bd\u03b1\u03bb\u03bf\u03b3\u03af\u03b1: a proportion)",
-  "version": "1.6.34",
+  "version": "1.7.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/analogia/.codex-plugin/plugin.json
+++ b/analogia/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "analogia",
-  "version": "1.6.34",
+  "version": "1.7.0",
   "description": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
   "author": {
     "name": "Jongwon Choi",

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -13,14 +13,15 @@ Validate structural mapping between abstract and concrete domains through AI-gui
 
 ```
 ── FLOW ──
-Analogia(R) → Detect(R) → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → I(M, Sₜ) → V → R' → (loop until terminalized)
+Analogia(R) → Detect(R) → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → AssessFit(M, Sₐ, Sₜ) → I(M, F, Sₜ) → V → R' → (loop until terminalized)
 
 ── MORPHISM ──
 R
   → detect(R, context)                 -- infer mapping uncertainty
   → decompose(abstract, concrete)      -- identify source and target domains
   → construct(mapping, Sₐ→Sₜ)          -- build structural correspondences
-  → instantiate(mapping, target)       -- generate concrete examples
+  → assess_fit(mapping, Sₐ, Sₜ, context) -- sort correspondence adequacy before user validation
+  → instantiate(mapping, fit_map, target) -- generate concrete examples scoped by fit map
   → validate(instantiation, user)      -- user verifies mapping adequacy
   → terminalize(mapping, user)         -- make mapping status explicit in output
   → ValidatedMapping
@@ -39,13 +40,22 @@ Map      = Structure-preserving mapping construction: (Sₐ, Sₜ) → Set(Corre
 M        = Set(Correspondence)                                   -- mapping result
 Correspondence = { abstract: Component, concrete: Component, relation: String }
 Component = { name: String, structure: String }
-I        = Concrete instantiation: M × Sₜ → Example
-Example  = { scenario: String, mapping_trace: List<Correspondence> }
+AssessFit = Correspondence adequacy assessment: M × Sₐ × Sₜ × context → F
+F        = CorrespondenceFitMap { preserved, partial, missing, overextended, open }
+preserved = Set(Correspondence) where target structure preserves source relation
+partial  = Set(Correspondence) where correspondence exists but some structural dimensions lack evidence
+missing  = Set(Component) from Sₐ with no evidenced Sₜ correspondent
+overextended = Set(Correspondence) where source relation adds unsupported target constraints
+open     = Set(StructuralQuestion) where answer could change validation of M
+StructuralQuestion = { structure: Component, reason: String, evidence_needed: String }
+I        = Concrete instantiation: M × F × Sₜ → Example
+Example  = { scenario: String, mapping_trace: List<Correspondence>, fit_basis: F }
 V        = User validation ∈ {Confirm, Adjust(feedback), Dismiss}
 R'       = Updated output with explicit mapping status
 ValidatedMapping = R' where terminalized(R')
-terminalized(R') = all_addressed(R') ∨ user_esc
+terminalized(R') = (all_addressed(R') ∧ fit_disposition_declared(F)) ∨ user_esc
 all_addressed(R') = ∀ c ∈ M : confirmed(c) ∨ dismissed(c)
+fit_disposition_declared(F) = (F.missing ∪ F.open = ∅) ∨ bounded_residual_declared(F.missing ∪ F.open)
 
 ── R-BINDING ──
 bind(R) = explicit_arg ∪ current_output ∪ most_recent_output
@@ -59,8 +69,8 @@ If no relevant text exists: pause activation and request a grounding target befo
 
 ── PHASE TRANSITIONS ──
 Phase 0: R → Detect(R) → uncertain?                             -- mapping uncertainty checkpoint (silent)
-Phase 1: uncertain → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → M               -- domain decomposition + mapping [Tool]
-Phase 2: M → I(M, Sₜ) → Qs(I, progress) → Stop → V             -- instantiation + validation [Tool]
+Phase 1: uncertain → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → M → AssessFit(M, Sₐ, Sₜ) → F  -- domain decomposition + fit map [Tool]
+Phase 2: (M, F) → I(M, F, Sₜ) → Qs(I, F, progress) → Stop → V  -- instantiation + validation [Tool]
 Phase 3: V → integrate(V, R) → R'                               -- output update (sense)
 
 ── LOOP ──
@@ -70,7 +80,7 @@ If V = Adjust(feedback): refine mapping with feedback → return to Phase 1.
 If V = Dismiss: accept this correspondence as unresolved for this session; terminalize if all correspondences addressed.
 Max 3 mapping attempts per domain pair.
 Continue until: terminalized(R') OR attempts exhausted.
-Convergence evidence: At all_addressed(R'), present transformation trace — for each c ∈ Λ.mappings, show (MappingUncertain(c) → validation_result(c)). When any abstract structure was flagged in Phase 1 step 3 as lacking a concrete correspondent in Sₜ, the trace appends a brief invitation for the user to supply the missing Sₜ correspondent if one can be identified — a free response within the existing turn, not a new gate or post-convergence morphism. Convergence is demonstrated, not asserted.
+Convergence evidence: At all_addressed(R'), present transformation trace — for each c ∈ Λ.mappings, show (MappingUncertain(c) → fit_classification(F, c) → validation_result(c)). When F.missing or F.open contains an abstract structure whose answer could change validation, the trace declares it as bounded residual mapping uncertainty and appends a brief invitation for the user to supply the missing Sₜ correspondent if one can be identified — a free response within the existing turn, not a new gate or post-convergence morphism. Convergence is demonstrated, not asserted.
 
 ── CONVERGENCE ──
 terminalized(R') = all_addressed(R') ∨ user_esc
@@ -90,7 +100,7 @@ converge     (extension)       → TextPresent+Proceed (convergence evidence tra
 Λ = { phase: Phase, R: Text, Sₐ: Domain, Sₜ: Domain,
       mappings: Set(Correspondence), confirmed: Set(Correspondence),
       dismissed: Set(Correspondence), remaining: Set(Correspondence),
-      instantiations: List<Example>,
+      fit_map: F, instantiations: List<Example>,
       validations: List<(Example, V)>, attempts: Nat, active: Bool,
       cause_tag: String }
 -- Invariant: mappings = confirmed ∪ dismissed ∪ remaining (pairwise disjoint)
@@ -193,7 +203,10 @@ Decompose abstract and concrete domains, then construct structural correspondenc
    - If correspondence is clear: add to confirmed candidates
    - If structural mismatch detected: flag as uncertain — include evidence
    - If no correspondent exists: flag as gap — the abstract structure may not apply
-4. Proceed to Phase 2 with mapping candidates
+4. **Assess fit** `F`: Sort the correspondence adequacy into preserved, partial, missing, overextended, and open
+   - `open` is limited to structural questions whose answer could change validation of the mapping
+   - Do not include general analogy ideas, background caveats, or future exploration horizons
+5. Proceed to Phase 2 with mapping candidates and fit map
 
 **Web context** (conditional): When source or target domain knowledge exists primarily outside the codebase (external APIs, academic domains, industry standards), extend context collection to web search.
 Web evidence is tagged with `source: "web:{url}"` for traceability.
@@ -204,15 +217,17 @@ Web evidence is tagged with `source: "web:{url}"` for traceability.
 
 **Present** concrete instantiations for user validation via Cognitive Partnership Move (Constitution).
 
-**Selection criterion**: Choose the correspondence whose validation would maximally narrow the remaining mapping uncertainty. When priority is equal, prefer the correspondence with richer structural evidence.
+**Selection criterion**: Choose the correspondence whose validation would maximally narrow the remaining mapping uncertainty using `F`. Prioritize partial, overextended, missing-adjacent, or open-adjacent correspondences before already-preserved ones. When priority is equal, prefer the correspondence with richer structural evidence.
 
 **Surfacing format**:
 
 Present the mapping details as text output:
 - **Abstract**: [component from Sₐ with structural description]
 - **Concrete**: [proposed correspondence in Sₜ with evidence]
+- **Fit**: [preserved / partial / missing / overextended / open issue, in plain language]
 - **Example**: [concrete scenario demonstrating the mapping]
 - [If structural mismatch detected: flag and explain]
+- [If open issue could change validation: name the missing evidence or user-known fact]
 - **Progress**: [N validated / M total correspondences]
 
 Then **present**:
@@ -230,6 +245,7 @@ Other is always available — user can propose an alternative mapping or describ
 
 **Design principles**:
 - **Structural evidence**: Show what abstract structures are being mapped and why
+- **Fit map before choice**: Show only the correspondence-fit distinctions that matter for the current validation
 - **Concrete instantiation**: Always include at least one concrete example in user's domain
 - **Progress visible**: Display validation progress across all identified correspondences
 - **Actionable options**: Each option leads to a concrete next step
@@ -285,3 +301,4 @@ After integration:
 13. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option while preserving the TYPES coproduct) is distinct from mutation
 14. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 15. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
+16. **Protocol-native pressure map**: Phase 1 produces a CorrespondenceFitMap before validation. The map is a pre-gate support object for correspondence adequacy, not a terminal status and not generic calibration. `open` may surface bounded discovery pressure only when the missing evidence could change the user's validation of the current mapping.

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -13,7 +13,7 @@ Validate structural mapping between abstract and concrete domains through AI-gui
 
 ```
 ── FLOW ──
-Analogia(R) → Detect(R) → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → AssessFit(M, Sₐ, Sₜ) → I(M, F, Sₜ) → V → R' → (loop until terminalized)
+Analogia(R) → Detect(R) → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → AssessFit(M, Sₐ, Sₜ) → I(M, F, Sₜ) → V → D_f → R' → (loop until terminalized)
 
 ── MORPHISM ──
 R
@@ -23,7 +23,8 @@ R
   → assess_fit(mapping, Sₐ, Sₜ, context) -- sort correspondence adequacy before user validation
   → instantiate(mapping, fit_map, target) -- generate concrete examples scoped by fit map
   → validate(instantiation, user)      -- user verifies mapping adequacy
-  → terminalize(mapping, user)         -- make mapping status explicit in output
+  → declare_fit_disposition(fit_map, validation) -- record bounded residual status without a new gate
+  → terminalize(mapping, user, fit_disposition) -- make mapping status explicit in output
   → ValidatedMapping
 requires: uncertain(mapping(Sₐ, Sₜ))    -- runtime checkpoint (Phase 0)
 deficit:  MappingUncertain               -- activation precondition (Layer 1/2)
@@ -40,7 +41,8 @@ Map      = Structure-preserving mapping construction: (Sₐ, Sₜ) → Set(Corre
 M        = Set(Correspondence)                                   -- mapping result
 Correspondence = { abstract: Component, concrete: Component, relation: String }
 Component = { name: String, structure: String }
-AssessFit = Correspondence adequacy assessment: M × Sₐ × Sₜ × context → F
+Context  = Observable mapping context from R, session context, and cited domain evidence
+AssessFit = Correspondence adequacy assessment: M × Sₐ × Sₜ × Context → F
 F        = CorrespondenceFitMap { preserved, partial, missing, overextended, open }
 preserved = Set(Correspondence) where target structure preserves source relation
 partial  = Set(Correspondence) where correspondence exists but some structural dimensions lack evidence
@@ -48,14 +50,27 @@ missing  = Set(Component) from Sₐ with no evidenced Sₜ correspondent
 overextended = Set(Correspondence) where source relation adds unsupported target constraints
 open     = Set(StructuralQuestion) where answer could change validation of M
 StructuralQuestion = { structure: Component, reason: String, evidence_needed: String }
+FitLabel ∈ {Preserved, Partial, Overextended}
+fit_classification(F, c) =
+  Preserved if c ∈ F.preserved
+  Partial if c ∈ F.partial
+  Overextended if c ∈ F.overextended
+fit_partition(F, M) = F.preserved ∪ F.partial ∪ F.overextended = M (pairwise disjoint)
+ResidualFitIssue ∈ Missing(Component) ∪ OpenQuestion(StructuralQuestion)
+residual_issues(F) = { Missing(x) | x ∈ F.missing } ∪ { OpenQuestion(q) | q ∈ F.open }
+FitDisposition = { issues: Set(ResidualFitIssue), status: None ∪ Bounded, declaration: String }
+D_f      = FitDisposition
+fit_disposition_declared(F, D_f) =
+  (residual_issues(F) = ∅ ∧ D_f.status = None)
+  ∨ (D_f.status = Bounded ∧ D_f.issues = residual_issues(F))
 I        = Concrete instantiation: M × F × Sₜ → Example
 Example  = { scenario: String, mapping_trace: List<Correspondence>, fit_basis: F }
 V        = User validation ∈ {Confirm, Adjust(feedback), Dismiss}
+ValidationRecord = { example: Example, answer: V, fit_label: FitLabel, residual_disposition: FitDisposition }
 R'       = Updated output with explicit mapping status
-ValidatedMapping = R' where terminalized(R')
-terminalized(R') = (all_addressed(R') ∧ fit_disposition_declared(F)) ∨ user_esc
+ValidatedMapping = R' where terminalized(R', F, D_f)
+terminalized(R', F, D_f) = (all_addressed(R') ∧ fit_disposition_declared(F, D_f)) ∨ user_esc
 all_addressed(R') = ∀ c ∈ M : confirmed(c) ∨ dismissed(c)
-fit_disposition_declared(F) = (F.missing ∪ F.open = ∅) ∨ bounded_residual_declared(F.missing ∪ F.open)
 
 ── R-BINDING ──
 bind(R) = explicit_arg ∪ current_output ∪ most_recent_output
@@ -71,19 +86,19 @@ If no relevant text exists: pause activation and request a grounding target befo
 Phase 0: R → Detect(R) → uncertain?                             -- mapping uncertainty checkpoint (silent)
 Phase 1: uncertain → (Sₐ, Sₜ) → Map(Sₐ, Sₜ) → M → AssessFit(M, Sₐ, Sₜ) → F  -- domain decomposition + fit map [Tool]
 Phase 2: (M, F) → I(M, F, Sₜ) → Qs(I, F, progress) → Stop → V  -- instantiation + validation [Tool]
-Phase 3: V → integrate(V, R) → R'                               -- output update (sense)
+Phase 3: V → integrate(V, R, F) → (D_f, R')                     -- fit disposition + output update (sense)
 
 ── LOOP ──
 After Phase 3: evaluate validation result.
-If V = Confirm: mark correspondence confirmed; terminalize if all correspondences addressed.
+If V = Confirm: mark correspondence confirmed; record fit label snapshot and D_f; terminalize if all correspondences addressed and fit disposition is declared.
 If V = Adjust(feedback): refine mapping with feedback → return to Phase 1.
-If V = Dismiss: accept this correspondence as unresolved for this session; terminalize if all correspondences addressed.
+If V = Dismiss: accept this correspondence as unresolved for this session; record fit label snapshot and D_f; terminalize if all correspondences addressed and fit disposition is declared.
 Max 3 mapping attempts per domain pair.
-Continue until: terminalized(R') OR attempts exhausted.
-Convergence evidence: At all_addressed(R'), present transformation trace — for each c ∈ Λ.mappings, show (MappingUncertain(c) → fit_classification(F, c) → validation_result(c)). When F.missing or F.open contains an abstract structure whose answer could change validation, the trace declares it as bounded residual mapping uncertainty and appends a brief invitation for the user to supply the missing Sₜ correspondent if one can be identified — a free response within the existing turn, not a new gate or post-convergence morphism. Convergence is demonstrated, not asserted.
+Continue until: terminalized(R', F, D_f) OR attempts exhausted.
+Convergence evidence: At terminalized(R', F, D_f), present transformation trace — for each record in Λ.validations, show (MappingUncertain(record.example.mapping_trace) → record.fit_label → record.answer). When D_f.status = Bounded, append the bounded residual mapping uncertainty from D_f.declaration and briefly invite the user to supply a missing Sₜ correspondent if one can be identified — a free response within the existing turn, not a new gate or post-convergence morphism. Convergence is demonstrated, not asserted.
 
 ── CONVERGENCE ──
-terminalized(R') = all_addressed(R') ∨ user_esc
+terminalized(R', F, D_f) = (all_addressed(R') ∧ fit_disposition_declared(F, D_f)) ∨ user_esc
 progress(Λ) = 1 - |remaining| / |mappings|
 narrowing(V, M) = |remaining(after)| < |remaining(before)|
 early_exit = user_declares_mapping_sufficient
@@ -91,7 +106,7 @@ early_exit = user_declares_mapping_sufficient
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Phase 0 Detect  (sense)     → Internal analysis (no external tool)
-Phase 1 Map     (observe)   → Read, Grep (stored knowledge extraction: domain structure analysis); WebSearch (conditional: external domain knowledge)
+Phase 1 Map/AssessFit (observe) → Read, Grep (stored knowledge extraction: domain structure and fit analysis); WebSearch (conditional: external domain knowledge)
 Phase 2 Qs      (constitution)      → present (mandatory; Esc key → loop termination at LOOP level, not a Validation)
 Phase 3         (track)     → Internal state update
 converge     (extension)       → TextPresent+Proceed (convergence evidence trace; proceed with validated mapping)
@@ -100,10 +115,11 @@ converge     (extension)       → TextPresent+Proceed (convergence evidence tra
 Λ = { phase: Phase, R: Text, Sₐ: Domain, Sₜ: Domain,
       mappings: Set(Correspondence), confirmed: Set(Correspondence),
       dismissed: Set(Correspondence), remaining: Set(Correspondence),
-      fit_map: F, instantiations: List<Example>,
-      validations: List<(Example, V)>, attempts: Nat, active: Bool,
+      fit_map: F, fit_disposition: D_f, instantiations: List<Example>,
+      validations: List<ValidationRecord>, attempts: Nat, active: Bool,
       cause_tag: String }
 -- Invariant: mappings = confirmed ∪ dismissed ∪ remaining (pairwise disjoint)
+-- Invariant: fit_partition(F, M)
 
 ── COMPOSITION ──
 *: product — (D₁ × D₂) → (R₁ × R₂). graph.json edges preserved. Dimension resolution emergent via session context.
@@ -204,6 +220,8 @@ Decompose abstract and concrete domains, then construct structural correspondenc
    - If structural mismatch detected: flag as uncertain — include evidence
    - If no correspondent exists: flag as gap — the abstract structure may not apply
 4. **Assess fit** `F`: Sort the correspondence adequacy into preserved, partial, missing, overextended, and open
+   - `preserved`, `partial`, and `overextended` partition the constructed correspondences `M`
+   - `missing` tracks source components that do not yet have evidenced target correspondents
    - `open` is limited to structural questions whose answer could change validation of the mapping
    - Do not include general analogy ideas, background caveats, or future exploration horizons
 5. Proceed to Phase 2 with mapping candidates and fit map
@@ -254,15 +272,17 @@ Other is always available — user can propose an alternative mapping or describ
 
 After user response:
 
-1. **Confirm**: Mark correspondence as validated, update output `R'` to include explicit mapping status
+1. **Confirm**: Mark correspondence as validated, record the current fit classification with the validation, declare `D_f`, and update output `R'` to include explicit mapping status
 2. **Adjust(feedback)**: Incorporate feedback, reconstruct mapping — return to Phase 1
-3. **Dismiss**: Mark correspondence as not requiring further grounding in this session, keep current output
+3. **Dismiss**: Mark correspondence as not requiring further grounding in this session, record the current fit classification with the dismissal, declare `D_f`, and keep current output
+
+`D_f` is declared during Phase 3 from the Phase 2 surface: `None` when `residual_issues(F)` is empty, otherwise `Bounded` with the missing/open issues that were visible before the gate. This is trace metadata, not a separate user gate.
 
 After integration:
 - Check remaining unvalidated correspondences
 - If correspondences remain: return to Phase 2 (present next correspondence)
-- If all correspondences are addressed (confirmed/dismissed): proceed with updated output
-- Log `(Example, V)` to validations
+- If all correspondences are addressed and `D_f` is declared: proceed with updated output
+- Log `ValidationRecord` to validations so convergence traces use the fit label that was active when the user judged the correspondence
 
 ## Intensity
 
@@ -295,10 +315,10 @@ After integration:
 7. **Validation respected**: User validation or dismissal is final for that correspondence in the current session
 8. **Convergence persistence**: Mode active until all identified correspondences are addressed or user Esc key
 9. **Context-Question Separation**: Output all analysis, evidence, and rationale as text before presenting via Cognitive Partnership Move (Constitution). The question contains only the essential question; options contain only option-specific differential implications. Embedding context in question fields = protocol violation
-10. **Convergence evidence**: Present transformation trace before declaring all_addressed(R'); per-correspondence evidence is required
+10. **Convergence evidence**: Present transformation trace before declaring terminalized(R', F, D_f); per-correspondence evidence is required
 11. **Zero-gap surfacing**: If Phase 1 structural analysis finds perfect correspondence with no mapping gaps, present this finding with reasoning for user confirmation
 12. **Option-set relay test (Extension classification)**: If AI analysis converges to a single dominant option (option-level entropy→0 — Extension mode of the Cognitive Partnership Move), present the finding directly. Each Constitution option must be genuinely viable under different user value weightings. Options sharing a downstream trajectory collapse to one; options lacking an on-axis trajectory surface as free-response pathways rather than peer options
 13. **Gate integrity**: The defined option set is presented intact — injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic option while preserving the TYPES coproduct) is distinct from mutation
 14. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 15. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
-16. **Protocol-native pressure map**: Phase 1 produces a CorrespondenceFitMap before validation. The map is a pre-gate support object for correspondence adequacy, not a terminal status and not generic calibration. `open` may surface bounded discovery pressure only when the missing evidence could change the user's validation of the current mapping.
+16. **Protocol-native pressure map**: Phase 1 produces a CorrespondenceFitMap before validation. The map is a pre-gate support object for correspondence adequacy, not a terminal status and not generic calibration. `open` may surface bounded discovery pressure only when the missing evidence could change the user's validation of the current mapping. Missing/open residuals are declared through Phase 3 fit disposition metadata without adding a user gate.


### PR DESCRIPTION
## Summary
- pilot #417 pressure-map/type morphism work in Analogia only
- add `CorrespondenceFitMap` as a protocol-native pre-gate support object before validation
- keep `ValidatedMapping` as the endpoint and bound `open` discovery pressure to validation-changing structural questions
- bump Analogia plugin metadata to `1.7.0`

## Candidate rationale
- Analogia is the smallest fit: correspondence adequacy is native to `/ground`, and the map sits naturally between mapping construction and instantiation.
- Epharmoge remains a later candidate because its fit-map surface overlaps existing mismatch severity and behavioral-impact rules.
- Syneidesis remains higher-risk because gap pressure can become interruption-heavy if `hidden_high_impact` is not tightly capped.
- Katalepsis continuation closure from #424 is not reused here.

## Verification
- `node .claude/skills/verify/scripts/static-checks.js .`
- `git diff --cached --check`
- pre-commit runtime-contract tests
- pre-commit packaging dry-run

Refs #417
Refs #402