### PR TITLE
fix(release): 릴리스 내러티브 포맷을 이전 릴리스 패턴에 정렬

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -77,7 +77,7 @@ Draft narrative using this template (Korean, matching repo's PR body convention)
 ```
 > **Background**
 >
-> {experiential / contextual narrative — the lived origin and why this release matters; 1-3 paragraphs. No theme sentence here — Background is pure context.}
+> {experiential / contextual narrative — the lived origin and why this release matters; 1-3 paragraphs. Background IS pure context — the theme sentence belongs in the 무엇이 새로운가요? section below.}
 >
 > ---
 >
@@ -95,7 +95,14 @@ Draft narrative using this template (Korean, matching repo's PR body convention)
 {script-generated body, with its leading `# Epistemic Protocols vX` H1 line removed so it starts at `## Highlights`}
 ```
 
-The narrative splits into two blockquoted sections matching the repo's prior-release convention: a **Background** section (pure experiential/contextual narrative — the lived origin) and a **무엇이 새로운가요?** section that leads with the theme sentence and then the bullets. The two sections are separated by an in-blockquote divider (`> ---`), and a second in-blockquote divider closes the narrative before the script body. The script body's leading `# Epistemic Protocols vX` H1 is stripped: the GitHub release title already renders the version, so a body H1 would surface a duplicate title. After stripping, the body begins at `## Highlights`.
+The narrative splits into two blockquoted sections, matching the repo's prior-release convention:
+
+- **Background** — pure experiential/contextual narrative (the lived origin). The label is intentionally English `**Background**`: a grandfathered exception to the Korean-narrative convention, carried forward from earlier releases (`v2026.05.18`, `v2026.05.15`) for visual continuity. The change-section label `**무엇이 새로운가요?**` stays Korean.
+- **무엇이 새로운가요?** — leads with the theme sentence (`이번 릴리스의 핵심은 **{theme}** — ...`), then the change bullets.
+
+Both sections, and the close before the script body, are bounded by in-blockquote dividers (`> ---`). Each `> ---` must be preceded by a blank `>` line: in CommonMark a `---` placed flush against paragraph text parses as a setext H2 underline, which would render the preceding line as a heading instead of a divider — the blank `>` line keeps it a thematic break.
+
+The script body's leading `# Epistemic Protocols vX` H1 is stripped: the GitHub release title already renders the version, so a body H1 would surface a duplicate title. After stripping, the body begins at `## Highlights`.
 
 Emoji selection is descriptive: choose an emoji whose visual semantic matches the change class. The same change class may take different emoji across releases — match the release's framing, not a fixed table.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -75,18 +75,27 @@ After enumeration, draft narrative using the axis the agent judges best-fit; the
 Draft narrative using this template (Korean, matching repo's PR body convention):
 
 ```
-> 이번 릴리스의 핵심은 **{theme}** — {one sentence explaining why this release matters}.
+> **Background**
+>
+> {experiential / contextual narrative — the lived origin and why this release matters; 1-3 paragraphs. No theme sentence here — Background is pure context.}
+>
+> ---
 >
 > **무엇이 새로운가요?**
+>
+> 이번 릴리스의 핵심은 **{theme}** — {one sentence summarizing the release}.
+>
 > - {emoji} **`/command`** 또는 **{feature name}** — {user-facing narrative, 1-2 sentences}
 > - {emoji} **...** — ...
 > - {emoji} **...** — ...
 > - {emoji} **...** — ...
+>
+> ---
 
----
-
-{script-generated body}
+{script-generated body, with its leading `# Epistemic Protocols vX` H1 line removed so it starts at `## Highlights`}
 ```
+
+The narrative splits into two blockquoted sections matching the repo's prior-release convention: a **Background** section (pure experiential/contextual narrative — the lived origin) and a **무엇이 새로운가요?** section that leads with the theme sentence and then the bullets. The two sections are separated by an in-blockquote divider (`> ---`), and a second in-blockquote divider closes the narrative before the script body. The script body's leading `# Epistemic Protocols vX` H1 is stripped: the GitHub release title already renders the version, so a body H1 would surface a duplicate title. After stripping, the body begins at `## Highlights`.
 
 Emoji selection is descriptive: choose an emoji whose visual semantic matches the change class. The same change class may take different emoji across releases — match the release's framing, not a fixed table.
 
@@ -94,7 +103,7 @@ Emoji selection is descriptive: choose an emoji whose visual semantic matches th
 
 **Context** (emit before the gate, as text output):
 - Theme axis enumeration when generated in Phase 4 — condense to a labels-only form (axis names without per-axis 4-tuple) and reference the Phase 4 detail above when full re-surfacing would bloat the gate context; otherwise re-surface in full. Either form preserves Recognition that the user may select a different axis than the one the agent drafted from.
-- Full composed body preview: narrative draft + `---` + script-generated body
+- Full composed body preview: narrative draft (closed with `> ---` inside the blockquote) + script-generated body with its leading `# Epistemic Protocols vX` H1 stripped (begins at `## Highlights`)
 - Theme sentence and bullet selection rationale
 
 **Experiential elicitation** (emit as part of context):
@@ -122,7 +131,7 @@ This gate is mandatory even if the narrative seems obvious — theme choice and 
 
 ### Phase 6: Apply + surface
 
-- Compose final body: narrative + `---` + CI body
+- Compose final body: narrative (closed with `> ---` inside the blockquote) + CI body with its leading `# Epistemic Protocols vX` H1 stripped (begins at `## Highlights`) — prevents a duplicate title alongside the GitHub release title
 - `gh release edit <tag> --notes-file <tmp-path>`
 - Output draft URL with a note that the user publishes manually via GitHub web UI
 


### PR DESCRIPTION
## 배경

`v2026.05.23` 릴리스 작성 중, `/release` 스킬이 생성한 본문이 이전 릴리스 포맷과 두 가지 지점에서 어긋났습니다.

1. **제목 중복** — script 생성 본문(`scripts/package.js`)의 leading H1 `# Epistemic Protocols vX`를 그대로 두어, GitHub 릴리스 제목과 합쳐 동일 제목이 두 번 렌더링됨
2. **섹션 구조 불일치** — 내러티브가 단일 블록이라, 이전 릴리스(`v2026.05.18`, `v2026.05.15`)의 두-섹션 구조(`Background` + `무엇이 새로운가요?`)와 다름

## 변경 사항

`.claude/skills/release/SKILL.md` Phase 4 템플릿을 이전 릴리스 패턴에 정렬:

- **두 섹션 재구성**: `**Background**`(순수 맥락/경험 내러티브, theme 문장 없음) + in-blockquote 구분선 `> ---` + `**무엇이 새로운가요?**`(theme 문장 선두 + bullets) + 닫는 `> ---`
- **H1 strip 명시**: script 본문의 leading `# Epistemic Protocols vX`를 제거해 `## Highlights`부터 시작 → 제목 중복 방지
- **문구 정합**: Phase 5 preview / Phase 6 compose 설명을 새 구조에 맞게 갱신

## 검증

- `v2026.05.23` draft 릴리스 본문을 동일 포맷으로 수정 완료(H1 0개, 두 섹션 + in-quote 구분선) — 이전 릴리스 구조와 일치 확인
- horizon-fusion 서브프로토콜 규약("Background는 Horizon B 흡수, bullets는 Horizon A 고정")과 정합: theme 문장이 Background에서 분리되어 What's New 선두로 이동

> 참고: `/release`는 프로젝트 로컬 유틸리티 스킬로 패키지 플러그인이 아니므로 plugin.json 버전 bump 대상이 아닙니다.
