### PR TITLE
feat(epistemic-cooperative): /review-loop 스킬 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.4",
+  "version": "2.21.5",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.2",
+  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+  "version": "2.21.3",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.6",
+  "version": "2.21.7",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.21.5",
+  "version": "2.21.6",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.5",
+  "version": "2.21.6",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.4",
+  "version": "2.21.5",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.2",
-  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+  "version": "2.21.3",
+  "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
@@ -17,8 +17,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Epistemic Cooperative",
-    "shortDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
-    "longDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+    "shortDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
+    "longDescription": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
     "developerName": "Jongwon Choi",
     "category": "Productivity",
     "capabilities": [

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.21.6",
+  "version": "2.21.7",
   "description": "Utility skills layered on top of the core 11 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/README.md
+++ b/epistemic-cooperative/README.md
@@ -20,6 +20,7 @@ A utility plugin for epistemic protocol onboarding, analytics, and work orchestr
 | `/triage` | Work-unit triage from GitHub issues | Dispatchable initial prompts |
 | `/dispatch` | Focused work-unit execution | Branches, PRs, feedback inscriptions |
 | `/forge` | Reference-grounded initial-prompt formation | Initial prompt for a follow-up session/tool |
+| `/review-loop` | Source-agnostic code/PR review-resolve loop to convergence | Applied fixes + convergence trace |
 
 ## Skills
 

--- a/epistemic-cooperative/README_ko.md
+++ b/epistemic-cooperative/README_ko.md
@@ -20,6 +20,7 @@
 | `/triage` | GitHub 이슈 기반 work-unit triage | dispatchable initial prompt |
 | `/dispatch` | focused work-unit 실행 | 브랜치, PR, feedback inscription |
 | `/forge` | 레퍼런스-grounded initial-prompt 형성 | 후속 세션/도구용 initial prompt |
+| `/review-loop` | source-agnostic 코드/PR 리뷰-resolve 루프 (수렴까지) | 적용된 수정 + 수렴 trace |
 
 ## 스킬
 

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-loop
-description: "Convergence-paced code/PR review-resolve loop via /review-loop. Drives a pluggable review source (review-ensemble | codex), verifies each finding against the codebase (/inquire) and work-flow (/contextualize), auto-applies Mechanical fixes (Extension) and gates Judgment fixes by shared disposition (Constitution), applies via /attend risk classification, then re-reviews until the source verdict converges to approve. User-invoked via /review-loop."
+description: "Convergence-paced code/PR review-resolve loop via /review-loop. Drives a pluggable review source (review-ensemble | codex | code-review), verifies each finding against the codebase (/inquire) and work-flow (/contextualize), auto-applies Mechanical fixes (Extension) and gates Judgment fixes by shared disposition (Constitution), applies via /attend risk classification, then re-reviews until the source verdict converges to approve. User-invoked via /review-loop."
 skills:
   - aitesis:inquire
   - epharmoge:contextualize
@@ -16,12 +16,12 @@ A source-agnostic, convergence-paced review-resolve loop for code/PR diffs: it d
 ```
 /review-loop [source?] [scope?]
 
-source : { review-ensemble | codex }   -- optional; review source behind the (diff) → { findings[], verdict } interface
-                                        --   absent → Phase 0 surfaces the choice with a recognizable default
-scope  : PR number | (implicit)         -- optional; PR number, or implicit current-PR / working-tree detection
+source : { review-ensemble | codex | code-review }   -- optional; review source behind the (diff) → { findings[], verdict } interface
+                                                     --   absent → Phase 0 surfaces the choice with a recognizable default
+scope  : PR number | (implicit)                      -- optional; PR number, or implicit current-PR / working-tree detection
 ```
 
-The review source is pluggable: any source satisfying the `(diff) → { findings[], verdict }` interface can drive the loop. `review-ensemble` and `codex` are the two sources documented in the Source Interface section; both are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 surfaces the choice with the available default. When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
+The review source is pluggable: any source satisfying the `(diff) → { findings[], verdict }` interface can drive the loop. `review-ensemble`, `codex`, and `code-review` are the three sources documented in the Source Interface section; all are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 surfaces the choice with the available default. When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
 
 ## Pipeline Overview
 
@@ -112,12 +112,13 @@ Phase 5's re-review **is** round k+1's review — one source call per round, not
 
 Every source satisfies one abstraction: `(diff) → { findings[], verdict }`. A finding is `[severity] file:line — description`; the verdict is `approve | needs-attention`. A source whose native output is richer than this shape (e.g. a sectioned report) satisfies the interface through an **extraction step** in its adapter — the adapter maps the native output onto `{ findings[], verdict }`. The set of sources is open and extensible (Emergent) — new sources may be added as long as their adapter yields this interface.
 
-Review sources are **runtime-selected, not static frontmatter dependencies**: the frontmatter `skills:` list declares only the unconditionally-composed protocols (`/inquire`, `/contextualize`, `/attend`); sources are pluggable and called dynamically (`review-ensemble` via a `Skill` call when chosen; `codex` via a background CLI call), so they are intentionally not fixed `skills:` entries. Two sources are documented:
+Review sources are **runtime-selected, not static frontmatter dependencies**: the frontmatter `skills:` list declares only the unconditionally-composed protocols (`/inquire`, `/contextualize`, `/attend`); sources are pluggable and called dynamically (`review-ensemble` via a `Skill` call when chosen; `codex` via a background CLI call; `code-review` via a `Skill` call to the built-in), so they are intentionally not fixed `skills:` entries. Three sources are documented:
 
 | Source | Kind | Mechanics |
 |--------|------|-----------|
 | `review-ensemble` | composite (cross-model: codex + /frame) | Call via `Skill("review-ensemble", ...)` passing the detected scope. Its Phase 5 output is a **sectioned report**, not a flat array — the adapter extracts the interface from it: the Codex section is already `[severity] file:line — description`; /frame's Lens findings are extracted from its Convergence/Assessment prose; the unified verdict is read directly. |
 | `codex` | single model, background | Launch in background and collect on the completion notification (see below). |
+| `code-review` | single, Claude-native (built-in) | Call via `Skill("code-review", ...)` passing the detected scope; it runs its own multi-angle finder fan-out and returns a findings JSON array (`{ file, line, summary, failure_scenario }`, ranked most-severe-first, capped at 15) with **no verdict line** — the adapter derives the verdict (`[]` → approve, otherwise needs-attention) and maps each finding to `[severity] file:line — description` (severity from rank order). Claude-native, no external CLI, so it is available whenever the loop runs. |
 
 **`codex` source mechanics** (reuse review-ensemble's exact pattern):
 

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: review-loop
+description: "Convergence-paced code/PR review-resolve loop via /review-loop. Drives a pluggable review source (review-ensemble | codex), verifies each finding against the codebase (/inquire) and work-flow (/contextualize), auto-applies Mechanical fixes (Extension) and gates Judgment fixes by shared disposition (Constitution), applies via /attend risk classification, then re-reviews until the source verdict converges to approve. User-invoked via /review-loop."
+skills:
+  - aitesis:inquire
+  - epharmoge:contextualize
+  - prosoche:attend
+---
+
+# Review Loop
+
+A source-agnostic, convergence-paced review-resolve loop for code/PR diffs: it drives a pluggable review source to convergence (verdict=approve), auto-applying mechanical fixes and gating the judgment calls.
+
+## Caller Signature
+
+```
+/review-loop [source?] [scope?]
+
+source : { review-ensemble | codex }   -- optional; review source behind the (diff) → { findings[], verdict } interface
+                                        --   absent → Phase 0 surfaces the choice with a recognizable default
+scope  : PR number | (implicit)         -- optional; PR number, or implicit current-PR / working-tree detection
+```
+
+The review source is pluggable: any source satisfying the `(diff) → { findings[], verdict }` interface can drive the loop. `review-ensemble` and `codex` are the two sources documented in the Source Interface section; both are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 surfaces the choice with the available default. When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
+
+## Pipeline Overview
+
+```
+/review-loop [source?] [scope?]
+  Phase 0  : source designation (arg → relay | absent → ask) + scope detect (PR diff | working tree)
+  Phase 1  : review    — source(diff) → { findings[], verdict }
+  Phase 2  : verify     — per finding: /inquire (vs codebase) + /contextualize (vs work-flow);
+                          drop findings failing support-integrity / context-fit (cite basis)
+  Phase 3  : classify  — Mechanical → Extension (auto)
+                          Judgment   → cluster by shared disposition → Constitution scope-gate
+  Phase 4  : apply      — /attend risk classification → apply approved edits
+  Phase 5  : re-review  — source(diff') → verdict'
+               verdict'=approve (or 0 new) → converge ; else round k+1: these findings → Phase 2 (re-review already done; no second source call)
+  free-exit : user may end the loop at any time (declared once in Phase 0)
+```
+
+The loop is the skill's identity; the review source is a parameter behind it. Loop control (verify → classify → apply → re-review) is fixed; the source that produces `{ findings[], verdict }` is swappable.
+
+## When to Use
+
+- Driving code/PR review findings all the way to resolution and convergence (verdict=approve)
+- A review pass surfaced findings and you want them verified, dispositioned, applied, and re-checked in one controlled loop
+- Multiple review rounds are expected before the diff is clean
+
+## When NOT to Use
+
+- Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets code/PR diffs)
+- Wanting a one-shot cross-model verdict with no resolution stage — that is `/review-ensemble` alone (it produces a VERDICT and stops; `/review-loop` is the loop that drives that verdict to approve)
+- Trivial single-line edits where a direct Edit is faster than a review loop
+
+## Phase 0: Source Designation + Scope Detection
+
+**Source designation.** If a `source` argument is given, use it directly — this is relay (Extension): the user already decided. If `source` is absent, **ask** — an init Constitution gate: present the available sources as a choice with a recommended default (`review-ensemble` when the `prothesis:frame` skill AND the codex CLI are both available — cross-model coverage is the richer review — else `codex`, single-model but still independent), and let the user constitute the selection. The recommended default makes the choice Recognition-fast, but source selection determines the cost and coverage of every round, so the loop waits for the answer rather than proceeding on the default silently.
+
+**Scope detection** (mirrors review-ensemble Phase 1):
+
+1. PR number given as `scope`: scope = `gh pr diff {N}`
+2. No PR argument: `gh pr view --json number,title,headRefName,changedFiles 2>/dev/null` to detect a current-branch PR; if found, scope = its diff
+3. No PR: scope = working tree (`git diff HEAD`)
+4. No changes anywhere: ask the user what to review (stop here)
+
+Capture the full diff content (needed for the codex prompt) and diff stats for context.
+
+**Free-exit affordance (declared once).** Announce here, before the first review round: *"You can end this loop at any time by saying so; on exit I will present the convergence trace so far and stop."* This is a free-response pathway, not a gate option — it does not reappear as a peer option at later gates.
+
+## Phase 1: Review
+
+Call the designated source over the current diff and obtain `{ findings[], verdict }`. Each finding carries the form `[severity] file:line — description`; `severity ∈ critical | high | medium | low | suggestion`; `verdict ∈ approve | needs-attention`. The per-source mechanics (how `review-ensemble` versus `codex` produce this output) live in the Source Interface section below — Phase 1 only consumes the interface.
+
+## Phase 2: Verify (against codebase + work-flow)
+
+Before acting on any finding, verify it — a review model can hallucinate or flag a stale issue, and currency is not the same as fidelity. For each finding:
+
+- Call `/inquire` to check the finding against the current codebase: does the asserted issue actually hold against the code as it stands? This is the support-integrity / currency check — an artifact being fresh does not establish that it tracks current behavior.
+- Call `/contextualize` to check fit against the work-flow and surrounding context: is the flagged pattern intentional here, and is the proposed fix contextually appropriate for this codebase's conventions?
+
+This phase is primarily relay — read-only codebase checks with cited basis. A finding that fails verification (the issue does not hold, or the fix is contextually wrong) is **dropped**, and the drop is surfaced with its cited basis rather than silently discarded or applied. Genuine Constitution uncertainties that `/inquire` raises (where the user's judgment is genuinely needed) fold forward into the Phase 3 disposition gate rather than firing as separate in-round chat gates — keeping the in-round gate count down to the Phase 3 cluster gates.
+
+## Phase 3: Classify + Disposition Gate
+
+Classify each surviving finding:
+
+- **Mechanical** — typo, rename, mechanical symbol or format fix; deterministic, one correct edit, no design judgment. → **Extension**: auto-apply, no gate. Mechanical findings never trigger Stop — the loop continues (only Constitution warrants interruption).
+- **Judgment** — multiple valid resolutions, a design tradeoff, or a change with irreversible divergence. → **Constitution**: the user's judgment constitutes the resolution.
+
+For Judgment findings, **cluster by shared disposition** — group findings that share the same resolution stance (apply / dismiss / defer / redesign) and present ONE scope-gate per cluster rather than one gate per finding. Follow context-question separation: present all analysis, evidence, and per-finding rationale as text BEFORE the gate; the gate itself carries only the question and the options with their differential implications. Each option must produce a materially different downstream trajectory — if two dispositions converge to the same trajectory, collapse them. Use plain everyday language in the user-facing emit.
+
+## Phase 4: Apply
+
+For every fix that is going to land — Mechanical (auto-approved) or Judgment (user-approved at the Phase 3 gate) — call `/attend` to risk-classify the edit before applying it. A "Mechanical" edit can still be risky: it may touch an irreversibility, a security boundary, or an external / human-visible effect that the Mechanical/Judgment axis does not capture. `/attend`'s risk classification is orthogonal to the resolution class and gates the apply on risk grounds.
+
+Apply the approved, risk-cleared edits. When `/attend` does **not** clear an edit (it surfaces an irreversibility, a security boundary, or a high-stake effect), the edit is not applied silently: surface the risk as a Constitution decision — the user chooses to accept-the-risk-and-apply, defer, or drop — and the finding is carried forward (re-entering the next round's disposition) until that decision lands. Where gate passage requires harness permission or high-stake execution, route that to the harness — surface it for approval, do not absorb the substrate decision into the loop.
+
+## Phase 5: Re-review + Convergence
+
+Re-call the source on the updated diff — a **FULL re-review each round**, not an incremental check against the prior round's findings. Convergence is reached when:
+
+- the source verdict converges to `approve`, OR
+- the re-review surfaces zero new non-refuted findings, OR
+- the user exits (free-response).
+
+Carried-forward findings — deferred at a prior disposition gate and still open — are not silently swallowed by a "zero new findings" convergence: at convergence, any still-open carried-forward findings are surfaced as annotated residual for the user (a dismiss-with-residual exit), never closed implicitly.
+
+Phase 5's re-review **is** round k+1's review — one source call per round, not a separate verdict-check followed by a fresh Phase 1 call. If the verdict is still `needs-attention`, the findings this re-review just produced become round k+1's input: increment the round counter and carry them into Phase 2 (verify) directly — do not re-call the source again at the next round's Phase 1. The re-review is full because a fix can introduce a regression a narrow incremental check would miss; only a full pass over the updated diff justifies declaring convergence.
+
+## Source Interface
+
+Every source satisfies one abstraction: `(diff) → { findings[], verdict }`. A finding is `[severity] file:line — description`; the verdict is `approve | needs-attention`. A source whose native output is richer than this shape (e.g. a sectioned report) satisfies the interface through an **extraction step** in its adapter — the adapter maps the native output onto `{ findings[], verdict }`. The set of sources is open and extensible (Emergent) — new sources may be added as long as their adapter yields this interface.
+
+Review sources are **runtime-selected, not static frontmatter dependencies**: the frontmatter `skills:` list declares only the unconditionally-composed protocols (`/inquire`, `/contextualize`, `/attend`); sources are pluggable and called dynamically (`review-ensemble` via a `Skill` call when chosen; `codex` via a background CLI call), so they are intentionally not fixed `skills:` entries. Two sources are documented:
+
+| Source | Kind | Mechanics |
+|--------|------|-----------|
+| `review-ensemble` | composite (cross-model: codex + /frame) | Call via `Skill("review-ensemble", ...)` passing the detected scope. Its Phase 5 output is a **sectioned report** (see review-ensemble Phase 5), not a flat array — the adapter extracts the interface from it: the Codex section is already `[severity] file:line — description`; /frame's Lens findings are extracted from its Convergence/Assessment prose; the unified verdict is read directly. |
+| `codex` | single model, background | Launch in background and collect on the completion notification (see below). |
+
+**`codex` source mechanics** (reuse review-ensemble's exact pattern):
+
+1. Write a review prompt to `/tmp/review_loop_codex_${SUFFIX}.txt` (generate `SUFFIX=$(openssl rand -hex 4)`), embedding the actual diff content so the model reviews exactly what changed. Ask for findings as `[severity] file:line — description` and a closing line `VERDICT: approve | needs-attention`.
+2. Launch via `Bash(run_in_background: true, timeout: 300000)`:
+   ```bash
+   codex exec --ephemeral --skip-git-repo-check -m gpt-5.5 --config model_reasoning_effort="high" --sandbox read-only < /tmp/review_loop_codex_${SUFFIX}.txt
+   ```
+3. Collect on the completion notification — do not poll or sleep. Parse the findings and the VERDICT.
+4. Clean up the temp file after reading (`rm -f /tmp/review_loop_codex_${SUFFIX}.txt`) to prevent `/tmp` accumulation across rounds.
+
+## Convergence
+
+Convergence is `verdict=approve`, OR zero new (non-refuted) findings on a full re-review, OR a user free-response exit. Convergence is demonstrated, not asserted: at each round, present a relay trace showing the round's transformation:
+
+```
+Round {k} — source: {source} — verdict: {verdict}
+  Resolved (auto):   {Mechanical findings auto-applied}
+  Resolved (gated):  {Judgment findings applied after the disposition gate}
+  Dropped at verify: {findings dropped, each with its cited basis}
+  Carried forward:   {findings deferred / still open}
+```
+
+The per-round trace is a relay presentation — present it and proceed; it is not a gate. At convergence, the accumulated traces are the evidence that each finding reached a disposition — applied, dropped at verify, or explicitly surfaced as annotated residual.
+
+## Error Handling
+
+| Condition | Action |
+|-----------|--------|
+| codex CLI not found | Fall back to the other source (`review-ensemble` if frame is available); if no source is available, note single-source limitation and stop |
+| No diff / no changes | Report and stop at Phase 0 (nothing to review) |
+| Source timeout (>300s) | Present partial findings collected so far, note the timeout, let the user decide whether to continue |
+| Source approves with no findings | Report converged immediately — verdict=approve at round 1, no edits needed |
+
+## Rules
+
+1. **Extension findings never trigger Stop** — Mechanical fixes auto-apply and the loop continues; only Constitution (Judgment) findings warrant interruption.
+2. **Context-question separation at every gate** — all analysis and evidence as pre-gate text; the gate carries only the question and options with differential implications.
+3. **Plain everyday language** in all user-facing emit — no internal protocol jargon at the gates.
+4. **FULL re-review each round** — re-call the source over the updated diff; do not trust an incremental delta check to declare convergence.
+5. **Verify before apply** — a finding that fails support-integrity or context-fit is dropped with its cited basis, never applied.
+6. **`/attend` gates risky applies regardless of class** — a Mechanical edit still passes through `/attend` risk classification before it lands; risk is orthogonal to the Mechanical/Judgment axis.
+
+## Deferred (v1.x stretch)
+
+Out of v1 scope, recorded so the source interface stays forward-compatible:
+
+- **Live-teammate driving** — driving an already-active teammate via SendMessage rather than spawning a fresh source per round. No codebase precedent yet; spawn-and-wait (background launch + collect on notification) is the current pattern.
+- **`/frame` as a direct single source** — using `/frame` standalone (not wrapped by `review-ensemble`) as a source behind the same interface.
+- **`/sublate` + `/gap` in the verify step** — adding `/sublate` (evidence-currency stress test) and `/gap` (decision-quality audit) alongside `/inquire` and `/contextualize` in Phase 2.
+
+## Composition Lineage
+
+Sibling of `comment-review`: both are review-resolve loops, but `/review-loop` targets code/PR diffs where `/comment-review` targets markdown artifacts before fixation. Termination differs — `/review-loop` is convergence-paced (it ends when the source verdict reaches approve), where `/comment-review` is user-paced (rounds end when the user answers the branch gate). The judgment venue differs too — `/review-loop` gates Judgment findings through a disposition-cluster chat scope-gate, where `/comment-review` surfaces findings through a browser sidepanel.
+
+`/review-loop` consumes `review-ensemble` as one of its review sources (the other being `codex` directly). It composes `/inquire` (codebase verification), `/contextualize` (work-flow fit), and `/attend` (apply-time risk classification).

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -17,11 +17,11 @@ A source-agnostic, convergence-paced review-resolve loop for code/PR diffs: it d
 /review-loop [source?] [scope?]
 
 source : { review-ensemble | codex | code-review }   -- optional; review source behind the (diff) → { findings[], verdict } interface
-                                                     --   absent → Phase 0 surfaces the choice with a recognizable default
+                                                     --   absent → Phase 0 asks which source to use (no default)
 scope  : PR number | (implicit)                      -- optional; PR number, or implicit current-PR / working-tree detection
 ```
 
-The review source is pluggable: any source satisfying the `(diff) → { findings[], verdict }` interface can drive the loop. `review-ensemble`, `codex`, and `code-review` are the three sources documented in the Source Interface section; all are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 surfaces the choice with the available default. When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
+The review source is pluggable: any source satisfying the `(diff) → { findings[], verdict }` interface can drive the loop. `review-ensemble`, `codex`, and `code-review` are the three sources documented in the Source Interface section; all are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 asks which source to use (no preselected default). When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
 
 ## Pipeline Overview
 
@@ -55,7 +55,7 @@ The loop is the skill's identity; the review source is a parameter behind it. Lo
 
 ## Phase 0: Source Designation + Scope Detection
 
-**Source designation.** If a `source` argument is given, use it directly — this is relay (Extension): the user already decided. If `source` is absent, **ask** — an init Constitution gate: present the available sources as a choice with a recommended default (`review-ensemble` when the `prothesis:frame` skill is available — it handles a missing codex internally, degrading to single-model review, so cross-model coverage is the richer choice whenever frame is present — else `codex`, single-model but still independent), and let the user constitute the selection. The recommended default makes the choice Recognition-fast, but source selection determines the cost and coverage of every round, so the loop waits for the answer rather than proceeding on the default silently.
+**Source designation.** If a `source` argument is given, use it directly — this is relay (Extension): the user already decided. If `source` is absent, **ask** — an init Constitution gate with no preselected default: present the available sources as a choice (`review-ensemble` for cross-model coverage when the `prothesis:frame` skill is available; `codex` for a single independent external model when the codex CLI is present; `code-review` for a Claude-native built-in review, always available), each with its coverage/cost trade-off, and let the user constitute the selection. Unless a `source` is named at invocation, the loop does not pick one on the user's behalf — source selection determines the cost and coverage of every round, so it waits for the answer.
 
 **Scope detection** (mirrors review-ensemble Phase 1):
 

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -50,12 +50,12 @@ The loop is the skill's identity; the review source is a parameter behind it. Lo
 ## When NOT to Use
 
 - Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets code/PR diffs)
-- Wanting a one-shot cross-model verdict with no resolution stage — that is `/review-ensemble` alone (it produces a VERDICT and stops; `/review-loop` is the loop that drives that verdict to approve)
+- Wanting a one-shot cross-model review with no apply phase — that is `/review-ensemble` alone (it surfaces findings and a verdict without applying fixes; `/review-loop` is the loop that drives those findings to approve)
 - Trivial single-line edits where a direct Edit is faster than a review loop
 
 ## Phase 0: Source Designation + Scope Detection
 
-**Source designation.** If a `source` argument is given, use it directly — this is relay (Extension): the user already decided. If `source` is absent, **ask** — an init Constitution gate: present the available sources as a choice with a recommended default (`review-ensemble` when the `prothesis:frame` skill AND the codex CLI are both available — cross-model coverage is the richer review — else `codex`, single-model but still independent), and let the user constitute the selection. The recommended default makes the choice Recognition-fast, but source selection determines the cost and coverage of every round, so the loop waits for the answer rather than proceeding on the default silently.
+**Source designation.** If a `source` argument is given, use it directly — this is relay (Extension): the user already decided. If `source` is absent, **ask** — an init Constitution gate: present the available sources as a choice with a recommended default (`review-ensemble` when the `prothesis:frame` skill is available — it handles a missing codex internally, degrading to single-model review, so cross-model coverage is the richer choice whenever frame is present — else `codex`, single-model but still independent), and let the user constitute the selection. The recommended default makes the choice Recognition-fast, but source selection determines the cost and coverage of every round, so the loop waits for the answer rather than proceeding on the default silently.
 
 **Scope detection** (mirrors review-ensemble Phase 1):
 
@@ -85,10 +85,10 @@ This phase is primarily relay — read-only codebase checks with cited basis. A 
 
 Classify each surviving finding:
 
-- **Mechanical** — typo, rename, mechanical symbol or format fix; deterministic, one correct edit, no design judgment. → **Extension**: auto-apply, no gate. Mechanical findings never trigger Stop — the loop continues (only Constitution warrants interruption).
+- **Mechanical** — typo, rename, mechanical symbol or format fix; deterministic, one correct edit, no design judgment. → **Extension**: auto-apply, no gate. Mechanical findings keep the loop running — only Constitution warrants interruption.
 - **Judgment** — multiple valid resolutions, a design tradeoff, or a change with irreversible divergence. → **Constitution**: the user's judgment constitutes the resolution.
 
-For Judgment findings, **cluster by shared disposition** — group findings that share the same resolution stance (apply / dismiss / defer / redesign) and present ONE scope-gate per cluster rather than one gate per finding. Follow context-question separation: present all analysis, evidence, and per-finding rationale as text BEFORE the gate; the gate itself carries only the question and the options with their differential implications. Each option must produce a materially different downstream trajectory — if two dispositions converge to the same trajectory, collapse them. Use plain everyday language in the user-facing emit.
+For Judgment findings, **cluster by shared disposition** — group findings that share the same resolution stance (apply / dismiss / defer) and present ONE scope-gate per cluster rather than one gate per finding. Follow context-question separation: present all analysis, evidence, and per-finding rationale as text BEFORE the gate; the gate itself carries only the question and the options with their differential implications. Each option must produce a materially different downstream trajectory — if two dispositions converge to the same trajectory, collapse them. Use plain everyday language in the user-facing emit.
 
 ## Phase 4: Apply
 
@@ -116,7 +116,7 @@ Review sources are **runtime-selected, not static frontmatter dependencies**: th
 
 | Source | Kind | Mechanics |
 |--------|------|-----------|
-| `review-ensemble` | composite (cross-model: codex + /frame) | Call via `Skill("review-ensemble", ...)` passing the detected scope. Its Phase 5 output is a **sectioned report** (see review-ensemble Phase 5), not a flat array — the adapter extracts the interface from it: the Codex section is already `[severity] file:line — description`; /frame's Lens findings are extracted from its Convergence/Assessment prose; the unified verdict is read directly. |
+| `review-ensemble` | composite (cross-model: codex + /frame) | Call via `Skill("review-ensemble", ...)` passing the detected scope. Its Phase 5 output is a **sectioned report**, not a flat array — the adapter extracts the interface from it: the Codex section is already `[severity] file:line — description`; /frame's Lens findings are extracted from its Convergence/Assessment prose; the unified verdict is read directly. |
 | `codex` | single model, background | Launch in background and collect on the completion notification (see below). |
 
 **`codex` source mechanics** (reuse review-ensemble's exact pattern):
@@ -154,11 +154,11 @@ The per-round trace is a relay presentation — present it and proceed; it is no
 
 ## Rules
 
-1. **Extension findings never trigger Stop** — Mechanical fixes auto-apply and the loop continues; only Constitution (Judgment) findings warrant interruption.
+1. **Extension findings keep the loop running** — Mechanical fixes auto-apply; only Constitution (Judgment) findings warrant interruption.
 2. **Context-question separation at every gate** — all analysis and evidence as pre-gate text; the gate carries only the question and options with differential implications.
 3. **Plain everyday language** in all user-facing emit — no internal protocol jargon at the gates.
 4. **FULL re-review each round** — re-call the source over the updated diff; do not trust an incremental delta check to declare convergence.
-5. **Verify before apply** — a finding that fails support-integrity or context-fit is dropped with its cited basis, never applied.
+5. **Verify before apply** — a finding that fails support-integrity or context-fit is dropped with its cited basis; only support-integrity-passing findings proceed to apply.
 6. **`/attend` gates risky applies regardless of class** — a Mechanical edit still passes through `/attend` risk classification before it lands; risk is orthogonal to the Mechanical/Judgment axis.
 
 ## Deferred (v1.x stretch)

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -148,7 +148,7 @@ The per-round trace is a relay presentation — present it and proceed; it is no
 
 | Condition | Action |
 |-----------|--------|
-| codex CLI not found | Fall back to the other source (`review-ensemble` if frame is available); if no source is available, note single-source limitation and stop |
+| Designated source not installed (codex CLI not found, or `prothesis:frame` absent for `review-ensemble`) | Surface which source is unavailable so the user recognizes it is not installed, and **ask** which available source to use instead — or whether to stop and install it; do not silently substitute. `code-review` is Claude-native and always available, so an alternative can always be offered |
 | No diff / no changes | Report and stop at Phase 0 (nothing to review) |
 | Source timeout (>300s) | Present partial findings collected so far, note the timeout, let the user decide whether to continue |
 | Source approves with no findings | Report converged immediately — verdict=approve at round 1, no edits needed |

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -206,7 +206,7 @@ describe('transformSkillMd', () => {
 describe('runtime contract view', () => {
   it('builds a packaged runtime view for every skill', () => {
     const views = buildRuntimeContractViews();
-    assert.equal(views.length, 32);
+    assert.equal(views.length, 33);
     for (const view of views) {
       assert.equal(view.skillEntryCount, 1, `${view.plugin}:${view.skill} should have one Skill.md entry`);
       assert.ok(view.transformedSkillMd, `${view.plugin}:${view.skill} should expose transformed Skill.md`);
@@ -503,7 +503,7 @@ describe('generate-changelog.js CLI', () => {
 // ============================================================
 
 describe('package.js CLI', () => {
-  it('packages all 32 skills plus bundle in dry-run', () => {
+  it('packages all 33 skills plus bundle in dry-run', () => {
     const output = execFileSync(process.execPath, [path.join(__dirname, 'package.js'), '--dry-run'], {
       encoding: 'utf8',
     });
@@ -516,7 +516,7 @@ describe('package.js CLI', () => {
     // surfacing the cause — this filter catches that specific failure mode.
     const anamnesisWarnings = result.warnings.filter(w => /anamnesis|recollect/.test(w));
     assert.deepEqual(anamnesisWarnings, [], 'no anamnesis/recollect packaging warnings');
-    assert.equal(result.results.length, 33);
+    assert.equal(result.results.length, 34);
     assert.deepEqual(
       result.results.map(entry => entry.zip).sort(),
       [
@@ -548,6 +548,7 @@ describe('package.js CLI', () => {
         'recollect.zip',
         'report.zip',
         'review-ensemble.zip',
+        'review-loop.zip',
         'sophia.zip',
         'steer.zip',
         'sublate.zip',


### PR DESCRIPTION
## 배경

`review-ensemble`은 cross-model 리뷰 verdict를 내고 멈춘다 — 해소(resolution) 단계가 없다. 이번 세션에서 수동으로 돌린 codex review-and-resolve 루프(리뷰 → finding 분류 → 자동적용/게이트 → 재리뷰 → 수렴)를 재사용 가능한 skill로 패키징한다.

## 변경

**신규 `/review-loop`** (epistemic-cooperative) — 소스 무관·수렴-페이스 코드/PR 리뷰-해소 루프 컨트롤러:

- 리뷰 소스(`review-ensemble` | `codex`)를 플러그블 인터페이스 `(diff)→{findings[], verdict}` 뒤에 두고 루프 제어와 오케스트레이션을 분리
- 매 라운드: 소스 리뷰 → `/inquire`·`/contextualize` 검증 → Mechanical 자동적용(Extension)·Judgment disposition 클러스터 게이트(Constitution) → `/attend` 위험분류 적용 → `verdict=approve`까지 full 재리뷰
- `comment-review`의 코드/PR 자매 스킬 (수렴-페이스 종료 / disposition 클러스터 채팅 게이트)

**설계·검증**:

- 설계: `/elicit`(Euporia) 4사이클 수렴
- 검증: review-loop **자기적용 dogfood** 3라운드 — R1에서 6 Judgment finding 게이트·적용, R2에서 1 Mechanical 자동적용(R1 fix가 심은 회귀를 full 재리뷰가 포착), R3 approve

**부수**: `plugin.json` 2.21.2→2.21.3 (`.codex-plugin` 동기), README·README_ko 행 추가, `package.test.js` 스킬 카운트 동기(views 32→33, results 33→34, `review-loop.zip` 추가).

## Test plan

- [ ] `node .claude/skills/verify/scripts/static-checks.js .` exit 0 (109 pass / 0 fail)
- [ ] `node --test scripts/package.test.js` 통과 (49 pass / 0 fail)
- [ ] CI 파이프라인(GitHub Actions) 통과
- [ ] 새 세션에서 플러그인 재로드 후 `/review-loop` 라우팅·발견 확인
- [ ] `/review-loop`을 실제 PR diff에 수동 실행해 `review-ensemble` 소스로 라운드 수렴 확인
