### PR TITLE
fix(curses): dual-interpretation 게이트 옵션 순서 strategy-first로 재정렬

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
-  "version": "2.20.9",
+  "version": "2.20.10",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.20.9",
+  "version": "2.20.10",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/curses/SKILL.md
+++ b/epistemic-cooperative/skills/curses/SKILL.md
@@ -119,14 +119,14 @@ this distinction. In cold-start sessions, the AI must proactively surface both
 interpretations before the user validates.
 
 Patterns that require dual-interpretation:
-- **D5 high + D6 high**: Could be "KK neglect via over-delegation" OR "deliberate
-  Extended Mind strategy with quality bridges"
-- **D2 high + D4 high**: Could be "cure-as-disease accumulation" OR "systematic
-  verification infrastructure that scales"
+- **D5 high + D6 high**: Could be "deliberate Extended Mind strategy with quality
+  bridges" OR "KK neglect via over-delegation"
+- **D2 high + D4 high**: Could be "systematic verification infrastructure that
+  scales" OR "cure-as-disease accumulation"
 
 For these dual-interpretation patterns specifically, retain a Constitution gate
-before downstream derivation: "This pattern admits two readings — [curse
-interpretation] or [strategy interpretation]. Which better describes your
+before downstream derivation: "This pattern admits two readings — [strategy
+interpretation] or [curse interpretation]. Which better describes your
 experience?" The user's intent here is project-profile category (a) — user IS
 the measurement target — and cannot be auto-resolved regardless of profile;
 downstream recommendations depend on this choice. Single-interpretation pairs


### PR DESCRIPTION
## 변경

curses skill의 dual-interpretation 게이트 패턴 예시 및 게이트 예문에서 옵션 순서를 swap. cost/curse interpretation이 첫 옵션이었던 것을 strategy interpretation을 첫 옵션으로 변경.

- D5 high + D6 high 패턴: "deliberate Extended Mind strategy with quality bridges" → "KK neglect via over-delegation"
- D2 high + D4 high 패턴: "systematic verification infrastructure that scales" → "cure-as-disease accumulation"
- 게이트 예문: "[strategy interpretation] or [curse interpretation]" 순서

## 근거

두 시점의 /curses 실행에서 AI가 차원 결합을 cost-default로 첫 옵션 제시 → 사용자가 매번 strategy로 재프레임하는 패턴이 재현됨:

- 2026-04-05 (708 sessions): D4+D2 누적을 "cure-as-disease"로, D6 극단을 "Delegation Dependency"로 첫 제시 → 사용자 재프레임
- 2026-05-20 (849 sessions): dual-interpretation 게이트 도입 후에도 옵션 1(curse)이 옵션 2(strategy)보다 먼저 제시되어 cost-bias 유지 → 사용자 재프레임 재발

옵션 순서를 strategy-first로 두면 자연어 first-anchor 효과가 사용자 운영 모드와 정렬되어 재프레임 부담이 감소함. 차원 결합이 의도된 전략인 경우(빈도 높음)에 인지부하를 줄임.

## 검증

- static-check pass (`node .claude/skills/verify/scripts/static-checks.js .`)
- plugin.json patch bump 포함
- 다음 /curses 사용자 세션에서 효과 검증 가능 (release 후 캐시 갱신 시점)

## 범위 외

- HTML 템플릿(`skills/curses/references/report-template.md`)의 option block에도 유사 cost-first 컨벤션 가능성 존재 — 별도 사이클에서 처리 예정.
- profiler 자체의 cost-frame signal 출력(예: "wrong_approach 28% friction")이 더 깊은 bias 원천일 가능성 — #452 열린 질문 3 참조.

Refs: #452
