### PR TITLE
feat(epistemic-cooperative): codex exec 호출에 --ephemeral 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/goal-research/SKILL.md
+++ b/epistemic-cooperative/skills/goal-research/SKILL.md
@@ -54,7 +54,7 @@ Report:
 Launch via `Bash(run_in_background: true, timeout: 1000000)`:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.5 \
+codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 \
   --config model_reasoning_effort="high" \
   --config mcp_servers.tavily.tool_timeout_sec=900 \
   < /tmp/goal_research_${SUFFIX}.txt

--- a/epistemic-cooperative/skills/review-ensemble/SKILL.md
+++ b/epistemic-cooperative/skills/review-ensemble/SKILL.md
@@ -68,7 +68,7 @@ End with: VERDICT: approve | needs-attention
 
 Run via `Bash(run_in_background: true, timeout: 300000)`:
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
+codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_review_${SUFFIX}.txt
 ```
 
 **Optional: codex-adversarial** — If the user requests adversarial review or the change is large/architectural, also launch an adversarial prompt in background using a distinct temp file `/tmp/ensemble_codex_adversarial_${SUFFIX}.txt` (same `SUFFIX`, different filename) so the adversarial runner does not overwrite or re-read the standard review prompt:
@@ -97,7 +97,7 @@ End with: VERDICT: approve | needs-attention
 
 Execute with `Bash(run_in_background: true, timeout: 300000)`:
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
+codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" --sandbox read-only < /tmp/ensemble_codex_adversarial_${SUFFIX}.txt
 ```
 
 ### Step 2: Invoke /frame Mode 2 (foreground, interactive)


### PR DESCRIPTION
## 요약

`epistemic-cooperative`의 `codex exec` 호출 3건에 `--ephemeral` 플래그를 추가합니다.

`--ephemeral`은 codex 세션 파일을 디스크에 영속화하지 않는 옵션입니다. 해당 호출들은 모두 일회성 명령이고 `resume`을 사용하지 않으므로 세션 영속화가 불필요합니다.

## 변경 내역

| 파일 | 위치 | 변경 |
|---|---|---|
| `skills/goal-research/SKILL.md` | Phase 2 launch 명령 | `codex exec --ephemeral --skip-git-repo-check ...` |
| `skills/review-ensemble/SKILL.md` | standard review 명령 | `codex exec --ephemeral ... --sandbox read-only` |
| `skills/review-ensemble/SKILL.md` | adversarial review 명령 | `codex exec --ephemeral ... --sandbox read-only` |
| `.claude-plugin/plugin.json` | version | `2.20.8` → `2.20.9` |

## 비고

- `--ephemeral`(세션 영속성 제어)과 `--sandbox`(네트워크 격리 제어)는 별개 축입니다. goal-research의 `--sandbox` 생략 관련 주석은 그대로 유효하며 수정하지 않았습니다.
- `node .claude/skills/verify/scripts/static-checks.js .` 통과 (`fail: []`; 잔여 warning은 기존 무관 항목).
