### PR TITLE
feat(comment-review): 사이드패널 finding 가시성 개선 및 복사 버튼 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/comment-review/templates/preview.html
+++ b/epistemic-cooperative/skills/comment-review/templates/preview.html
@@ -233,6 +233,11 @@
     overflow-y: auto;
     padding: .5em 0;
   }
+  #findings-list {
+    max-height: 40%;
+    overflow-y: auto;
+    min-height: 0;
+  }
   #sidebar-empty {
     padding: 2em 1em;
     color: var(--muted);
@@ -249,7 +254,7 @@
   .sidebar-item:hover { background: #f0f4f8; }
   .sidebar-item-anchor {
     font-size: .82em;
-    color: var(--muted);
+    color: #444;
     border-left: 3px solid var(--highlight-edge);
     padding-left: .55em;
     margin-bottom: .35em;
@@ -297,8 +302,8 @@
     border-left-color: var(--finding-edge);
   }
   .finding-item-meta {
-    font-size: .72em;
-    color: var(--muted);
+    font-size: .78em;
+    color: #444;
     margin-top: .25em;
     display: flex;
     gap: .55em;
@@ -323,10 +328,10 @@
     display: none;
     padding: .5em .65em;
     margin-bottom: .4em;
-    max-height: 9em;
+    max-height: 18em;
     overflow-y: auto;
-    font-size: .82em;
-    color: var(--muted);
+    font-size: .9em;
+    color: #222;
     border-left: 3px solid var(--finding-edge);
     line-height: 1.45;
     white-space: pre-wrap;
@@ -334,6 +339,7 @@
   #popup.finding-mode #popup-finding-body { display: block; }
   #popup.finding-mode #popup-anchor-preview { display: none; }
   #popup.finding-mode #popup-delete { display: none !important; }
+  #popup.finding-mode #popup-copy { display: none !important; }
   #findings-empty {
     padding: 1.2em 1em;
     color: var(--muted);
@@ -413,6 +419,7 @@
     #popup-anchor-preview { background: #2a2a2a; color: #aaa; }
     #popup textarea { background: #2a2a2a; border-color: #444; color: #e0e0e0; }
     #popup button { background: #2a2a2a; border-color: #444; color: #e0e0e0; }
+    #popup-finding-body { color: #e0e0e0; }
     #status { background: #1a1a1a; border-top-color: #333; }
     #status-count strong { color: #e0e0e0; }
     #status-count:hover { background: rgba(255,255,255,.06); color: #e0e0e0; }
@@ -426,6 +433,7 @@
     .sidebar-item-comment { color: #e0e0e0; }
     .sidebar-section-header { background: #1a1a1a; border-bottom-color: #333; color: #888; }
     .sidebar-section-header .count-pill { background: #2a2a2a; color: #ccc; }
+    .finding-item-meta { color: #aaa; }
     .finding-item-meta .tag { color: #ffb094; }
     #findings-empty { color: #888; }
   }
@@ -473,6 +481,7 @@
   <div id="popup-actions">
     <button id="popup-delete" class="danger" type="button" aria-label="Delete comment">Delete</button>
     <button id="popup-cancel">Cancel</button>
+    <button id="popup-copy" type="button">Copy</button>
     <button id="popup-submit" class="primary">Submit</button>
   </div>
   <div id="popup-hint">⌘Enter to submit · Esc to cancel · click a 💬 mark to edit</div>
@@ -794,6 +803,34 @@ function dismissPopup() {
 popupCancel.addEventListener("click", dismissPopup);
 popupSubmit.addEventListener("click", submitFeedback);
 popupDelete.addEventListener("click", deleteFeedback);
+async function copyTextToClipboard(text) {
+  // Secure context (https / localhost): use the async Clipboard API.
+  if (navigator.clipboard && window.isSecureContext) {
+    try { await navigator.clipboard.writeText(text); return true; } catch (e) {}
+  }
+  // Insecure context (http over LAN / tailnet IP): clipboard API is undefined,
+  // fall back to the legacy execCommand path via a transient textarea.
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.focus(); ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch (e) { return false; }
+}
+document.getElementById("popup-copy").addEventListener("click", async () => {
+  if (!(pending && pending.anchor)) return;
+  const ok = await copyTextToClipboard(pending.anchor);
+  const b = document.getElementById("popup-copy");
+  const prev = b.textContent;
+  b.textContent = ok ? "Copied" : "Failed";
+  setTimeout(() => { b.textContent = prev; }, 1000);
+});
 
 popupTextarea.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {


### PR DESCRIPTION
## 배경

comment-review의 scan 결과가 뜨는 우측 사이드패널의 제안 가시성이 낮았습니다 — finding 텍스트가 흐릿하고, 휠 스크롤이 동작하지 않고, 긴 finding 본문이 팝업에서 갑갑하게 읽혔습니다. 또한 드래그-셀렉트 팝업에 복사 수단이 없었습니다.

## 변경

`epistemic-cooperative/skills/comment-review/templates/preview.html` 단일 파일:

- **대비**: 사이드패널 anchor·meta 텍스트 `#666→#444`, meta 폰트 `.72→.78em`
- **스크롤**: `#findings-list`에 자체 스크롤(`max-height: 40%`, `overflow-y: auto`) 부여 — finding이 많아도 휠 스크롤 동작
- **팝업 본문 가독성**: `#popup-finding-body` 색 `#666→#222`, `.82→.9em`, `max-height 9em→18em`
- **다크모드**: 위 변경의 라이트용 hex가 다크 배경에서 묻히지 않도록 팝업 본문(`#e0e0e0`)·meta(`#aaa`) 오버라이드 추가
- **복사 버튼**: 드래그-셀렉트 팝업에 Copy 버튼 추가. 비보안 컨텍스트(tailnet IP·HTTP)에서 `navigator.clipboard`가 없을 때 `execCommand('copy')` 폴백 + 성공/실패 정직한 피드백

플러그인 버전 `2.21.1 → 2.21.2`.

## 검증

임시 태스크 루트(`COMMENT_REVIEW_TASK_ROOT`)에 anchor(UUID·부분문자열)·문서레벨 finding과 200자 초과 긴 본문 픽스처를 올려 라이브 프리뷰로 확인:

- 대비·휠 스크롤·팝업 가독성·다크모드 가시성 확보
- 복사 버튼 실제 클립보드 복사 동작(폴백 경로)
- anchor finding 렌더링(문서 하이라이트 + 스크롤) 동작

`node .claude/skills/verify/scripts/static-checks.js .` 통과.
