### PR TITLE
feat(prothesis): /frame 도구 위임 경계 + 평가 방법론 통합

### DIFF
--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.31",
+  "version": "5.17.32",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.32",
+  "version": "5.17.33",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.claude-plugin/plugin.json
+++ b/prothesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prothesis",
   "description": "Multi-perspective investigation \u2014 /frame (\u03c0\u03c1\u03cc\u03b8\u03b5\u03c3\u03b9\u03c2: a placing before)",
-  "version": "5.17.33",
+  "version": "5.17.34",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/prothesis/.codex-plugin/plugin.json
+++ b/prothesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prothesis",
-  "version": "5.17.33",
+  "version": "5.17.34",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
   "author": {
     "name": "Jongwon Choi",

--- a/prothesis/.codex-plugin/plugin.json
+++ b/prothesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prothesis",
-  "version": "5.17.32",
+  "version": "5.17.33",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
   "author": {
     "name": "Jongwon Choi",

--- a/prothesis/.codex-plugin/plugin.json
+++ b/prothesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prothesis",
-  "version": "5.17.31",
+  "version": "5.17.32",
   "description": "Multi-perspective investigation — /frame (πρόθεσις: a placing before)",
   "author": {
     "name": "Jongwon Choi",

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -14,7 +14,7 @@ Resolve absent frameworks by placing available epistemic perspectives before the
 ```
 ── FLOW ──
 Prothesis(U) → Q(MB(U), M) → (MBᵥ, m) → G(MBᵥ) → C → {P₁...Pₙ}(C, MBᵥ) → S → Pₛ → LensEstablished →
-  T(Pₛ) → ∥I(T) → Await(T_running) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
+  T₀(Pₛ) → Authorize(Pₛ) → Auth → T(T₀, Pₛ, MBᵥ, Auth) → ∥I(T) → Await(T_running) → R → Ω(T) → R' → P(R') → Δ(R') → Δₛ → D?(Δₛ, T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Q(routing) → J → FramedInquiry
 
 ── MORPHISM ──
 Inquiry
@@ -23,8 +23,9 @@ Inquiry
   → propose(perspectives)               -- generate distinct analytical lenses from context
   → select(perspectives)                -- user chooses lenses via Cognitive Partnership Move (Constitution)
   → LensEstablished                     -- compositional handoff object; Mode 1 terminalizes via characterize(Pₛ)
-  → spawn(team)                         -- assemble perspective team via TeamCreate
+  → create(team)                        -- TeamCreate → T₀ (empty team shell, no members yet)
   → authorize(tools)                    -- pass through user/orchestrator-supplied tool authorizations per perspective channel need ("None supplied" default)
+  → spawn(team)                         -- spawn teammates into T₀ with MBᵥ + perspective + Auth → T
   → inquire(parallel)                   -- isolated perspective analysis per teammate
   → await(notifications)                -- passive wait for teammate completion signals (see TOOL GROUNDING)
   → collect(results)                    -- finalize inquiry outputs, retain team
@@ -55,7 +56,8 @@ Pᵦ     = Pre-confirmed base perspectives (user-supplied in U; auto-included in
 S      = Selection: {P₁...Pₙ} → Pₛ             -- extern (user choice; Pᵦ auto-included)
 Pₛ     = Selected perspectives (Pₛ = Pᵦ ∪ sel({P₁...Pₙ}), |Pₛ| ≥ 2 when m=inquire; |Pₛ| ≥ 1 when m=recommend)
 LensEstablished = Pₛ where lens selection complete  -- compositional handoff object; Mode 1 packages it into FramedInquiry, Mode 2 continues
-T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with shared task list
+T₀     = TeamCreate(Pₛ): empty team shell (no members yet)        -- created before authorize/spawn
+T      = Spawn(T₀, Pₛ, MBᵥ, Auth): (∥ p∈Pₛ. Spawn(p, MBᵥ, Auth)) -- teammates spawned into T₀, each receives MBᵥ + perspective + Auth; shared task list
 Auth   = Tool authorizations passed through to teammates per perspective channel need (user/orchestrator-supplied; "None supplied" default; core selects no provider)
 T_running = Team with inquiries in flight             -- intermediate state between dispatch and completion
 ∥I     = Parallel inquiry dispatch: T → T_running    -- per-teammate Inquiry(p) launched
@@ -102,7 +104,7 @@ Edge cases:
 Phase 0:  U → MB(U) → Qc(MB, M) → Stop → (MBᵥ, m)              -- combined MB confirmation + mode selection [Tool]
 Phase 1:  MBᵥ → G(MBᵥ) → C                                      -- targeted context acquisition
 Phase 2:  (C, MBᵥ) → Sc({P₁...Pₙ}(C, MBᵥ)) → Stop → Pₛ → LensEstablished  -- perspective selection [Tool]
-Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: extension | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → Authorize(Pₛ) → Auth → ∥Spawn[Task](T, Pₛ, MBᵥ, Auth) → ∥I[TaskCreate](T) → Await[IdleNotification](T_running) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + tool-authorization passthrough + inquiry dispatch + wait + collection + preview [Tool]
+Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: extension | 2+: Qc(map) → Stop] → T₀[TeamCreate](Pₛ) → Authorize(Pₛ) → Auth → ∥Spawn[Task](T₀, Pₛ, MBᵥ, Auth) → T → ∥I[TaskCreate](T) → Await[IdleNotification](T_running) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + tool-authorization passthrough + inquiry dispatch + wait + collection + preview [Tool]
 Phase 4:  R' → Δ(R') → Δₛ → D?(Δₛ)[SendMessage](T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Qc(routing) → Stop → J  -- triggers, cross-dialogue, synthesis, presentation & routing [Tool]
           J=wrap_up → PF Qc(select) → Stop → Ω → TeamDelete → TaskCreate(selected)  [Tool]
 
@@ -153,9 +155,9 @@ Phase 0 Qc (constitution)        → present (combined: Q1=Mission Brief confirm
 Sc (constitution)                → present (mandatory; multiSelect: true; lens selection is epistemic choice; Esc key → loop termination at LOOP level)
 Phase 3 AgentMap_auto (extension)  → TextPresent+Proceed (when agent_count(perspective) ≤ 1; auto-assign for 1 match, AI-generated for 0 matches; execution assignment correctable by team restructuring)
 Phase 3 AgentMap_select (constitution) → present (when agent_count(perspective) ≥ 2; user confirms agent-perspective mapping; option-set relay test applies)
-Phase 3 T (dispatch)     → TeamCreate tool (parallel topology: creates team with shared task list; fires after either AgentMap_auto or AgentMap_select resolves the perspective → agent mapping)
+Phase 3 T₀ (dispatch)    → TeamCreate tool (parallel topology: creates empty team shell T₀ with shared task list; fires after either AgentMap_auto or AgentMap_select resolves the perspective → agent mapping)
 Phase 3 Authorize (extension) → TextPresent+Proceed (passthrough of user/orchestrator-supplied tool authorizations per perspective channel need into spawn prompts; "None supplied" default; core selects no provider — deterministic relay, bounded regret)
-∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates — each receives MBᵥ + perspective + tool authorizations (Auth); no Phase 1 context G passed)
+∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates into T₀ → T — each receives MBᵥ + perspective + tool authorizations (Auth); no Phase 1 context G passed)
 ∥I (track)               → TaskCreate/TaskUpdate (parallel topology: shared task list for inquiry coordination — dispatch phase)
 Await (sense)            → IdleNotification (passive wait: teammate SubagentStop events surface as coordinator idle notifications; teammate→coordinator message delivery occurs at coordinator turn boundary, not at teammate send time; async message-passing execution model; no coordinator poll per Rule 14)
 Phase 3 P (extension)        → TextPresent+Proceed (per-perspective epistemic contribution + key finding summaries)

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frame
-description: "Multi-perspective investigation. Recommends analytical lenses or assembles a team to analyze from selected viewpoints when the right framework is absent, producing a framed inquiry. Type: (FrameworkAbsent, AI, SELECT, Inquiry) → FramedInquiry. Alias: Prothesis(πρόθεσις)."
+description: "Multi-perspective investigation. Recommends analytical lenses or assembles a team to analyze from selected viewpoints when the right framework is absent; factual lookup or verification routes to fact-finding delegation, while contested design/value judgment routes to lens-conditioned evidence plus synthesis. Type: (FrameworkAbsent, AI, SELECT, Inquiry) → FramedInquiry. Alias: Prothesis(πρόθεσις)."
 ---
 
 # Prothesis Protocol
@@ -198,6 +198,9 @@ Command invocation activates mode until session end.
 - **Layer 1 (User-invocable)**: `/frame` slash command or description-matching input. Always available.
 - **Layer 2 (AI-guided)**: Purpose present but approach unspecified; multiple valid frameworks detected via in-protocol heuristics.
 
+**Trigger signals**:
+- Use fact-finding delegation when the task is primarily finding or verifying facts; use `/frame` when reasonable people could weigh contested design, value, interpretation, or scope differently and the work needs lens-conditioned evidence plus synthesis.
+
 ### Priority
 
 <system-reminder>
@@ -306,6 +309,8 @@ Optional dimension naming (apply when initial generation seems redundant):
 - Identify epistemic axes relevant to this inquiry
 - Dimensions remain revisable during perspective generation
 
+During perspective formulation, note whether each candidate lens depends on evidence from code/workspace, canonical external sources, instrumentation, or user-tacit context. This is only a channel-level need signal for later authorization; it does not select or name a concrete provider.
+
 **Pre-suggested perspective handling**: When the user supplies perspectives in U (e.g., naming specific agents, frameworks, or roles), treat these as **pre-confirmed base perspectives** (Pᵦ):
 
 - Pᵦ are **auto-included** in Pₛ — do not re-present them as selectable options
@@ -334,7 +339,7 @@ For each selected perspective in Pₛ, check whether available agents match the 
 
 Agent matching is heuristic: compare perspective focus description against agent `description` and `when to use` fields. Matching does not affect perspective selection (theoria) — it only determines execution assignment (praxis). "Placement over Prescription" invariant: /frame places perspectives; agent mapping realizes execution.
 
-**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. For Tier 2 (|Pₛ| ≥ 4): direct each perspective's initial investigation toward MBᵥ-relevant subdomain — full-codebase sweep per perspective is unnecessary when scope_constraint narrows the evidence space. The coordinator's spawn prompt Orientation field directs each perspective's initial investigation target.
+**Operational cost**: Independent context collection multiplies tool calls by |Pₛ| compared to shared-context distribution. This is the cost of epistemic independence — each perspective's unique evidence discovery justifies the amplification. Each perspective formulates any external research need through its own lens, so evidence differs by framework instead of collapsing into a shared fact list; that differentiated grounding raises cross-dialogue quality. For Tier 2 (|Pₛ| ≥ 4): direct each perspective's initial investigation toward MBᵥ-relevant subdomain — full-codebase sweep per perspective is unnecessary when scope_constraint narrows the evidence space. The coordinator's spawn prompt Orientation field directs each perspective's initial investigation target.
 
 **Team Setup**
 
@@ -343,7 +348,7 @@ Create an agent team and spawn perspective teammates:
 1. Call TeamCreate to create a team (e.g., `prothesis-inquiry`)
 2. For each selected perspective, call Task with `team_name` and `name` to spawn a teammate (agent-mapped or AI-generated)
 
-Teammates do not inherit the lead's conversation history. Each spawn prompt includes the Mission Brief and the perspective assignment — teammates independently collect evidence through their own lens via Read/Grep. Phase 1 context (G) is NOT passed to teammates: G serves meta-level perspective identification; each teammate's independent object-level investigation produces perspective-specific evidence that G's broad sweep would filter out.
+Teammates do not inherit the lead's conversation history. Each spawn prompt includes the Mission Brief, the perspective assignment, and any user- or orchestrator-supplied tool authorizations — teammates independently collect evidence through their own lens using available tools that serve the lens. Phase 1 context (G) is NOT passed to teammates: G serves meta-level perspective identification; each teammate's independent object-level investigation produces perspective-specific evidence that G's broad sweep would filter out.
 
 Each teammate receives the perspective prompt template:
 
@@ -354,10 +359,11 @@ You are a **[Perspective] Expert**.
 - Intent: {MBᵥ.inquiry_intent}
 - Deliverable: {MBᵥ.expected_deliverable}
 - Scope: {MBᵥ.scope_constraint} — constrain your analysis to this boundary
+- Tool authorizations: {user/orchestrator-supplied tool authorizations, or "None supplied"}
 
 Analyze from this epistemic standpoint:
 
-**Your Task**: Independently investigate the codebase through your lens. Use Read/Grep to collect perspective-specific evidence.
+**Your Task**: Independently investigate through your lens. Use any available tools, including utility skills, that serve your lens and respect the supplied authorizations. If your lens depends on external evidence, formulate the research need from that perspective rather than reusing a generic fact-finding query; differentiated evidence raises the quality of later cross-dialogue.
 **Orientation** (from Mission Brief): {MBᵥ-derived key terms, relevant directories, or domain anchors — minimal orientation without full Phase 1 context}
 **Question**: {original question verbatim}
 
@@ -487,6 +493,14 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 ```markdown
 ## Framed Analysis
 
+### Bottom-line
+[One-sentence answer with the decisive reason]
+
+### Integrated Assessment
+[Synthesized answer with attribution to contributing perspectives]
+[Carry the single decisive reason before supporting detail]
+[Distinguish findings from isolated inquiry (R') vs. cross-dialogue refinement (Dᵣ)]
+
 ### Convergence (Shared Horizon)
 [Where perspectives agree—indicates robust finding]
 [Per convergence point: coordinator-assessed agreement strength (strong/moderate/weak) with basis from Dᵣ; when Dᵣ = ∅, label as "independent convergence" — strength not assessable without cross-dialogue]
@@ -495,10 +509,6 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 [Where they disagree—different values, evidence standards, or scope]
 [Cross-dialogue resolution status per tension topic, if applicable]
 [If perspectives unexpectedly converged, note why distinct framing was nonetheless valuable]
-
-### Integrated Assessment
-[Synthesized answer with attribution to contributing perspectives]
-[Distinguish findings from isolated inquiry (R') vs. cross-dialogue refinement (Dᵣ)]
 
 ### Synthesis Basis
 [Per assessment claim: source perspective(s), evidence type (R' finding / Dᵣ agreement / Dᵣ divergence / synthesis constitution; omit Dᵣ types when Dᵣ = ∅), and whether claim combines multiple sources]
@@ -543,6 +553,7 @@ Heuristic criteria for Phase 4 trigger detection (Δ). Coordinator cites evidenc
 14. **Wait discipline**: During Phase 3 Await, the coordinator MUST NOT (a) re-prompt teammates regardless of interval duration — any re-prompt risks interrupting teammate mid-composition and inducing content revision rather than resolving apparent silence; (b) observe teammate state passively (TaskList reads, agent memory inspection, filesystem reads under team directories) as a basis for behavioral decisions before the completion signal arrives — passive observation defeats passive-wait semantics and becomes a post-hoc rationalization path disguised as "task tracking, not polling"; (c) proceed with partial R — Await converges only when all teammates in T have signaled completion, and partial collection without `user_esc` violates convergence persistence. Scope: Phase 3 inquiry wait only; Phase 4 hub-spoke step 4 content-bearing follow-ups are sent after peers have idled and are out of scope. Platform-specific delivery mechanics are documented in TOOL GROUNDING (Await entry); epistemic prose depends only on the existence of a completion signal, not on its platform form. Recovery from indefinite wait is user-initiated via `user_esc` per LOOP; any of (a)/(b)/(c) = protocol violation
 15. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 16. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
+17. **Utility-agnostic tool authorization**: The protocol core detects evidence-channel need at the perspective level; concrete tool or utility binding is supplied only by explicit user instruction or an orchestrating utility skill and passed through to teammates without provider names originating in the core. Persistent teammates keep Phase 4 cross-dialogue available because they stay addressable for peer negotiation; delegating execution to stateless one-shot workers (e.g. ephemeral research sessions) trades that away — such workers complete and exit, so when synthesis needs peer dialogue or contradiction resolution, route those perspectives through persistent teammates that remain reachable through Phase 4.
 
 ## Adversarial Guards
 

--- a/prothesis/skills/frame/SKILL.md
+++ b/prothesis/skills/frame/SKILL.md
@@ -24,6 +24,7 @@ Inquiry
   → select(perspectives)                -- user chooses lenses via Cognitive Partnership Move (Constitution)
   → LensEstablished                     -- compositional handoff object; Mode 1 terminalizes via characterize(Pₛ)
   → spawn(team)                         -- assemble perspective team via TeamCreate
+  → authorize(tools)                    -- pass through user/orchestrator-supplied tool authorizations per perspective channel need ("None supplied" default)
   → inquire(parallel)                   -- isolated perspective analysis per teammate
   → await(notifications)                -- passive wait for teammate completion signals (see TOOL GROUNDING)
   → collect(results)                    -- finalize inquiry outputs, retain team
@@ -55,6 +56,7 @@ S      = Selection: {P₁...Pₙ} → Pₛ             -- extern (user choice; P
 Pₛ     = Selected perspectives (Pₛ = Pᵦ ∪ sel({P₁...Pₙ}), |Pₛ| ≥ 2 when m=inquire; |Pₛ| ≥ 1 when m=recommend)
 LensEstablished = Pₛ where lens selection complete  -- compositional handoff object; Mode 1 packages it into FramedInquiry, Mode 2 continues
 T      = Team(Pₛ): TeamCreate → (∥ p∈Pₛ. Spawn(p)) -- agent team with shared task list
+Auth   = Tool authorizations passed through to teammates per perspective channel need (user/orchestrator-supplied; "None supplied" default; core selects no provider)
 T_running = Team with inquiries in flight             -- intermediate state between dispatch and completion
 ∥I     = Parallel inquiry dispatch: T → T_running    -- per-teammate Inquiry(p) launched
 Await  = Passive completion barrier: T_running → R   -- see TOOL GROUNDING (Await entry) for realization
@@ -69,7 +71,7 @@ Dᵣ     = Set(DialogueReport)                          -- peer negotiation outp
 DialogueReport = { perspective, final_position, agreement: AgreementStrength, divergence, rationale }  -- divergence gates hub-spoke conditional
 AgreementStrength ∈ {strong, moderate, weak}  -- coordinator-assessed in Cross-Dialogue Outcomes (horizons fusion); strong: shared evidence + shared conclusion; moderate: shared conclusion, different evidence paths; weak: partial overlap, significant residual divergence
 Syn    = Synthesis: (R', Dᵣ) → (∩, D, A)             -- dual-input: provenance-preserving (Dᵣ = ∅ when Δₛ = ∅)
-L      = Lens { convergence: ∩, divergence: D, assessment: A }
+L      = Lens { convergence: ∩, divergence: D, assessment: A }  -- Bottom-line is a presentation-layer projection of A (decision-relevant summary surfaced first), not a field of L; Syn(R', Dᵣ) → (∩, D, A) unchanged
 O      = Output: L → UserVisible(L)                   -- full synthesis presentation as text output before routing question
 CountTier ∈ {single_modifier, domain_narrowing, escalation_candidate}  -- advisory metadata (does not branch LOOP); recorded in Lᵣ.tier for downstream reading
 DownstreamUse ∈ {protocol_route, scope_directive, context_binding}  -- protocol_route: lens names a downstream protocol invocation; scope_directive: lens narrows downstream resolution domain; context_binding: lens enriches downstream protocol's pre-execution context
@@ -100,7 +102,7 @@ Edge cases:
 Phase 0:  U → MB(U) → Qc(MB, M) → Stop → (MBᵥ, m)              -- combined MB confirmation + mode selection [Tool]
 Phase 1:  MBᵥ → G(MBᵥ) → C                                      -- targeted context acquisition
 Phase 2:  (C, MBᵥ) → Sc({P₁...Pₙ}(C, MBᵥ)) → Stop → Pₛ → LensEstablished  -- perspective selection [Tool]
-Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: extension | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → ∥Spawn[Task](T, Pₛ, MBᵥ) → ∥I[TaskCreate](T) → Await[IdleNotification](T_running) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + inquiry dispatch + wait + collection + preview [Tool]
+Phase 3:  LensEstablished → AgentMap?(Pₛ) → [0/1: extension | 2+: Qc(map) → Stop] → T[TeamCreate](Pₛ) → Authorize(Pₛ) → Auth → ∥Spawn[Task](T, Pₛ, MBᵥ, Auth) → ∥I[TaskCreate](T) → Await[IdleNotification](T_running) → R → Ω[SendMessage](T) → R' → P(R')  -- agent mapping + tool-authorization passthrough + inquiry dispatch + wait + collection + preview [Tool]
 Phase 4:  R' → Δ(R') → Δₛ → D?(Δₛ)[SendMessage](T) → Dᵣ → Syn(R', Dᵣ) → L → O(L) → Qc(routing) → Stop → J  -- triggers, cross-dialogue, synthesis, presentation & routing [Tool]
           J=wrap_up → PF Qc(select) → Stop → Ω → TeamDelete → TaskCreate(selected)  [Tool]
 
@@ -152,13 +154,14 @@ Sc (constitution)                → present (mandatory; multiSelect: true; lens
 Phase 3 AgentMap_auto (extension)  → TextPresent+Proceed (when agent_count(perspective) ≤ 1; auto-assign for 1 match, AI-generated for 0 matches; execution assignment correctable by team restructuring)
 Phase 3 AgentMap_select (constitution) → present (when agent_count(perspective) ≥ 2; user confirms agent-perspective mapping; option-set relay test applies)
 Phase 3 T (dispatch)     → TeamCreate tool (parallel topology: creates team with shared task list; fires after either AgentMap_auto or AgentMap_select resolves the perspective → agent mapping)
-∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates — each receives MBᵥ + perspective only; no Phase 1 context G passed)
+Phase 3 Authorize (extension) → TextPresent+Proceed (passthrough of user/orchestrator-supplied tool authorizations per perspective channel need into spawn prompts; "None supplied" default; core selects no provider — deterministic relay, bounded regret)
+∥Spawn (dispatch)        → Task tool (parallel topology: team_name, name: spawn perspective teammates — each receives MBᵥ + perspective + tool authorizations (Auth); no Phase 1 context G passed)
 ∥I (track)               → TaskCreate/TaskUpdate (parallel topology: shared task list for inquiry coordination — dispatch phase)
 Await (sense)            → IdleNotification (passive wait: teammate SubagentStop events surface as coordinator idle notifications; teammate→coordinator message delivery occurs at coordinator turn boundary, not at teammate send time; async message-passing execution model; no coordinator poll per Rule 14)
 Phase 3 P (extension)        → TextPresent+Proceed (per-perspective epistemic contribution + key finding summaries)
 Phase 4 Δ (sense)        → Internal operation (trigger check per Trigger Detection Criteria; cite evidence per detected trigger)
 Phase 4 D? (dispatch)    → SendMessage tool (conditional topology: coordinator signals tension topic to peer pair → peer exchange → structured report → conditional hub-spoke; skip if Δₛ = ∅)
-Phase 4 O (extension)        → TextPresent+Proceed (full synthesis — convergence, divergence, integrated assessment)
+Phase 4 O (extension)        → TextPresent+Proceed (full synthesis — Bottom-line, Integrated Assessment, Convergence, Divergence, Synthesis Basis)
 Phase 4 Qc (constitution)        → present (routing only: extend/add_input/wrap_up/withdraw options; loop path + team lifecycle; Esc key → loop termination at LOOP level)
 PF Qc (constitution)             → present (multiSelect: preservation scope; knowledge preservation scope; in LOOP wrap_up path only)
 wrap_up TaskCreate (track) → TaskCreate (session-scoped: PF-selected findings, created after TeamDelete clears team context)
@@ -192,14 +195,13 @@ AgentRef  = { name: String, type: String, perspective: Option(String) }
 
 ### Activation
 
+**Pre-activation routing**: Before accepting a `/frame` invocation, check the task shape. When the task is primarily finding or verifying facts, suggest fact-finding delegation instead; engage `/frame` when reasonable people could weigh contested design, value, interpretation, or scope differently and the work needs lens-conditioned evidence plus synthesis. This guard precedes activation — it decides whether to accept the invocation, not how the mode behaves once active.
+
 Command invocation activates mode until session end.
 
 **Activation layers**:
 - **Layer 1 (User-invocable)**: `/frame` slash command or description-matching input. Always available.
 - **Layer 2 (AI-guided)**: Purpose present but approach unspecified; multiple valid frameworks detected via in-protocol heuristics.
-
-**Trigger signals**:
-- Use fact-finding delegation when the task is primarily finding or verifying facts; use `/frame` when reasonable people could weigh contested design, value, interpretation, or scope differently and the work needs lens-conditioned evidence plus synthesis.
 
 ### Priority
 
@@ -494,11 +496,10 @@ After cross-dialogue (R', Dᵣ), or directly from R' if no triggers (Dᵣ = ∅)
 ## Framed Analysis
 
 ### Bottom-line
-[One-sentence answer with the decisive reason]
+[The single decision-relevant takeaway in 1-2 sentences, surfaced first — the decisive answer, not the full reasoning]
 
 ### Integrated Assessment
-[Synthesized answer with attribution to contributing perspectives]
-[Carry the single decisive reason before supporting detail]
+[The full synthesized answer with attribution to contributing perspectives — the Bottom-line expanded with its supporting reasoning and detail]
 [Distinguish findings from isolated inquiry (R') vs. cross-dialogue refinement (Dᵣ)]
 
 ### Convergence (Shared Horizon)

--- a/prothesis/skills/frame/references/agent-teams-bp-applicability.md
+++ b/prothesis/skills/frame/references/agent-teams-bp-applicability.md
@@ -2,6 +2,8 @@
 
 Not all agent-teams best practices apply uniformly across Prothesis phases. This reference table maps which BPs are active, intentionally restricted, or not yet applicable at each phase — preventing compliance frame mismatch when evaluating phase-specific sessions.
 
+Use [`evaluation-methodology.md`](./evaluation-methodology.md) for the multi-session evaluation method and hidden-assumption checks that determine how this table should be applied.
+
 | Best Practice | Phase 0-2 (Setup) | Phase 3 (Theoria) | Phase 4-5 (Cross-Dialogue + Synthesis + Routing) |
 |---------------|-------------------|-------------------|----------------------|
 | BP1: Context in spawn prompts | — | **Active** (Mission Brief in prompt) | — |

--- a/prothesis/skills/frame/references/evaluation-methodology.md
+++ b/prothesis/skills/frame/references/evaluation-methodology.md
@@ -76,6 +76,8 @@ Evidence: [trace citation or repeated-session pattern]
 Disposition: [local issue / protocol patch / no action / needs more sessions]
 ```
 
+**Escalation threshold**: Escalate `local issue -> protocol patch` only when the same finding recurs across at least 3 independent sessions, or a structural proof ties it to a formal block (TYPES / MORPHISM / PHASE TRANSITIONS). Below that threshold, record it as a `local issue`. This mirrors the protocol's existing revision convention (named-trigger promotion across 3+ sessions), so a single striking session does not by itself justify a protocol-level change.
+
 Avoid verdicts that say only "violates agent-team best practice." The missing step is whether that practice applies to the Prothesis phase under evaluation.
 
 ## Worked Example: Isolation Value Is Scoped

--- a/prothesis/skills/frame/references/evaluation-methodology.md
+++ b/prothesis/skills/frame/references/evaluation-methodology.md
@@ -1,0 +1,83 @@
+# Prothesis Evaluation Methodology
+
+This reference defines how to evaluate Prothesis when its specialized epistemic behavior differs from generic agent-team best-practice compliance. Use it together with [`agent-teams-bp-applicability.md`](./agent-teams-bp-applicability.md), which marks which best practices are active, restricted, environment-dependent, or not applicable by phase.
+
+## Evaluation Unit
+
+Evaluate a Prothesis run as a phase-scoped protocol trace, not as a generic agent-team session snapshot.
+
+Minimum trace record:
+
+- input deficit: whether the user actually presented `FrameworkAbsent`
+- selected mode: Recommend or Inquire
+- phase path: Phase 0 through terminal phase reached
+- perspective set: options presented, selected perspectives, and rationale
+- team behavior when Inquire mode is used
+- synthesis output: Lens, convergence/divergence, routing, and residual uncertainties
+- verification signals: user recognition, follow-up correction, review findings, or downstream protocol fit
+
+## Multi-Session Method
+
+Do not judge the whole protocol from one execution path. Sample across at least these shapes before making a protocol-level claim:
+
+- Recommend mode with a lightweight framing request
+- Inquire mode with distinct selected perspectives
+- high-ambiguity request where perspective selection is the main value
+- high-complexity request where synthesis quality is the main value
+- a case where a best practice is intentionally restricted by the applicability table
+
+Session-level findings may justify a local patch, but claims about Prothesis as a protocol require cross-session recurrence or a structural proof tied to the formal block.
+
+## Specialized-Use Criteria
+
+Generic agent-team best practices are evidence only after phase applicability is established.
+
+| Criterion | Evaluation question |
+|---|---|
+| Phase applicability | Is the best practice active, restricted, environment-dependent, or not applicable for this phase? |
+| Epistemic purpose | Does the observed behavior help resolve `FrameworkAbsent` into `FramedInquiry`? |
+| Isolation warrant | If communication is restricted, does the restriction preserve independent perspective formation? |
+| Synthesis warrant | Does cross-dialogue or synthesis integrate findings without flattening perspective differences? |
+| Recognition burden | Did the user need only to recognize suitable perspectives, or were they forced to invent the framework? |
+| Routing fit | Did the output point to the next appropriate protocol or execution path when framing alone was not enough? |
+
+## Hidden Assumptions To Check
+
+### Completeness = Quality
+
+Completeness is not sufficient evidence of quality. A Prothesis output is good when it exposes the load-bearing perspectives needed for the user's inquiry and preserves meaningful divergence. Exhaustive perspective lists can lower quality if they dilute the user's recognition task.
+
+### Session Representativeness
+
+A single trace is not representative by default. Mode, stakes, ambiguity, and selected perspectives change the relevant evaluation criteria. Treat one-session critiques as instance findings unless the same failure recurs or the formal block makes the defect inevitable.
+
+### Cost = Tokens
+
+Token usage is only one cost surface. Also evaluate recognition burden, review burden, unnecessary team coordination, false-positive perspective inflation, and downstream rework prevented by better framing.
+
+### No Communication = Isolation Failure
+
+No communication is not automatically a failure. In Phase 3, isolation can be intentional because independent perspectives reduce premature convergence. Use the applicability table before applying cross-team communication expectations.
+
+### Static Snapshot Evaluation
+
+Static snapshots miss whether Prothesis correctly routes, corrects, or preserves residual uncertainty over the loop. Evaluate the phase trace plus follow-up signals: user recognition, reviewer challenges, downstream protocol fit, and whether a later session had to re-derive the same framing.
+
+## Verdict Structure
+
+Use this shape for review notes:
+
+```text
+Scope: [phase/mode/session set]
+Applicability basis: [active/restricted/environment-dependent/not applicable, with table row]
+Finding: [observed behavior]
+Protocol relevance: [effect on FrameworkAbsent -> FramedInquiry]
+Evidence: [trace citation or repeated-session pattern]
+Disposition: [local issue / protocol patch / no action / needs more sessions]
+```
+
+Avoid verdicts that say only "violates agent-team best practice." The missing step is whether that practice applies to the Prothesis phase under evaluation.
+
+## Worked Example: Isolation Value Is Scoped
+
+An observed evaluation case ran the same inquiry two ways: as isolated per-perspective research (each selected lens investigated independently, then synthesized) versus a single flat research pass over the same question. Isolation surfaced a robust convergent finding that several independent lenses reached on their own and that the flat pass missed entirely — evidence that isolation pays off on decomposable questions where independent derivation cross-checks a result. On a cross-cutting architectural sub-question, the flat single-context pass integrated better, because one context held the whole problem while the isolated lenses each saw only a fragment. Read this as scoped, not settled: isolation's benefit tracks how decomposable the inquiry is, so evaluate it per inquiry shape rather than crediting or discrediting isolation in general. This remains an instance finding pending multi-session corroboration per Session Representativeness above.


### PR DESCRIPTION
## 요약

세션의 풍부한 컨텍스트로 통합 검토 후, Open 상태였던 3개 Prothesis(`/frame`) PR을 하나로 흡수해 대체합니다.

## 통합 대상

- **#459 ≡ #460**: 바이트 동일 중복(세 파일 모두 동일 blob, SKILL.md `0a8feaf2`). 검증된 #460 내용을 베이스로 사용.
- **#436**: 평가 방법론 reference (런타임 SKILL.md 불변, 독립).

## 취한 부분

- 라우팅 **Trigger signals**: 사실 조회/검증은 fact-finding 위임으로, 논쟁적 설계·가치·해석·스코프 판단은 `/frame`으로.
- **Phase 1 evidence-channel 표기**: 각 lens가 의존하는 채널(code/workspace, 외부 정전 소스, instrumentation, user-tacit)을 provider-agnostic하게 표기 — provider 선택이 아닌 채널 단위 need 신호.
- **Rule 17 utility-agnostic tool authorization** + Team Setup tool authorization passthrough.
- (세션 value-add) Rule 17에 **cross-dialogue 보전 caveat**: persistent teammate는 Phase 4 peer 협상을 유지하지만, stateless 일회성 worker(예: ephemeral research 세션) 위임은 그것을 상실시킴 → 합성·대질이 필요한 관점은 Phase 4까지 reachable한 persistent teammate로 라우팅.
- **Framed Analysis 재정렬**: Bottom-line / Integrated Assessment 우선 노출.
- **evaluation-methodology.md** + 백링크: 다중세션 평가 방법.
- (세션 value-add) evaluation-methodology.md에 **Arm A(flat) vs Arm B(격리) 실측 사례**: 격리의 가치는 *분해 가능한* 질문에 한정되고, 교차절단/아키텍처 질문에선 단일 컨텍스트(flat)가 더 잘 통합한다는 scoped 관찰(instance finding, 다중세션 corroboration 대기).

## 미룬 부분 (측정-미검증 → pilot 후)

전체 적응적 격리 selector, 인식-우선 escalation의 *기본값* 전환, 옵션 경계(3-5+dissent), expert bypass, synthesis-criterion 라벨링은 문헌-동기지만 측정-미검증이므로 측정 pilot 이후로 이관(별도 Task로 추적).

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → **fail 0**
- 경고 2건(`Horizontverschmelzung`, `hermeneutic-cycle.md` Korean)은 모두 기존 — 이 변경이 도입한 신규 경고 없음.
- version 5.17.31 → 5.17.32 (claude + codex manifest 동기화), 단일 bump으로 세 PR의 버전 충돌 해소.
