### PR TITLE
feat(epistemic-cooperative): comment-review 모바일 미리보기 — 터치 선택 수정 + Tailscale 직접 접속

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.20.12",
+  "version": "2.20.13",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.20.13",
+  "version": "2.21.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.20.12",
+  "version": "2.20.13",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.20.13",
+  "version": "2.21.0",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/comment-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/comment-review/scripts/serve.ts
@@ -241,8 +241,33 @@ interface DeleteBody {
 
 const MAX_ID_LEN = 128;
 
+// When the tailscale CLI is present and the device is on a tailnet, return its
+// Tailscale IPv4 and MagicDNS name; otherwise null. Degrades silently on any
+// probe failure (CLI absent, logged out, unexpected JSON).
+function detectTailscale(): { ip: string; dnsName: string } | null {
+  const tsBin = Bun.which("tailscale");
+  if (!tsBin) return null;
+  try {
+    const proc = Bun.spawnSync([tsBin, "status", "--json"]);
+    if (proc.exitCode !== 0) return null;
+    const self = JSON.parse(proc.stdout.toString())?.Self;
+    const ip = (self?.TailscaleIPs ?? []).find((a: string) => /^\d+\.\d+\.\d+\.\d+$/.test(a));
+    if (!ip) return null; // tailscale present but not connected to a tailnet
+    return { ip, dnsName: (self?.DNSName ?? "").replace(/\.$/, "") };
+  } catch {
+    return null;
+  }
+}
+
+// Loopback keeps drafts/feedback strictly local. When tailscale is detected we
+// bind to the tailnet interface instead, exposing the preview to the user's own
+// tailnet devices (e.g. mobile) — a deliberate widening from loopback-private to
+// tailnet-private, scoped to that single interface (not 0.0.0.0/all networks).
+const tailnet = detectTailscale();
+const bindHost = tailnet ? tailnet.ip : "127.0.0.1";
+
 const server = Bun.serve({
-  hostname: "127.0.0.1", // bind to loopback only — drafts and feedback are user-private
+  hostname: bindHost,
   port: 0,
   async fetch(req, srv) {
     const url = new URL(req.url);
@@ -438,45 +463,15 @@ for (const [slug, path] of drafts) {
   });
 }
 
-// The server binds to 127.0.0.1 only, so a Tailscale IP:port cannot reach it
-// directly — `tailscale serve` (tailnet → loopback reverse proxy) is required.
-// Detect an active serve mapping for our port; otherwise print the exact enable
-// command (the port is OS-assigned, so it cannot be pre-configured). Degrades
-// silently when the tailscale CLI is absent or any probe fails.
-function tailscaleHint(port: number): string[] | null {
-  const tsBin = Bun.which("tailscale");
-  if (!tsBin) return null;
-  try {
-    const statusProc = Bun.spawnSync([tsBin, "status", "--json"]);
-    if (statusProc.exitCode !== 0) return null;
-    const dnsName = (JSON.parse(statusProc.stdout.toString())?.Self?.DNSName ?? "").replace(/\.$/, "");
-    if (!dnsName) return null; // tailscale present but device not on a tailnet
-
-    let served = false;
-    try {
-      const serveProc = Bun.spawnSync([tsBin, "serve", "status", "--json"]);
-      if (serveProc.exitCode === 0) {
-        const txt = serveProc.stdout.toString();
-        served = txt.includes(`127.0.0.1:${port}`) || txt.includes(`localhost:${port}`);
-      }
-    } catch { /* serve status unsupported on this version — fall through to hint */ }
-
-    if (served) return [`tailnet: https://${dnsName}/ (mobile-reachable via tailscale serve)`];
-    return [
-      `tailnet: not exposed. To reach from mobile over Tailscale, run:`,
-      `  tailscale serve --bg localhost:${port}`,
-      `  then open https://${dnsName}/`,
-    ];
-  } catch {
-    return null;
-  }
-}
-
-const url = `http://localhost:${server.port}/`;
+// Bound to the tailnet IP, the device reaches its own address locally, so this
+// URL also opens on this machine — no separate localhost URL needed.
+const url = `http://${bindHost}:${server.port}/`;
 console.error(`serving at ${url}`);
 console.error(`drafts: ${[...drafts.keys()].join(", ")}`);
-const tsLines = tailscaleHint(server.port);
-if (tsLines) for (const line of tsLines) console.error(line);
+if (tailnet) {
+  console.error(`tailnet: reachable from your tailnet devices (e.g. mobile) at ${url}`);
+  if (tailnet.dnsName) console.error(`  or via MagicDNS: http://${tailnet.dnsName}:${server.port}/`);
+}
 console.error("Ctrl-C to stop.");
 
 const opener = Bun.which("open") ?? Bun.which("xdg-open");

--- a/epistemic-cooperative/skills/comment-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/comment-review/scripts/serve.ts
@@ -438,9 +438,45 @@ for (const [slug, path] of drafts) {
   });
 }
 
+// The server binds to 127.0.0.1 only, so a Tailscale IP:port cannot reach it
+// directly — `tailscale serve` (tailnet → loopback reverse proxy) is required.
+// Detect an active serve mapping for our port; otherwise print the exact enable
+// command (the port is OS-assigned, so it cannot be pre-configured). Degrades
+// silently when the tailscale CLI is absent or any probe fails.
+function tailscaleHint(port: number): string[] | null {
+  const tsBin = Bun.which("tailscale");
+  if (!tsBin) return null;
+  try {
+    const statusProc = Bun.spawnSync([tsBin, "status", "--json"]);
+    if (statusProc.exitCode !== 0) return null;
+    const dnsName = (JSON.parse(statusProc.stdout.toString())?.Self?.DNSName ?? "").replace(/\.$/, "");
+    if (!dnsName) return null; // tailscale present but device not on a tailnet
+
+    let served = false;
+    try {
+      const serveProc = Bun.spawnSync([tsBin, "serve", "status", "--json"]);
+      if (serveProc.exitCode === 0) {
+        const txt = serveProc.stdout.toString();
+        served = txt.includes(`127.0.0.1:${port}`) || txt.includes(`localhost:${port}`);
+      }
+    } catch { /* serve status unsupported on this version — fall through to hint */ }
+
+    if (served) return [`tailnet: https://${dnsName}/ (mobile-reachable via tailscale serve)`];
+    return [
+      `tailnet: not exposed. To reach from mobile over Tailscale, run:`,
+      `  tailscale serve --bg localhost:${port}`,
+      `  then open https://${dnsName}/`,
+    ];
+  } catch {
+    return null;
+  }
+}
+
 const url = `http://localhost:${server.port}/`;
 console.error(`serving at ${url}`);
 console.error(`drafts: ${[...drafts.keys()].join(", ")}`);
+const tsLines = tailscaleHint(server.port);
+if (tsLines) for (const line of tsLines) console.error(line);
 console.error("Ctrl-C to stop.");
 
 const opener = Bun.which("open") ?? Bun.which("xdg-open");

--- a/epistemic-cooperative/skills/comment-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/comment-review/scripts/serve.ts
@@ -12,7 +12,7 @@
 //
 // Stop with Ctrl-C. No port collision: Bun.serve(port: 0) lets the OS pick.
 
-import { watch } from "node:fs";
+import { existsSync, watch } from "node:fs";
 import { appendFile, readdir, readFile } from "node:fs/promises";
 import { basename, dirname, extname, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -241,11 +241,29 @@ interface DeleteBody {
 
 const MAX_ID_LEN = 128;
 
+// Resolve the tailscale CLI: PATH lookup first (cross-platform). On macOS only,
+// fall back to the app-bundle CLI, since GUI / App Store builds ship it inside
+// the bundle rather than on PATH. The bundle fallback is darwin-scoped so the
+// platform-specific paths stay isolated from the generic PATH resolution.
+function tailscaleBin(): string | null {
+  const onPath = Bun.which("tailscale");
+  if (onPath) return onPath;
+  if (process.platform === "darwin") {
+    for (const p of [
+      "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+      `${homedir()}/Applications/Tailscale.app/Contents/MacOS/Tailscale`,
+    ]) {
+      if (existsSync(p)) return p;
+    }
+  }
+  return null;
+}
+
 // When the tailscale CLI is present and the device is on a tailnet, return its
 // Tailscale IPv4 and MagicDNS name; otherwise null. Degrades silently on any
 // probe failure (CLI absent, logged out, unexpected JSON).
 function detectTailscale(): { ip: string; dnsName: string } | null {
-  const tsBin = Bun.which("tailscale");
+  const tsBin = tailscaleBin();
   if (!tsBin) return null;
   try {
     const proc = Bun.spawnSync([tsBin, "status", "--json"]);

--- a/epistemic-cooperative/skills/comment-review/scripts/serve.ts
+++ b/epistemic-cooperative/skills/comment-review/scripts/serve.ts
@@ -248,7 +248,7 @@ const server = Bun.serve({
     const url = new URL(req.url);
 
     if (url.pathname === "/") {
-      return new Response(renderIndex(), { headers: { "Content-Type": "text/html; charset=utf-8" } });
+      return new Response(renderIndex(), { headers: { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" } });
     }
 
     if (url.pathname.startsWith("/preview/")) {
@@ -256,7 +256,7 @@ const server = Bun.serve({
       try {
         const html = await renderPreview(slug);
         if (!html) return new Response("not found", { status: 404 });
-        return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+        return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-store" } });
       } catch (e) {
         console.error(`[preview] render failed for slug=${slug}: ${(e as Error).message}`);
         return new Response("render failed", { status: 500 });

--- a/epistemic-cooperative/skills/comment-review/templates/preview.html
+++ b/epistemic-cooperative/skills/comment-review/templates/preview.html
@@ -774,6 +774,10 @@ content.addEventListener("click", (e) => {
 });
 
 function dismissPopup() {
+  // Cancel any pending selection-settle timer explicitly. The removeAllRanges()
+  // below also re-fires selectionchange (which clears selSettle), but clearing it
+  // here makes the timer lifecycle self-documenting rather than implicit.
+  clearTimeout(selSettle);
   // Clean up pending temp marks before clearing state
   if (pending && pending.tempMarks && pending.tempMarks.length > 0) {
     removePendingMarks(pending.tempMarks);

--- a/epistemic-cooperative/skills/comment-review/templates/preview.html
+++ b/epistemic-cooperative/skills/comment-review/templates/preview.html
@@ -544,6 +544,19 @@ content.addEventListener("mouseup", () => {
   setTimeout(handleSelection, 0);
 });
 
+// Touch devices: a long-press selection ends with `selectionchange`, not a clean
+// `mouseup`, so the popup never opened on mobile. Debounce so it opens only after
+// the selection settles (after the user finishes dragging the selection handles).
+// `selectionchange` fires on selection only (not on scroll), so mobile scrolling
+// stays unaffected; `handleSelection` ends by collapsing the range, which re-fires
+// `selectionchange` as collapsed and is ignored by handleSelection's own guard.
+let selSettle = null;
+document.addEventListener("selectionchange", () => {
+  if (popup.classList.contains("show")) return; // a popup is already open
+  clearTimeout(selSettle);
+  selSettle = setTimeout(handleSelection, 450);
+});
+
 function setPopupMode(isEdit) {
   popupSubmit.textContent = isEdit ? "Update" : "Submit";
   popup.classList.toggle("edit-mode", !!isEdit);


### PR DESCRIPTION
## 배경

`/comment-review` 미리보기 서버의 모바일 사용성 개선. 시작은 터치 선택 hotfix였고, 모바일에서 실제로 접속하려면 loopback 바인딩이 걸림돌이라는 점이 드러나 Tailscale 직접 접속까지 확장됨. 실기기로 접속·동작을 검증함.

## 변경

### 1. 모바일 터치 선택 팝업 (hotfix)
- **`templates/preview.html`**: 터치 디바이스의 롱프레스 선택은 깔끔한 `mouseup` 대신 `selectionchange`로 종료되어 기존 핸들러가 발화하지 않았음. `selectionchange`를 450ms 디바운스해 선택이 안정된 뒤에만 팝업을 열도록 처리.
  - `selectionchange`는 스크롤이 아닌 선택 변경 시에만 발화 → 모바일 스크롤 영향 없음
  - `removeAllRanges()` 재발화·이미 열린 팝업은 guard로 무시
  - `dismissPopup()` 상단에 명시적 `clearTimeout(selSettle)` 추가 (리뷰 반영, 타이머 생명주기 self-documenting)

### 2. Tailscale 직접 바인딩 (feat)
- **`scripts/serve.ts`**: 기동 시 `tailscale` CLI를 감지해 tailnet 연결 시 loopback 대신 **Tailscale IPv4에 직접 바인딩**.
  - 모바일이 `tailscale serve` 프록시 없이 `http://100.x.y.z:<port>/` 또는 MagicDNS `http://<device>:<port>/` 로 직접 접속
  - 로컬 머신도 자기 tailnet IP로 접속되어 별도 localhost URL 불필요
  - tailscale 미설치·미연결 시 기존 `127.0.0.1` loopback으로 폴백 (silent degradation)
- **`scripts/serve.ts`**: CLI 감지를 PATH 조회(크로스플랫폼)에 더해, **macOS 한정으로 앱 번들 경로** 폴백 탐색. macOS GUI/App Store판(`io.tailscale.ipn.macsys`)은 `tailscale`을 PATH에 두지 않고 `/Applications/Tailscale.app/Contents/MacOS/Tailscale`에만 두므로, 이 흔한 환경에서 기능이 발동조차 안 되던 버그 수정. 앱 번들 폴백은 `process.platform === "darwin"` 가드로 격리.
- **`scripts/serve.ts`**: `/` 및 `/preview/:slug` 응답에 `Cache-Control: no-store` 헤더 추가 — 미리보기 캐시 무효화.

## 다중 프로세스 설계 근거

여러 Claude Code 프로세스가 각각 `/comment-review`를 호출하는 상황을 위한 노출 모델은 **무공유 port 격리**로 결정. 각 프로세스가 `port: 0`으로 고유 포트에 독립 direct-bind하고 매직 URL을 터미널에 출력 → 공유 가변 상태 0, 프로세스 수에 선형 확장.

대안 검토 결과:
- **`tailscale serve` 경로 매핑은 부적합** — 클라이언트가 root-absolute 경로(`/marked.min.js`, `/feedback`, `/ws`, `/preview/<slug>`)와 WebSocket을 사용해 path-prefix 마운트 시 에셋·피드백·핫리로드·네비가 모두 깨짐. base-path 인식 앱에서만 성립.
- **`tailscale serve` 포트 매핑은 부적합** — 노드-전역 serve config 하나를 공유하므로 조율되지 않는 다중 프로세스에서 경쟁·포트 충돌·잔존 엔트리 발생.
- discovery는 각 CC 세션 터미널의 출력 URL로 충분(추가 인프라 불요).

## 보안 영향

`127.0.0.1` loopback("user-private")에서 **tailnet-private**로 사생활 경계를 의도적으로 확장. 단일 tailnet 인터페이스로 한정(`0.0.0.0`/전체 네트워크 아님)했으나, **공유 tailnet에서는 같은 네트워크의 타인이 drafts/feedback에 접근 가능** — 1인 tailnet에서는 무관. tailscale 미감지 시 loopback 유지로 기본 동작은 보존.

## 버전

`epistemic-cooperative` 2.20.12 → **2.21.0** (minor). hotfix에 feat가 더해져 patch에서 minor 승격. `.claude-plugin` / `.codex-plugin` 동기 bump.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → fail 0
- pre-commit 런타임 계약 hook (테스트 + static + 패키징 dry-run) 통과
- serve.ts: parse OK
- **실기기 검증**: macOS(App Store판 Tailscale 1.96.5) + 모바일 — 서버가 Tailscale IP에 바인딩, IP·MagicDNS 양쪽 HTTP 200, `Cache-Control: no-store` 확인, 폰에서 터치 선택 팝업 동작 확인
