### PR TITLE
feat(prothesis): 평가 방법론 참조 추가

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.31",
+  "version": "5.17.32",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.codex-plugin/plugin.json
+++ b/prothesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prothesis",
-  "version": "5.17.31",
+  "version": "5.17.32",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
   "author": {
     "name": "Jongwon Choi",

--- a/prothesis/skills/frame/references/agent-teams-bp-applicability.md
+++ b/prothesis/skills/frame/references/agent-teams-bp-applicability.md
@@ -2,6 +2,8 @@
 
 Not all agent-teams best practices apply uniformly across Prothesis phases. This reference table maps which BPs are active, intentionally restricted, or not yet applicable at each phase — preventing compliance frame mismatch when evaluating phase-specific sessions.
 
+Use [`evaluation-methodology.md`](./evaluation-methodology.md) for the multi-session evaluation method and hidden-assumption checks that determine how this table should be applied.
+
 | Best Practice | Phase 0-2 (Setup) | Phase 3 (Theoria) | Phase 4-5 (Cross-Dialogue + Synthesis + Routing) |
 |---------------|-------------------|-------------------|----------------------|
 | BP1: Context in spawn prompts | — | **Active** (Mission Brief in prompt) | — |

--- a/prothesis/skills/frame/references/evaluation-methodology.md
+++ b/prothesis/skills/frame/references/evaluation-methodology.md
@@ -1,0 +1,79 @@
+# Prothesis Evaluation Methodology
+
+This reference defines how to evaluate Prothesis when its specialized epistemic behavior differs from generic agent-team best-practice compliance. Use it together with [`agent-teams-bp-applicability.md`](./agent-teams-bp-applicability.md), which marks which best practices are active, restricted, environment-dependent, or not applicable by phase.
+
+## Evaluation Unit
+
+Evaluate a Prothesis run as a phase-scoped protocol trace, not as a generic agent-team session snapshot.
+
+Minimum trace record:
+
+- input deficit: whether the user actually presented `FrameworkAbsent`
+- selected mode: Recommend or Inquire
+- phase path: Phase 0 through terminal phase reached
+- perspective set: options presented, selected perspectives, and rationale
+- team behavior when Inquire mode is used
+- synthesis output: Lens, convergence/divergence, routing, and residual uncertainties
+- verification signals: user recognition, follow-up correction, review findings, or downstream protocol fit
+
+## Multi-Session Method
+
+Do not judge the whole protocol from one execution path. Sample across at least these shapes before making a protocol-level claim:
+
+- Recommend mode with a lightweight framing request
+- Inquire mode with distinct selected perspectives
+- high-ambiguity request where perspective selection is the main value
+- high-complexity request where synthesis quality is the main value
+- a case where a best practice is intentionally restricted by the applicability table
+
+Session-level findings may justify a local patch, but claims about Prothesis as a protocol require cross-session recurrence or a structural proof tied to the formal block.
+
+## Specialized-Use Criteria
+
+Generic agent-team best practices are evidence only after phase applicability is established.
+
+| Criterion | Evaluation question |
+|---|---|
+| Phase applicability | Is the best practice active, restricted, environment-dependent, or not applicable for this phase? |
+| Epistemic purpose | Does the observed behavior help resolve `FrameworkAbsent` into `FramedInquiry`? |
+| Isolation warrant | If communication is restricted, does the restriction preserve independent perspective formation? |
+| Synthesis warrant | Does cross-dialogue or synthesis integrate findings without flattening perspective differences? |
+| Recognition burden | Did the user need only to recognize suitable perspectives, or were they forced to invent the framework? |
+| Routing fit | Did the output point to the next appropriate protocol or execution path when framing alone was not enough? |
+
+## Hidden Assumptions To Check
+
+### Completeness = Quality
+
+Completeness is not sufficient evidence of quality. A Prothesis output is good when it exposes the load-bearing perspectives needed for the user's inquiry and preserves meaningful divergence. Exhaustive perspective lists can lower quality if they dilute the user's recognition task.
+
+### Session Representativeness
+
+A single trace is not representative by default. Mode, stakes, ambiguity, and selected perspectives change the relevant evaluation criteria. Treat one-session critiques as instance findings unless the same failure recurs or the formal block makes the defect inevitable.
+
+### Cost = Tokens
+
+Token usage is only one cost surface. Also evaluate recognition burden, review burden, unnecessary team coordination, false-positive perspective inflation, and downstream rework prevented by better framing.
+
+### No Communication = Isolation Failure
+
+No communication is not automatically a failure. In Phase 3, isolation can be intentional because independent perspectives reduce premature convergence. Use the applicability table before applying cross-team communication expectations.
+
+### Static Snapshot Evaluation
+
+Static snapshots miss whether Prothesis correctly routes, corrects, or preserves residual uncertainty over the loop. Evaluate the phase trace plus follow-up signals: user recognition, reviewer challenges, downstream protocol fit, and whether a later session had to re-derive the same framing.
+
+## Verdict Structure
+
+Use this shape for review notes:
+
+```text
+Scope: [phase/mode/session set]
+Applicability basis: [active/restricted/environment-dependent/not applicable, with table row]
+Finding: [observed behavior]
+Protocol relevance: [effect on FrameworkAbsent -> FramedInquiry]
+Evidence: [trace citation or repeated-session pattern]
+Disposition: [local issue / protocol patch / no action / needs more sessions]
+```
+
+Avoid verdicts that say only "violates agent-team best practice." The missing step is whether that practice applies to the Prothesis phase under evaluation.


### PR DESCRIPTION
## 요약

- Prothesis 평가를 generic agent-team best-practice compliance로 바로 환원하지 않도록 `evaluation-methodology.md` reference를 추가했습니다.
- 기존 `agent-teams-bp-applicability.md`에서 새 방법론을 링크해, phase별 active/restricted/not-applicable 판정과 multi-session 평가를 함께 사용하도록 했습니다.
- 런타임 `SKILL.md`의 endpoint/phase 구조는 변경하지 않았습니다.
- packaged reference가 늘었기 때문에 Prothesis plugin version을 `5.17.32`로 올렸습니다.

Closes #433

## Dispatch category

- Category: Specialized evaluation methodology
- Issue: #433
- Category rationale: Prothesis의 northstar-aligned 역할은 `FrameworkAbsent → FramedInquiry`를 성립시키는 관점 표면화입니다. 따라서 generic agent-team BP는 phase applicability가 확인된 뒤에만 평가 근거가 됩니다.

## PremiseTrace

| Issue | existence_status | axis_selection | substrate_citations |
|---|---|---|---|
| #433 | Current repo already had `prothesis/skills/frame/references/agent-teams-bp-applicability.md`, but no evaluation methodology surface under `prothesis/skills/frame/references/` or `docs/` matching this scope. | Selected a non-runtime-critical reference file adjacent to the applicability table, with a backlink from the table. Did not edit `SKILL.md` because the issue asks for documentation unless runtime behavior changes. | #433 body: “Add or update a documentation surface that is not runtime-critical `SKILL.md` prose”; existing `agent-teams-bp-applicability.md`; new `evaluation-methodology.md`. |

## 검증

- `node --test scripts/package.test.js`
- `node .claude/skills/verify/scripts/static-checks.js .`
- `node scripts/package.js --dry-run`
- `git diff --check`

Static/package warnings are pre-existing guideline warnings: long `epistemic-cooperative` descriptions, `prosoche`/`prothesis` Skill.md line-count guidelines, and existing static-check warnings for Prothesis `Horizontverschmelzung`, Korean text in `.claude/principles/hermeneutic-cycle.md`, and `dist-site`.
