### PR TITLE
feat(epistemic-cooperative): add /image-companion skill

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
-  "version": "2.20.11",
+  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+  "version": "2.20.12",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.20.11",
-  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
+  "version": "2.20.12",
+  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
@@ -17,8 +17,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Epistemic Cooperative",
-    "shortDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
-    "longDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, and /forge. See each skill's SKILL.md for details.",
+    "shortDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+    "longDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
     "developerName": "Jongwon Choi",
     "category": "Productivity",
     "capabilities": [

--- a/epistemic-cooperative/skills/image-companion/SKILL.md
+++ b/epistemic-cooperative/skills/image-companion/SKILL.md
@@ -24,13 +24,14 @@ the defining duty is that they read as one set. Visual consistency is a first-cl
 responsibility, not an afterthought.
 
 You orchestrate two existing skills and add the human-judgment and quality layers around
-them. You do **not** reimplement grounding, prompt-schema filling, or the codex runner.
+them. Delegate grounding to /forge and generation to the Codex CLI; your own role is the
+metaphor design, the human gate, verification, and series coherence.
 
 ```
 bind artifact + passage
   → (recommended) metaphor preview gate   ← human picks the visual idea cheaply
   → /forge   (grounding + gpt-image prompt block)        [DELEGATE]
-  → codex-plus:codex   (gpt-image-2 generation)          [DELEGATE]
+  → Codex CLI   (gpt-image-2 generation)                 [DELEGATE]
   → verify + enforce series coherence + report
 ```
 
@@ -109,8 +110,8 @@ codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 \
 
 For multiple images, launch one background call per image in the same turn so they run in
 parallel. Each completion sends a notification — then read the output from the completed
-background task and `rm -f /tmp/image_companion_${SUFFIX}.txt`. Do not poll or sleep;
-wait for the notification.
+background task and `rm -f /tmp/image_companion_${SUFFIX}.txt`. Wait for the completion
+notification before reading output.
 
 Running in the background keeps Codex's verbose banner out of the main context. The model
 (`-m gpt-5.5`) is fixed by design — Codex substitutes its own internal image skill
@@ -127,7 +128,7 @@ companion set's contract (two brand colors + exactly one reserved accent for the
 emphasized moment).
 
 Then produce a Korean consolidated report using the template in
-`references/verification.md`: a SESSION_ID table, the per-image verdict, and any
+`references/verification.md`: a table with image, filename, and verdict, plus any
 non-fatal warnings (e.g., auth-token refresh notices, deprecation notices) so the user
 sees the full picture without reading raw codex output.
 

--- a/epistemic-cooperative/skills/image-companion/SKILL.md
+++ b/epistemic-cooperative/skills/image-companion/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: image-companion
+description: >-
+  A symbolic slide image for a document passage, consistent with the artifact's companion
+  images. Triggers on "이 부분 상징화", "슬라이드 다이어그램", or a request for a diagram/symbol.
+  Composes /forge + Codex.
+skills:
+  - epistemic-cooperative:forge
+---
+
+# Image Companion
+
+Invoke with `/image-companion` (or whenever the user wants a slide-ready image for a
+passage in a document they are working on).
+
+Supply images that **belong to one artifact**. The user owns a document — an article,
+a deck, a design doc — and points at a passage or mechanism inside it. Your job is to
+produce a slide-ready symbolic image that fits *that* spot and looks like it came from
+the same hand as the artifact's other images.
+
+This is not a one-shot "make an image" tool. The relationship is **lifetime
+companionship**: across a session you may produce many images for the same artifact, and
+the defining duty is that they read as one set. Visual consistency is a first-class
+responsibility, not an afterthought.
+
+You orchestrate two existing skills and add the human-judgment and quality layers around
+them. You do **not** reimplement grounding, prompt-schema filling, or the codex runner.
+
+```
+bind artifact + passage
+  → (recommended) metaphor preview gate   ← human picks the visual idea cheaply
+  → /forge   (grounding + gpt-image prompt block)        [DELEGATE]
+  → codex-plus:codex   (gpt-image-2 generation)          [DELEGATE]
+  → verify + enforce series coherence + report
+```
+
+## Step 0 — Bind the artifact and the target
+
+Read the artifact passage the user is pointing at. Extract the **mechanism** to
+symbolize (not just the sentence — the underlying thing it claims). This is per-call
+data; nothing here is fixed.
+
+Then locate the **companion set**: other images already made for this artifact (same
+output directory, or earlier in this session). Their palette, tone, and text rules are
+the consistency contract for the new image. If this is the first image, you are
+*establishing* the contract — record the choices so later calls inherit them.
+
+Carry the design-tone context forward by continuing in the same session. Compaction
+preserves it; that is how series coherence survives a long-running artifact.
+
+## Step 1 — Metaphor preview gate (recommended, not required)
+
+Image generation costs real time and money. Before spending it, agree on the visual
+idea in plain text. This step is **recommended** — skip it only when the user has
+already named the exact metaphor.
+
+1. Design 2–3 candidate metaphors for the mechanism. Keep them free of domain jargon
+   (no SQL/JOIN/INNER/OUTER, no internal API names *in the image*) so an all-hands
+   audience reads them at a glance.
+2. Sketch each candidate as small **ASCII art** and put it in the `preview` field of an
+   `AskUserQuestion` option, so the user compares the *ideas* in the terminal before any
+   pixels are generated.
+3. In the same gate, ask the **loss-depiction depth** when the passage describes a
+   failure/loss: neutral (mechanism only) vs. show-through-to-the-loss (depict the bad
+   outcome). This choice changes the image's punchline.
+
+The ASCII preview is a cheap proxy that has repeatedly de-risked the expensive step —
+treat it as the default, but don't force it on a user who already knows what they want.
+
+## Step 2 — Structure the initial prompt with /forge
+
+Invoke `epistemic-cooperative:forge` with the **gpt-image adapter**. Forge's job here is
+not just to "write a prompt" — it is to **structure the initial prompt so that the
+character extracted from the artifact is preserved**. Two things make up that character:
+the grounded essence of the passage (what the mechanism actually claims) and the
+companion set's identity (palette, tone, text rules). Forge encodes both into the
+structured prompt, so the prompt block itself becomes the carrier of artifact fidelity —
+not something checked back in afterward.
+
+Forge owns the reference grounding and fills the `infographic-diagram` prompt schema (Use
+case / Asset type / Primary request / Scene / Subject / Style / Composition / Lighting /
+Color palette / Text verbatim / Constraints / Avoid). Hand it: the artifact passage, the
+chosen metaphor, the loss-depth decision, and the house-style constraints from
+`references/house-style.md` (Step 0's companion-set reading is what makes those
+constraints concrete). You do not write the schema yourself — forge does.
+
+## Step 3 — Generate via Codex CLI
+
+Call the Codex CLI directly, in the same form as `/review-ensemble` and `/goal-research`.
+This runs gpt-image-2 generation as an independent model call.
+
+Check `which codex 2>/dev/null`. If the Codex CLI is not found, surface the
+missing-binary error and stop — failure modes are raw errors, not handled internally.
+
+Generate a unique suffix: `SUFFIX=$(openssl rand -hex 4)`. Write forge's prompt block to
+`/tmp/image_companion_${SUFFIX}.txt`. The prompt MUST be English and MUST include the
+`$imagegen` marker so Codex engages image generation.
+
+Launch via `Bash(run_in_background: true, timeout: 600000)`, with `--cd` pointing at the
+artifact's image directory so the PNG lands beside its companions:
+
+```bash
+codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 \
+  --config model_reasoning_effort="medium" \
+  --sandbox workspace-write \
+  --cd <artifact-image-dir> \
+  < /tmp/image_companion_${SUFFIX}.txt
+```
+
+For multiple images, launch one background call per image in the same turn so they run in
+parallel. Each completion sends a notification — then read the output from the completed
+background task and `rm -f /tmp/image_companion_${SUFFIX}.txt`. Do not poll or sleep;
+wait for the notification.
+
+Running in the background keeps Codex's verbose banner out of the main context. The model
+(`-m gpt-5.5`) is fixed by design — Codex substitutes its own internal image skill
+targeting gpt-image-2, so the model is structural, not a quality knob (see
+`references/house-style.md`). Note: `--ephemeral` means there is no resumable session — a
+correction is a fresh run with a corrective prompt, not a session resume.
+
+## Step 4 — Verify, enforce coherence, report
+
+Read the produced PNG and run the checklist in `references/verification.md`. The image
+fails review if in-image text is not the verbatim English/numeric strings, if any
+CJK/SQL/JOIN text appears, if it is not landscape, or if the palette breaks the
+companion set's contract (two brand colors + exactly one reserved accent for the single
+emphasized moment).
+
+Then produce a Korean consolidated report using the template in
+`references/verification.md`: a SESSION_ID table, the per-image verdict, and any
+non-fatal warnings (e.g., auth-token refresh notices, deprecation notices) so the user
+sees the full picture without reading raw codex output.
+
+## What stays fixed vs. what varies
+
+**Fixed discipline** (carry into every call — details in `references/house-style.md`):
+Codex CLI run in the background, output read on notification; in-image text
+English/numeric only; landscape; no SQL/JOIN jargon; two brand colors + one reserved
+accent; fixed model.
+
+**Per-call data** (never bake into the skill): the artifact path and target passage, the
+metaphor candidates, the loss-depth choice, the verbatim in-image strings, what the
+accent emphasizes, and the output filename.
+
+## Boundary
+
+This skill forms and verifies; it delegates grounding to /forge and runs generation as a
+background Codex CLI call. It does not open branches or PRs.

--- a/epistemic-cooperative/skills/image-companion/SKILL.md
+++ b/epistemic-cooperative/skills/image-companion/SKILL.md
@@ -2,7 +2,7 @@
 name: image-companion
 description: >-
   A symbolic slide image for a document passage, consistent with the artifact's companion
-  images. Triggers on "이 부분 상징화", "슬라이드 다이어그램", or a request for a diagram/symbol.
+  images. Use when the user wants a diagram or visual symbol for a section.
   Composes /forge + Codex.
 skills:
   - epistemic-cooperative:forge
@@ -127,7 +127,7 @@ CJK/SQL/JOIN text appears, if it is not landscape, or if the palette breaks the
 companion set's contract (two brand colors + exactly one reserved accent for the single
 emphasized moment).
 
-Then produce a Korean consolidated report using the template in
+Then produce a consolidated report in the user's language using the template in
 `references/verification.md`: a table with image, filename, and verdict, plus any
 non-fatal warnings (e.g., auth-token refresh notices, deprecation notices) so the user
 sees the full picture without reading raw codex output.

--- a/epistemic-cooperative/skills/image-companion/references/house-style.md
+++ b/epistemic-cooperative/skills/image-companion/references/house-style.md
@@ -1,0 +1,60 @@
+# House Style Discipline
+
+These are the constraints that make a set of images read as one artifact's voice. Apply
+them to every image; pass them into `/forge` as the `Constraints` / `Avoid` / `Color
+palette` material.
+
+## Why each rule exists
+
+Understanding the reason lets you adapt the rule to a new artifact instead of copying it
+blindly.
+
+### In-image text: English / numeric only
+
+gpt-image-2 renders CJK glyphs unreliably — Korean text in the image often comes out
+garbled or invented. So keep every in-image string to short Latin/numeric tokens that
+the model renders cleanly, and add the Korean slide copy later in the deck, outside the
+image. List the exact strings as the `Text (verbatim)` field so forge constrains the
+model to them and nothing else.
+
+### No SQL / JOIN / internal jargon in the image
+
+The images are usually for an all-hands or cross-functional audience. Words like
+`JOIN`, `INNER`, `OUTER`, `SQL`, or internal API/emitter names defeat the "intuitive at a
+glance" goal and read as engineer-only. Symbolize the *mechanism* with an everyday
+metaphor instead. Put these words in the `Avoid` list explicitly — the model will
+otherwise label diagram parts with them.
+
+### Landscape aspect
+
+These are slide assets. Landscape composition leaves room for slide copy above/below and
+matches deck geometry.
+
+### Two brand colors + exactly one reserved accent
+
+A set reads as one set when its palette is disciplined: two brand/identity colors carry
+the structure, and **one** warm accent (amber/orange) is reserved for the single
+emphasized moment — the loss, the reveal, the punchline. Spending the accent on more than
+one thing per image dilutes the emphasis and breaks set consistency.
+
+The *specific* colors are per-artifact data, not part of the discipline. For the
+ring_alarm series the contract was: Amplitude purple `#6838b0`, Snowplow blue `#0060c8`,
+neutral grays on near-white, and amber reserved for the unsent/loss moment. A different
+artifact will have different brand colors — read them off the existing companion images
+and reuse them; only the "two + one-accent" *structure* is fixed.
+
+### Fixed model (not a tunable)
+
+The Codex image path substitutes its own internal `imagegen` skill, which targets
+`gpt-image-2`. So the model choice is structural, not a quality knob you sweep. Settle it
+once on the `codex exec -m gpt-5.5` call and keep it stable across the set — changing it
+mid-series risks a visible style break, which is exactly what series coherence forbids.
+
+## Series coherence is first-class
+
+Before generating a new image, read the companion images already made for the same
+artifact (same output directory, or earlier in this session). Their palette, accent
+choice, icon style (flat line icons, no 3D/photorealism), and text conventions are the
+contract the new image must satisfy. When you are making the *first* image, you are
+setting that contract — state the choices explicitly so later calls in the session
+inherit them through the carried context.

--- a/epistemic-cooperative/skills/image-companion/references/house-style.md
+++ b/epistemic-cooperative/skills/image-companion/references/house-style.md
@@ -37,11 +37,9 @@ the structure, and **one** warm accent (amber/orange) is reserved for the single
 emphasized moment — the loss, the reveal, the punchline. Spending the accent on more than
 one thing per image dilutes the emphasis and breaks set consistency.
 
-The *specific* colors are per-artifact data, not part of the discipline. For the
-ring_alarm series the contract was: Amplitude purple `#6838b0`, Snowplow blue `#0060c8`,
-neutral grays on near-white, and amber reserved for the unsent/loss moment. A different
-artifact will have different brand colors — read them off the existing companion images
-and reuse them; only the "two + one-accent" *structure* is fixed.
+The *specific* colors are per-artifact data, not part of the discipline. Each artifact has
+its own brand colors — read them off the existing companion images and reuse them; only
+the "two + one-accent" *structure* is fixed.
 
 ### Fixed model (not a tunable)
 

--- a/epistemic-cooperative/skills/image-companion/references/house-style.md
+++ b/epistemic-cooperative/skills/image-companion/references/house-style.md
@@ -11,10 +11,10 @@ blindly.
 
 ### In-image text: English / numeric only
 
-gpt-image-2 renders CJK glyphs unreliably — Korean text in the image often comes out
-garbled or invented. So keep every in-image string to short Latin/numeric tokens that
-the model renders cleanly, and add the Korean slide copy later in the deck, outside the
-image. List the exact strings as the `Text (verbatim)` field so forge constrains the
+gpt-image-2 renders CJK glyphs unreliably — Korean/Japanese/Chinese text in the image
+often comes out garbled or invented. So keep every in-image string to short Latin/numeric
+tokens that the model renders cleanly, and add the localized slide copy later in the deck,
+outside the image. List the exact strings as the `Text (verbatim)` field so forge constrains the
 model to them and nothing else.
 
 ### No SQL / JOIN / internal jargon in the image

--- a/epistemic-cooperative/skills/image-companion/references/verification.md
+++ b/epistemic-cooperative/skills/image-companion/references/verification.md
@@ -21,10 +21,9 @@ regenerate with a corrective note rather than shipping.
    stroke style consistent with the companion images.
 6. **Reads at a glance** — the single intended punchline is obvious without explanation.
 
-When a regeneration is needed, give codex a targeted corrective note (what specifically
-to change) rather than a full rewrite — this matches how the runs self-corrected in
-practice (e.g. "remove the stray 'ready'/'time' labels"; "use text-only labels, no
-brand-like icons").
+When a regeneration is needed, give codex a targeted corrective note naming what
+specifically to change, rather than a full rewrite — this matches how runs self-correct
+in practice.
 
 ## Korean consolidated report template
 

--- a/epistemic-cooperative/skills/image-companion/references/verification.md
+++ b/epistemic-cooperative/skills/image-companion/references/verification.md
@@ -1,0 +1,56 @@
+# Verification & Report
+
+Read the produced PNG and check it against the contract before declaring it done. The
+goal is to catch the failure modes gpt-image-2 actually produces, not to rubber-stamp.
+
+## Per-image checklist
+
+Read the image and confirm each point. A "no" on any of the first four is a fail —
+regenerate with a corrective note rather than shipping.
+
+1. **Verbatim text** — every in-image string is one of the agreed English/numeric tokens,
+   spelled correctly, and legible. No invented labels, no stray words from a different
+   image's spec.
+2. **No CJK / no jargon** — no Korean or other CJK glyphs anywhere; none of the avoided
+   words (`JOIN`, `INNER`, `OUTER`, `SQL`, internal API/emitter names) appear.
+3. **Landscape** — wide aspect, with breathing room for slide copy.
+4. **Palette contract** — the two brand colors match the companion set; the warm accent
+   appears on **exactly one** emphasized element (the loss / reveal / punchline), nowhere
+   else.
+5. **Style match** — flat line icons, no 3D/photorealism, no logos/watermarks; icon and
+   stroke style consistent with the companion images.
+6. **Reads at a glance** — the single intended punchline is obvious without explanation.
+
+When a regeneration is needed, give codex a targeted corrective note (what specifically
+to change) rather than a full rewrite — this matches how the runs self-corrected in
+practice (e.g. "remove the stray 'ready'/'time' labels"; "use text-only labels, no
+brand-like icons").
+
+## Korean consolidated report template
+
+After the image(s) pass, report to the user in Korean. Keep it scannable.
+
+```
+## ◆ <묶음 이름> — 검증 결과
+
+| 이미지 | 파일 | 판정 |
+|---|---|---|
+| <은유/역할> | <…-name.png> | 통과 / 재생성 N회 후 통과 |
+
+**판정 근거 (이미지별)**: <핵심 문구 verbatim 렌더 ✓ / CJK·SQL 부재 ✓ / landscape ✓ / 팔레트 정합 ✓>
+
+**시리즈 정렬**: <이 이미지가 동반 자산과 어떻게 한 세트로 읽히는지 한 줄>
+
+**비고 (비치명적)**: <자기교정 재시도 횟수와 이유 / MCP 토큰 갱신 경고(invalid_grant) / --full-auto deprecation 등 — 이미지 생성에는 무관>
+```
+
+The non-fatal notes matter: codex runs routinely emit an `invalid_grant` auth-token
+refresh warning on unrelated MCP servers and a `--full-auto` deprecation notice. Surface
+them as harmless so the user isn't left wondering, but don't treat them as failures.
+
+## Correction
+
+The generation call is `--ephemeral`, so there is no session to resume. A correction is a
+**fresh background `codex exec` run** with a corrective prompt (state exactly what to
+change). Reuse the same `--cd` and filename so the corrected image overwrites its
+predecessor in place and stays in the companion set.

--- a/epistemic-cooperative/skills/image-companion/references/verification.md
+++ b/epistemic-cooperative/skills/image-companion/references/verification.md
@@ -25,22 +25,23 @@ When a regeneration is needed, give codex a targeted corrective note naming what
 specifically to change, rather than a full rewrite — this matches how runs self-correct
 in practice.
 
-## Korean consolidated report template
+## Consolidated report template
 
-After the image(s) pass, report to the user in Korean. Keep it scannable.
+After the image(s) pass, report to the user in their working language. Keep it scannable.
+The labels below are illustrative — render them in whatever language the user is using.
 
 ```
-## ◆ <묶음 이름> — 검증 결과
+## ◆ <set name> — verification
 
-| 이미지 | 파일 | 판정 |
+| image | file | verdict |
 |---|---|---|
-| <은유/역할> | <…-name.png> | 통과 / 재생성 N회 후 통과 |
+| <metaphor / role> | <…-name.png> | pass / pass after N regenerations |
 
-**판정 근거 (이미지별)**: <핵심 문구 verbatim 렌더 ✓ / CJK·SQL 부재 ✓ / landscape ✓ / 팔레트 정합 ✓>
+**Per-image basis**: <verbatim strings render ✓ / no CJK·SQL ✓ / landscape ✓ / palette consistent ✓>
 
-**시리즈 정렬**: <이 이미지가 동반 자산과 어떻게 한 세트로 읽히는지 한 줄>
+**Series fit**: <one line on how this image reads as one set with its companions>
 
-**비고 (비치명적)**: <자기교정 재시도 횟수와 이유 / MCP 토큰 갱신 경고(invalid_grant) / --full-auto deprecation 등 — 이미지 생성에는 무관>
+**Notes (non-fatal)**: <self-correction retries and why / MCP token-refresh warning (invalid_grant) / --full-auto deprecation — unrelated to image generation>
 ```
 
 The non-fatal notes matter: codex runs routinely emit an `invalid_grant` auth-token

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -206,7 +206,7 @@ describe('transformSkillMd', () => {
 describe('runtime contract view', () => {
   it('builds a packaged runtime view for every skill', () => {
     const views = buildRuntimeContractViews();
-    assert.equal(views.length, 31);
+    assert.equal(views.length, 32);
     for (const view of views) {
       assert.equal(view.skillEntryCount, 1, `${view.plugin}:${view.skill} should have one Skill.md entry`);
       assert.ok(view.transformedSkillMd, `${view.plugin}:${view.skill} should expose transformed Skill.md`);
@@ -503,7 +503,7 @@ describe('generate-changelog.js CLI', () => {
 // ============================================================
 
 describe('package.js CLI', () => {
-  it('packages all 31 skills plus bundle in dry-run', () => {
+  it('packages all 32 skills plus bundle in dry-run', () => {
     const output = execFileSync(process.execPath, [path.join(__dirname, 'package.js'), '--dry-run'], {
       encoding: 'utf8',
     });
@@ -516,7 +516,7 @@ describe('package.js CLI', () => {
     // surfacing the cause — this filter catches that specific failure mode.
     const anamnesisWarnings = result.warnings.filter(w => /anamnesis|recollect/.test(w));
     assert.deepEqual(anamnesisWarnings, [], 'no anamnesis/recollect packaging warnings');
-    assert.equal(result.results.length, 32);
+    assert.equal(result.results.length, 33);
     assert.deepEqual(
       result.results.map(entry => entry.zip).sort(),
       [
@@ -537,6 +537,7 @@ describe('package.js CLI', () => {
         'goal-research.zip',
         'grasp.zip',
         'ground.zip',
+        'image-companion.zip',
         'induce.zip',
         'inquire.zip',
         'introspect.zip',


### PR DESCRIPTION
## 요약
`epistemic-cooperative`에 `/image-companion` 스킬을 추가합니다 — 하나의 대상 아티팩트(문서·덱)에 종속되어, 사용자가 가리킨 구절에 맞는 슬라이드용 상징 이미지를 동반 이미지와 일관되게 공급하는 오케스트레이션 스킬입니다. `/forge`(grounding + 프롬프트 구조화)와 Codex CLI 이미지 생성(`codex exec --ephemeral`, `/review-ensemble`·`/goal-research`와 동형)을 조립하며, 직접 재구현하지 않습니다. `/induce`로 이번 세션의 반복 7장 워크플로에서 결정화했습니다.

## 파이프라인
1. (권장) ASCII 은유 프리뷰 게이트 — 생성 비용 전 텍스트로 은유·손실깊이 합의
2. `/forge` 호출 — 아티팩트에서 추출된 성격(grounding된 본질 + 동반 세트 팔레트/톤)을 프롬프트에 보존
3. Codex CLI 이미지 생성 (백그라운드, `--ephemeral`)
4. 검증 + 시리즈 정합 강제 + 한국어 통합 리포트

## 변경
- 신규 스킬: `SKILL.md` + `references/house-style.md` + `references/verification.md`
- 버전 범프 `2.20.11 → 2.20.12` (`.claude-plugin` + `.codex-plugin` 동기)
- plugin 설명에 `/image-companion` 라우팅 cue 추가
- `scripts/package.test.js` 런타임-컨트랙트 카운트 `31→32` 및 zip 목록에 `image-companion` 등록

## 테스트
- pre-commit 훅 통과: `package.test.js` 49/49, static-checks EXIT 0, 패키징 dry-run 0

## 비고
- 잔여 non-blocking warn 2건: ① description의 한국어 트리거 cue(의도적 — 한국어 사용 환경 트리거), ② plugin description 200자 초과(기존부터 존재하던 사항)
