### PR TITLE
Add Epharmoge applicability fit map

### DIFF
--- a/epharmoge/.claude-plugin/plugin.json
+++ b/epharmoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epharmoge",
   "description": "Detect application-context mismatch after execution \u2014 /contextualize (\u1f10\u03c6\u03b1\u03c1\u03bc\u03bf\u03b3\u03ae: an application)",
-  "version": "0.7.41",
+  "version": "0.8.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/epharmoge/.codex-plugin/plugin.json
+++ b/epharmoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epharmoge",
-  "version": "0.7.41",
+  "version": "0.8.0",
   "description": "Detect application-context mismatch after execution — /contextualize (ἐφαρμογή: an application)",
   "author": {
     "name": "Jongwon Choi",

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -13,7 +13,7 @@ Detect application-context mismatch after execution through AI-guided applicabil
 
 ```
 ── FLOW ──
-Epharmoge(R, X) → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F → Register(Mᵢ) → Q(F-scoped Mᵢ[0]) → A → R' → Eval(R', X) → Mₑ? → (loop until contextualized)
+Epharmoge(R, X) → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F → Register(Mᵢ) → SelectNext(pending, F, Σ) → Mₛ → Q(F-scoped Mₛ) → A → R' → Eval(R', X) → Mₑ? → Register(Mₑ) → AssessFit(R', X, pending) → F' → (loop: SelectNext → Q → A → adapt → re-scan until contextualized)
 
 ── MORPHISM ──
 (R, X)
@@ -37,34 +37,48 @@ Dimension ∈ {Convention, Environment, Audience, Dependency} ∪ Emergent(Dimen
 Origin ∈ {Initial, Emerged(aspect)}                            -- mismatch provenance: initial scan or spawned by adapting parent aspect
 Severity ∈ {Critical, Significant, Minor}                      -- Significant requires demonstrable behavioral impact (current-session task graph / downstream protocol activations); see Rule 17
 AssessFit = Applicability fit assessment: R × X × Set(Mismatch) → F
-F      = ApplicabilityFitMap { fits, conflicts, depends, adaptation_options, open }
-fits   = Set(AspectFit) where aspect(R) is warranted in X
+           -- classifier over input_mismatches; does not generate new Mismatch objects
+F      = ApplicabilityFitMap { fit_justifications, conflicts, depends, adaptation_options, open }
+fit_justifications = Set(AspectFit) where aspect(R) is warranted in X
 AspectFit = { aspect: String, evidence: String }
 conflicts = Set(Mismatch) where evidence shows result behavior or meaning conflicts with X
+           -- invariant: conflicts ⊆ input_mismatches
 depends = Set(ContextCondition) where fitness hinges on an observable but unverified condition that could change adaptation or dismissal
-ContextCondition = { condition: String, evidence: String, consequence: String }
+ContextCondition = { target: Mismatch, condition: String, evidence: String, consequence: String }
+                 -- invariant: target ∈ input_mismatches
 adaptation_options = Set(AdaptationOption) where each option is tied to a conflict or dependency
 AdaptationOption = { target: Mismatch ∪ ContextCondition, direction: String, effect: String }
 open   = Set(ApplicabilityQuestion) where the answer could materially change the next adaptation judgment
-ApplicabilityQuestion = { condition: String, reason: String, evidence_needed: String }
+ApplicabilityQuestion = { target: Mismatch, condition: String, reason: String, evidence_needed: String }
+                       -- invariant: target ∈ input_mismatches
+fit_category(m, F) =
+  Conflict if m ∈ F.conflicts
+  Dependent if ∃d ∈ F.depends : d.target = m
+  Open if ∃q ∈ F.open : q.target = m
+  Supported otherwise
+FitRank = Conflict > Dependent > Open > Supported
+SelectNext = Set(Mismatch) × F × Σ → Mₛ
+           -- priority: severity(Critical > Significant > Minor), then FitRank, then oldest registered task
+Mₛ     = Selected mismatch
 Mᵢ     = Identified mismatches from Eval(R, X)                 -- origin = Initial
 Mₑ     = Newly emerged mismatches from Eval(R', X)             -- origin = Emerged(adapted_aspect)
-Register = Mᵢ → Set(Task) [Tool: TaskCreate]                  -- mismatch registration as tracked tasks
+Register = Set(Mismatch) → Set(Task) [Tool: TaskCreate]       -- mismatch registration as tracked tasks
+pending(Σ) = Set(Mismatch) where registered task status ∉ {completed, dismissed}
 Q      = Applicability inquiry over F-scoped mismatch (gate interaction)
 A      = User answer ∈ {Confirm(mismatch), Adapt(direction), Dismiss}
 R'     = Adapted result (contextualized output)
 ContextualizedExecution = R' where (∀ task ∈ registered: task.status = completed) ∨ user_esc
 
 ── PHASE TRANSITIONS ──
-Phase 0: R → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F        -- applicability checkpoint + fit map (silent)
-Phase 1: (Mᵢ, F) → TaskCreate[all mismatches] → Qc(F-scoped Mᵢ[0], evidence) → Stop → A  -- register all mismatches, surface first with fit basis [Tool]
-Phase 2: A → adapt(A, R) → R' → TaskUpdate → Eval(R', X) → Mₑ? → AssessFit(R', X, Mₑ) → F' -- adaptation + update + re-scan [Tool]
+Phase 0: R → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F → Λ.fit_map := F  -- applicability checkpoint + fit map (silent)
+Phase 1: Mᵢ → TaskCreate[all initial mismatches] → pending(Σ) → SelectNext(pending, F, Σ) → Mₛ → Qc(F-scoped Mₛ, evidence) → Stop → A  -- register all initial mismatches, surface selected mismatch with fit basis [Tool]
+Phase 2: A → adapt(A, R) → R' → TaskUpdate → Eval(R', X) → Mₑ? → TaskCreate[all Mₑ] → pending(Σ) → AssessFit(R', X, pending) → F' → Λ.fit_map := F' -- adaptation + update + re-scan + recompute fit map [Tool]
 
 ── LOOP ──
 After Phase 2: re-scan R' against X for remaining AND newly emerged mismatches.
-Recompute F over remaining and newly emerged mismatches before selecting the next surfaced mismatch.
-If new mismatches from adaptation (Mₑ): TaskCreate → add to queue when Mₑ ∈ F'.conflicts.
-If remaining non-empty: return to Phase 1 (next by severity, then fit-map relevance).
+Register all newly emerged mismatches from adaptation (Mₑ); AssessFit classifies tracked mismatches but never suppresses them.
+Recompute F over pending(Σ) before selecting the next surfaced mismatch, even when Mₑ = ∅.
+If pending(Σ) non-empty: return to Phase 1 (SelectNext by severity, then FitRank, then oldest registered task).
 If adjudicated(R', X): all tasks completed → convergence.
 User can exit at Phase 1 (early_exit option or Esc).
 Continue until: contextualized(R') OR user ESC.
@@ -222,7 +236,7 @@ Evaluate result against application context. This phase is **silent** — no use
 
 1. **Scan result** `R` against context `X`: environment state, conventions, use case scope, temporal validity, user constraints
 2. **Check applicability**: For each aspect, assess whether `correct(R) ∧ fits(R, X)` (i.e., `warranted(R, X)`)
-3. **Assess fit**: Build `ApplicabilityFitMap` from warranted aspects, conflicts, dependencies, adaptation options, and bounded open questions
+3. **Assess fit**: Build `ApplicabilityFitMap` from warranted aspect evidence, conflicts, dependencies, adaptation options, and bounded open questions
 4. If all aspects warranted: present finding per Rule 14 before concluding (Epharmoge not activated)
 5. If mismatches identified: record `Mᵢ` with aspect, description, evidence, severity (per Rule 17 — behavioral-impact qualifier assessed against current-session task graph), `origin=Initial`, and fit-map placement — proceed to Phase 1
 
@@ -230,11 +244,11 @@ Evaluate result against application context. This phase is **silent** — no use
 
 **Scan scope**: Completed result, observable context (structure, conventions, constraints), session context. Does NOT re-execute or modify files.
 
-**Fit-map scope**: The map is pre-gate support for mismatch selection and adaptation direction. It may surface bounded open conditions only when the answer could change whether the result should be adapted or accepted as-is.
+**Fit-map scope**: The map is pre-gate support for mismatch selection and adaptation direction. It classifies already detected mismatches; it does not create or suppress mismatch tasks. It may surface bounded open conditions only when the answer could change whether the result should be adapted or accepted as-is.
 
 ### Phase 1: Mismatch Surfacing
 
-**Register all identified mismatches as Tasks** (TaskCreate), then **present** the highest-severity remaining mismatch via Cognitive Partnership Move (Constitution).
+**Register all identified mismatches as Tasks** (TaskCreate), then **present** the next pending mismatch selected by `SelectNext` via Cognitive Partnership Move (Constitution).
 
 **Task format**:
 ```
@@ -253,7 +267,7 @@ Present the mismatch findings as text output:
 - Done. One thing to verify about applicability:
   - **Mismatch**: [Specific mismatch description]
   - **Evidence**: [what in the result and what in the context diverge]
-  - **Fit basis**: [what already fits, what conflicts or depends, and any open condition that could change this adaptation decision]
+  - **Fit basis**: [what already fits, what conflicts or depends, and any open condition tied to this mismatch that could change this adaptation decision]
   - **Progress**: [N completed / M total tasks] (M may increase on re-scan)
 
 Then **present**:
@@ -289,9 +303,9 @@ After user response:
 
 After adaptation — **re-scan**:
 - Re-evaluate `R'` against `X` for remaining AND **newly emerged** mismatches
-- Recompute `ApplicabilityFitMap` before selecting the next mismatch
-- If new mismatches (`Mₑ`) from adaptation: TaskCreate with `origin=Emerged(adapted_aspect)` when fit-map placement shows conflict → add to queue
-- If remaining tasks non-empty: return to Phase 1 (surface next mismatch by severity)
+- Register all new mismatches (`Mₑ`) from adaptation with `origin=Emerged(adapted_aspect)`; do not filter them by fit-map category
+- Recompute `ApplicabilityFitMap` over all pending mismatches before selecting the next mismatch, even when `Mₑ = ∅`
+- If remaining tasks non-empty: return to Phase 1 (surface next mismatch via `SelectNext`: severity, then FitRank, then oldest registered task)
 - If all tasks completed: execution complete with contextualized result
 - Log `(Mismatch, A)` to `Σ.history`, increment `Σ.scan_count`
 
@@ -317,6 +331,7 @@ After adaptation — **re-scan**:
 | Mismatch cap | One mismatch per Phase 1 cycle, severity order | Prevents post-execution question overload |
 | Session immunity | Dismissed (aspect, description) → skip for session | Respects user's dismissal |
 | Progress visibility | Task list renders `[N addressed / M total]` in Phase 1 | User sees progress; total may grow on re-scan |
+| Deterministic selection | `SelectNext` orders pending mismatches by severity, FitRank, then oldest registered task | Removes unordered Set indexing from user-facing surfacing |
 | Fit-map cap | `depends`/`open` only when observable evidence could change adaptation or dismissal | Prevents broad contextual caveat lists |
 | Early exit | User can dismiss all at any Phase 1 | Full control over review depth |
 | Cross-protocol cooldown | `suppress(Epharmoge) if Aitesis.resolved_in_same_scope ∧ overlap(Aitesis.domains, Epharmoge.aspects)` | Prevents same-scope pre+post stacking |
@@ -344,5 +359,6 @@ After adaptation — **re-scan**:
 17. **Significant requires demonstrable behavioral impact**: Severity = Significant requires that the mismatch produces a demonstrable behavioral consequence — downstream-decision impact, runtime divergence, gate-trajectory change. Structural-change extent (line count, file count, scope size) alone is insufficient grounds — categorize as Minor when behavioral impact is undemonstrated. This guards against false-positive gating arising from conflation of structural-change extent with applicability impact, where Rule 15 (Option-set relay test) would otherwise apply only ex post via user challenge
 18. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 19. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
-20. **Applicability fit map is support only**: Use `ApplicabilityFitMap` to scope which mismatch is surfaced and which adaptation direction is practical. Do not present it as a separate gate, terminal object, or replacement for `ContextualizedExecution`.
+20. **Applicability fit map is support only**: Use `ApplicabilityFitMap` to scope which mismatch is surfaced and which adaptation direction is practical. It classifies already detected mismatches and must not create, suppress, or terminalize mismatch tasks.
 21. **Bounded discovery pressure**: `depends` and `open` entries require observable evidence plus a direct path to changing the user's next adaptation judgment. General caveats, interesting context, or future-session possibilities are omitted from the fit map.
+22. **All detected mismatches remain tracked**: Initial and emerged mismatches are registered before fit-map prioritization. Fit categories affect selection order and fit-basis wording only; they never remove a detected mismatch from convergence accounting.

--- a/epharmoge/skills/contextualize/SKILL.md
+++ b/epharmoge/skills/contextualize/SKILL.md
@@ -13,12 +13,13 @@ Detect application-context mismatch after execution through AI-guided applicabil
 
 ```
 ── FLOW ──
-Epharmoge(R, X) → Eval(R, X) → Mᵢ? → Register(Mᵢ) → Q(Mᵢ[0]) → A → R' → Eval(R', X) → Mₑ? → (loop until contextualized)
+Epharmoge(R, X) → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F → Register(Mᵢ) → Q(F-scoped Mᵢ[0]) → A → R' → Eval(R', X) → Mₑ? → (loop until contextualized)
 
 ── MORPHISM ──
 (R, X)
   → evaluate(result, context)          -- detect applicability mismatch
-  → surface(mismatch, as_inquiry)      -- present mismatch with evidence
+  → assess_fit(result, context, mismatches) -- sort applicability fit before user judgment
+  → surface(fit_scoped_mismatch, as_inquiry) -- present mismatch with fit basis and evidence
   → adapt(result, direction)           -- adapt result to context
   → ContextualizedExecution
 requires: mismatch_detected(R, X)       -- runtime checkpoint (Phase 0)
@@ -35,23 +36,35 @@ Mismatch = { aspect: String, dimension: Dimension, description: String, evidence
 Dimension ∈ {Convention, Environment, Audience, Dependency} ∪ Emergent(Dimension)
 Origin ∈ {Initial, Emerged(aspect)}                            -- mismatch provenance: initial scan or spawned by adapting parent aspect
 Severity ∈ {Critical, Significant, Minor}                      -- Significant requires demonstrable behavioral impact (current-session task graph / downstream protocol activations); see Rule 17
+AssessFit = Applicability fit assessment: R × X × Set(Mismatch) → F
+F      = ApplicabilityFitMap { fits, conflicts, depends, adaptation_options, open }
+fits   = Set(AspectFit) where aspect(R) is warranted in X
+AspectFit = { aspect: String, evidence: String }
+conflicts = Set(Mismatch) where evidence shows result behavior or meaning conflicts with X
+depends = Set(ContextCondition) where fitness hinges on an observable but unverified condition that could change adaptation or dismissal
+ContextCondition = { condition: String, evidence: String, consequence: String }
+adaptation_options = Set(AdaptationOption) where each option is tied to a conflict or dependency
+AdaptationOption = { target: Mismatch ∪ ContextCondition, direction: String, effect: String }
+open   = Set(ApplicabilityQuestion) where the answer could materially change the next adaptation judgment
+ApplicabilityQuestion = { condition: String, reason: String, evidence_needed: String }
 Mᵢ     = Identified mismatches from Eval(R, X)                 -- origin = Initial
 Mₑ     = Newly emerged mismatches from Eval(R', X)             -- origin = Emerged(adapted_aspect)
 Register = Mᵢ → Set(Task) [Tool: TaskCreate]                  -- mismatch registration as tracked tasks
-Q      = Applicability inquiry (gate interaction)
+Q      = Applicability inquiry over F-scoped mismatch (gate interaction)
 A      = User answer ∈ {Confirm(mismatch), Adapt(direction), Dismiss}
 R'     = Adapted result (contextualized output)
 ContextualizedExecution = R' where (∀ task ∈ registered: task.status = completed) ∨ user_esc
 
 ── PHASE TRANSITIONS ──
-Phase 0: R → Eval(R, X) → Mᵢ?                                  -- applicability checkpoint (silent)
-Phase 1: Mᵢ → TaskCreate[all mismatches] → Qc(Mᵢ[0], evidence) → Stop → A  -- register all, surface first [Tool]
-Phase 2: A → adapt(A, R) → R' → TaskUpdate → Eval(R', X) → Mₑ? -- adaptation + update + re-scan [Tool]
+Phase 0: R → Eval(R, X) → Mᵢ? → AssessFit(R, X, Mᵢ) → F        -- applicability checkpoint + fit map (silent)
+Phase 1: (Mᵢ, F) → TaskCreate[all mismatches] → Qc(F-scoped Mᵢ[0], evidence) → Stop → A  -- register all mismatches, surface first with fit basis [Tool]
+Phase 2: A → adapt(A, R) → R' → TaskUpdate → Eval(R', X) → Mₑ? → AssessFit(R', X, Mₑ) → F' -- adaptation + update + re-scan [Tool]
 
 ── LOOP ──
 After Phase 2: re-scan R' against X for remaining AND newly emerged mismatches.
-If new mismatches from adaptation (Mₑ): TaskCreate → add to queue.
-If remaining non-empty: return to Phase 1 (next by severity).
+Recompute F over remaining and newly emerged mismatches before selecting the next surfaced mismatch.
+If new mismatches from adaptation (Mₑ): TaskCreate → add to queue when Mₑ ∈ F'.conflicts.
+If remaining non-empty: return to Phase 1 (next by severity, then fit-map relevance).
 If adjudicated(R', X): all tasks completed → convergence.
 User can exit at Phase 1 (early_exit option or Esc).
 Continue until: contextualized(R') OR user ESC.
@@ -70,6 +83,7 @@ progress(Λ) = |completed_tasks| / |total_tasks|              -- may regress whe
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Eval   (sense)   → Internal analysis (no external tool)
+AssessFit (sense) → Internal analysis (no external tool)
 Qc     (constitution)    → present (mandatory; Esc key → loop termination at LOOP level, not an Answer)
 adapt  (transform) → Edit, Write (result adaptation based on user direction)
                     -- (transform): tool call that changes existing artifacts; medium-agnostic (files, analysis text, generated content)
@@ -78,7 +92,7 @@ converge (extension)  → TextPresent+Proceed (convergence evidence trace; proce
 
 ── MODE STATE ──
 Λ = { phase: Phase, R: Result, X: Context,
-      state: Σ, active: Bool, cause_tag: String }
+      fit_map: F, state: Σ, active: Bool, cause_tag: String }
 Σ = { history: List<(Mismatch, A)>, scan_count: Nat }
 
 ── COMPOSITION ──
@@ -208,12 +222,15 @@ Evaluate result against application context. This phase is **silent** — no use
 
 1. **Scan result** `R` against context `X`: environment state, conventions, use case scope, temporal validity, user constraints
 2. **Check applicability**: For each aspect, assess whether `correct(R) ∧ fits(R, X)` (i.e., `warranted(R, X)`)
-3. If all aspects warranted: present finding per Rule 14 before concluding (Epharmoge not activated)
-4. If mismatches identified: record `Mᵢ` with aspect, description, evidence, severity (per Rule 17 — behavioral-impact qualifier assessed against current-session task graph), `origin=Initial` — proceed to Phase 1
+3. **Assess fit**: Build `ApplicabilityFitMap` from warranted aspects, conflicts, dependencies, adaptation options, and bounded open questions
+4. If all aspects warranted: present finding per Rule 14 before concluding (Epharmoge not activated)
+5. If mismatches identified: record `Mᵢ` with aspect, description, evidence, severity (per Rule 17 — behavioral-impact qualifier assessed against current-session task graph), `origin=Initial`, and fit-map placement — proceed to Phase 1
 
 **Information source**: The result `R` itself compared against observable context `X`. NOT a re-scan of pre-execution context (non-circularity with Aitesis).
 
 **Scan scope**: Completed result, observable context (structure, conventions, constraints), session context. Does NOT re-execute or modify files.
+
+**Fit-map scope**: The map is pre-gate support for mismatch selection and adaptation direction. It may surface bounded open conditions only when the answer could change whether the result should be adapted or accepted as-is.
 
 ### Phase 1: Mismatch Surfacing
 
@@ -236,6 +253,7 @@ Present the mismatch findings as text output:
 - Done. One thing to verify about applicability:
   - **Mismatch**: [Specific mismatch description]
   - **Evidence**: [what in the result and what in the context diverge]
+  - **Fit basis**: [what already fits, what conflicts or depends, and any open condition that could change this adaptation decision]
   - **Progress**: [N completed / M total tasks] (M may increase on re-scan)
 
 Then **present**:
@@ -271,7 +289,8 @@ After user response:
 
 After adaptation — **re-scan**:
 - Re-evaluate `R'` against `X` for remaining AND **newly emerged** mismatches
-- If new mismatches (`Mₑ`) from adaptation: TaskCreate with `origin=Emerged(adapted_aspect)` → add to queue
+- Recompute `ApplicabilityFitMap` before selecting the next mismatch
+- If new mismatches (`Mₑ`) from adaptation: TaskCreate with `origin=Emerged(adapted_aspect)` when fit-map placement shows conflict → add to queue
 - If remaining tasks non-empty: return to Phase 1 (surface next mismatch by severity)
 - If all tasks completed: execution complete with contextualized result
 - Log `(Mismatch, A)` to `Σ.history`, increment `Σ.scan_count`
@@ -298,6 +317,7 @@ After adaptation — **re-scan**:
 | Mismatch cap | One mismatch per Phase 1 cycle, severity order | Prevents post-execution question overload |
 | Session immunity | Dismissed (aspect, description) → skip for session | Respects user's dismissal |
 | Progress visibility | Task list renders `[N addressed / M total]` in Phase 1 | User sees progress; total may grow on re-scan |
+| Fit-map cap | `depends`/`open` only when observable evidence could change adaptation or dismissal | Prevents broad contextual caveat lists |
 | Early exit | User can dismiss all at any Phase 1 | Full control over review depth |
 | Cross-protocol cooldown | `suppress(Epharmoge) if Aitesis.resolved_in_same_scope ∧ overlap(Aitesis.domains, Epharmoge.aspects)` | Prevents same-scope pre+post stacking |
 | Cooldown scope | Cooldown applies within recommendation chains only; direct `/contextualize` invocation is never suppressed | User authority preserved |
@@ -324,3 +344,5 @@ After adaptation — **re-scan**:
 17. **Significant requires demonstrable behavioral impact**: Severity = Significant requires that the mismatch produces a demonstrable behavioral consequence — downstream-decision impact, runtime divergence, gate-trajectory change. Structural-change extent (line count, file count, scope size) alone is insufficient grounds — categorize as Minor when behavioral impact is undemonstrated. This guards against false-positive gating arising from conflation of structural-change extent with applicability impact, where Rule 15 (Option-set relay test) would otherwise apply only ex post via user challenge
 18. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 19. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
+20. **Applicability fit map is support only**: Use `ApplicabilityFitMap` to scope which mismatch is surfaced and which adaptation direction is practical. Do not present it as a separate gate, terminal object, or replacement for `ContextualizedExecution`.
+21. **Bounded discovery pressure**: `depends` and `open` entries require observable evidence plus a direct path to changing the user's next adaptation judgment. General caveats, interesting context, or future-session possibilities are omitted from the fit map.


### PR DESCRIPTION
## Summary
- Adds `AssessFit` and `ApplicabilityFitMap` to Epharmoge `/contextualize` as the next #417 pressure-map pilot after Analogia.
- Keeps `ContextualizedExecution` as the terminal endpoint; the fit map is a pre-gate support object only.
- Bounds discovery pressure by limiting `depends` and `open` entries to observable conditions that could change the next adaptation judgment.
- Bumps Epharmoge plugin metadata from `0.7.41` to `0.8.0`.

## Verification
- `git diff --check`
- `node .claude/skills/verify/scripts/static-checks.js .`
- pre-commit runtime-contract tests, static checks, and packaging dry-run

## Notes
- Refs #417.
- Does not touch #422 Prosoche `/attend` condition-compiler work.
- Static verification still reports existing warnings for Prothesis `Horizontverschmelzung` and Korean text in `.claude/principles/hermeneutic-cycle.md` plus the built dist asset.
