### PR TITLE
feat(katalepsis): add guarded Horizon gap type (empty-horizon probe)

### DIFF
--- a/docs/philosophical-anchors.md
+++ b/docs/philosophical-anchors.md
@@ -136,10 +136,49 @@ This boundary preserves the Stoic distinction between grasping a presented
 object and possessing a stable system of knowledge. Katalepsis operationalizes
 the former; it should not silently claim the latter.
 
+### Horizon Gap — Husserl's Empty Horizon and Gadamer's Hermeneutic Circle
+
+The `Horizon` gap type (added v2.4.0) grounds AI-initiated blind-spot surfacing
+in two phenomenological-hermeneutic sources. Husserl's *horizon* (Horizont):
+every act of understanding co-intends more than is given; the *empty horizon*
+(Leerhorizont) is the co-intended-but-unfulfilled region — extended by Iser's
+*Leerstellen* (the textual blanks a reader must fill, which drive the act of
+reading). A Horizon gap is exactly this: a co-intended edge of the result the
+user cannot name from within their own frame, yet whose filling is required for
+`P' ≅ R`. Gadamer supplies the dynamics: understanding advances through the
+*question* (Collingwood's logic of question and answer — to grasp something is to
+grasp the question it answers), and the *hermeneutic circle* lets the part revise
+the whole. When a Horizon probe lands, the user's frame expands (`P → P'`); the
+conditional `ReassessRoute` re-derivation (gated by `horizon_reframes(A)`) is that
+circle made operational — a part (one answer) revising the whole (the route map).
+
+**Complementary to Prothesis, not duplicative.** Prothesis (`/frame`) already
+instantiates Gadamer's *Horizontverschmelzung* (fusion of horizons) at the
+multi-perspective synthesis layer, fusing distinct interpretive horizons into one
+assessment. Katalepsis' `Horizon` operates one layer down: a single user's
+comprehension of a single result. Rule 14a fixes this boundary so the two do not
+conflate.
+
+**Why a named type rather than a heuristic — and why falsifiable.** The recall
+store had no category that could record a horizon moment, so empirical clustering
+of the pattern was unobservable by construction — an unknown-unknowns *silent
+failure*, not evidence of rarity. The ordinary Revision threshold (promote only
+after 3+ observed clusters) is therefore a catch-22 here: it demands evidence the
+instrumentation cannot emit. Promotion is the instrument that makes the pattern
+visible. To keep this from becoming an unfalsifiable license for "insight
+theater," `Horizon` ships with a six-condition false-positive guard
+(`admissible(HC)`) and a demotion review under the *unmeasurable-by-construction
+amendment*: if, once measurable, the type proves consistently empty,
+user-rejected, or non-improving, it is demoted. The bootstrap is a falsifiable
+hypothesis, not a permanent commitment.
+
 ## Citations
 
 - Clark, A., & Chalmers, D. (1998). The extended mind. *Analysis*, 58(1), 7-19.
 - Husserl, E. (1931). *Cartesian Meditations*, translated by Dorion Cairns. The Hague: Martinus Nijhoff, 1960. (Especially §§38-39 on passive and active synthesis.)
+- Husserl, E. (1913). *Ideas: General Introduction to Pure Phenomenology*. (On horizon/Horizont and the empty horizon, Leerhorizont.)
+- Gadamer, H.-G. (1960). *Truth and Method*. (On the hermeneutic circle, fusion of horizons, and the logic of question and answer.)
+- Iser, W. (1978). *The Act of Reading: A Theory of Aesthetic Response*. (On Leerstellen — textual blanks/gaps that drive the reading act.)
 - Stanford Encyclopedia of Philosophy. Stoicism. https://plato.stanford.edu/entries/stoicism/
 - Bertsch, S., Pesta, B. J., Wiscott, R., & McDaniel, M. A. (2007). The generation effect: A meta-analytic review. *Memory & Cognition*, 35, 201-210.
 - Roediger, H. L., & Karpicke, J. D. (2006). Test-enhanced learning: Taking memory tests improves long-term retention. *Psychological Science*, 17(3), 249-255.
@@ -153,6 +192,7 @@ the former; it should not silently claim the latter.
 - `.claude/rules/axioms.md` §A5 (main axiom; philosophical ground lives here)
 - `.claude/principles/architectural-principles.md` §Epistemic Cost Topology (principle statement only; phenomenological vindication lives here)
 - `anamnesis/skills/recollect/SKILL.md` (runtime protocol using Husserlian "synthesis of identification" and "empty_intention" as load-bearing operational terms; phenomenological context lives here)
+- `prothesis/skills/frame/SKILL.md` (uses Gadamer's Horizontverschmelzung at the multi-perspective synthesis layer; Katalepsis' `Horizon` gap is the comprehension-layer complement — see §Katalepsis Horizon Gap)
 
 ## Note on rules/ purity
 

--- a/docs/philosophical-anchors.md
+++ b/docs/philosophical-anchors.md
@@ -148,9 +148,12 @@ user cannot name from within their own frame, yet whose filling is required for
 `P' ≅ R`. Gadamer supplies the dynamics: understanding advances through the
 *question* (Collingwood's logic of question and answer — to grasp something is to
 grasp the question it answers), and the *hermeneutic circle* lets the part revise
-the whole. When a Horizon probe lands, the user's frame expands (`P → P'`); the
-conditional `ReassessRoute` re-derivation (gated by `horizon_reframes(A)`) is that
-circle made operational — a part (one answer) revising the whole (the route map).
+the whole. When a Horizon probe lands, the user's frame expands (`P → P'`):
+surfacing the blind spot is what resolves the unknown. Katalepsis stops there — the
+surfaced edge is the *basis* for a fusion of horizons, but the fusion itself (a part
+revising the whole framing) belongs to Prothesis' synthesis layer, not to the
+comprehension loop. This keeps the part-revises-whole movement where it belongs and
+the Katalepsis loop strictly terminating.
 
 **Complementary to Prothesis, not duplicative.** Prothesis (`/frame`) already
 instantiates Gadamer's *Horizontverschmelzung* (fusion of horizons) at the

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/.claude-plugin/plugin.json
+++ b/katalepsis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "katalepsis",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/katalepsis/.codex-plugin/plugin.json
+++ b/katalepsis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "katalepsis",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
   "author": {
     "name": "Jongwon Choi",

--- a/katalepsis/.codex-plugin/plugin.json
+++ b/katalepsis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "katalepsis",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
   "author": {
     "name": "Jongwon Choi",

--- a/katalepsis/.codex-plugin/plugin.json
+++ b/katalepsis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "katalepsis",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Verify understanding after AI work through intent-scented entry points — /grasp (κατάληψις: a grasping firmly)",
   "author": {
     "name": "Jongwon Choi",

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -14,6 +14,7 @@ Achieve certain comprehension of AI work through structured verification, enabli
 ```
 ── FLOW ──
 (R, U) → I → E → Fᵣ → Sₑ → B → Tᵣ → detect(E, B) → GT → P → Δ → Q → A → Q(coverage) → Tᵤ → P' → (loop until katalepsis)
+   back-edge: A → ReassessRoute(R, U, P') → Fᵣ' → E (re-enter Phase 1) when horizon_reframes(A); bounded to one re-derivation per task
 
 ── MORPHISM ──
 Result
@@ -24,6 +25,7 @@ Result
   → materialize(artifact_basis)        -- derive concrete artifact anchors for the chosen intent
   → register(tasks)                   -- track selected entry points as tasks
   → verify(comprehension)             -- Socratic probing per gap type
+  → reassess_route(R, U, P')          -- conditional back-edge: when a Horizon answer reframes (horizon_reframes(A)), re-derive the route map (Fᵣ') and re-enter at select(); bounded to one re-derivation per task
   → confirm(coverage)                 -- aspect coverage check per entry point
   → VerifiedUnderstanding
 requires: result_exists(R)              -- AI work output must exist in context
@@ -61,10 +63,14 @@ J_cov = CoverageRouting ∈ {sufficient, aspect(GapType), proposal}
 J_ref = ReframeRouting ∈ {continue_coverage, rederive_route}   -- after a Horizon hit: keep current coverage, or re-derive the route map
 GapType = {Expectation, Causality, Scope, Sequence, Horizon} ∪ Emergent(E, B)
 GT = Relevant gap types per entry point ⊆ GapType
-HC = HorizonCandidate { edge, anchors, failure_mode, probe_scenario }   -- a co-intended-but-unspoken edge the user did not name from within their framing
-admissible(HC) ≡ evidence_bound(HC, B) ∧ material(HC.failure_mode, P' ≅ R) ∧ unspoken(HC.edge, U ∪ prior A)
-              ∧ ¬route_selection_question(HC.edge) ∧ ¬decision_gap(HC.edge) ∧ scarce(HC)
+HC = HorizonCandidate { edge, anchors, failure_mode, probe_scenario }   -- a co-intended-but-unspoken edge the user did not name from within their framing; probe_scenario is the opacity-preserving scenario text, materialized at Phase 3 detection and consumed when the Qs probe is emitted, then discarded after A is received (it carries the scenario only — never the edge, answer, or rationale)
+admissible(HC) ≡ qualifies(HC) ∧ scarce(HC)
               -- false-positive guard: Horizon ∈ GT for an entry point only when some HC is admissible (else detect none)
+qualifies(HC) ≡ evidence_bound(HC, B) ∧ material(HC.failure_mode, P' ≅ R) ∧ unspoken(HC.edge, U ∪ prior A)
+              ∧ ¬route_selection_question(HC.edge) ∧ ¬decision_gap(HC.edge)   -- the five non-scarcity guards
+scarce(HC) ≡ |{ HC' : qualifies(HC') for this entry_point }| ≤ 1   -- at most one qualifying Horizon candidate per entry point; if several weak candidates compete, detect none
+horizon_reframes(A) ≡ answers_horizon_probe(A) ∧ reframed(P', Fᵣ)   -- A answers a Horizon probe AND the answer shifts P' so the selected entry_point is no longer well-anchored to the user's intent; gates route re-derivation (J_ref = rederive_route), else continue_coverage
+Fᵣ' : ComprehensionRouteMap   -- temporal successor of Fᵣ (prime = succession per notation convention); the re-derived route map output of ReassessRoute, same structure as Fᵣ
 Cursor = ContinuationCursor { task: TaskId, entry_point: EntryPoint, aspect: Optional(GapType), resume_target: String }
        -- resume_target is a short user-facing phase label, not a serialized cursor; structural position is task × entry_point × aspect
 BranchKind = {Proposal} ∪ Emergent(BranchKind)
@@ -87,7 +93,7 @@ Phase 3: Tᵣ → TaskUpdate(current) → detect(E, B) → GT → P → Δ  -- c
        → Read(source) if eval(A, Aᵣ) requires           -- AI-determined reference [Tool]
        → C(correct) if correct(A)                         -- verified-aspect continuation closure [Tool]
        → Qc(coverage) → Stop if correct(A)               -- aspect summary [Tool]
-       → ReassessRoute(R, U, P') → Fᵣ' → Phase 1 if horizon_reframes(A)  -- hermeneutic-circle re-derivation: only when a Horizon hit makes the selected entry point stale (J_ref = rederive_route); else J_ref = continue_coverage [Tool]
+       → ReassessRoute(R, U, P') → Fᵣ' → Phase 1 if horizon_reframes(A)  -- hermeneutic-circle re-derivation: fires after the Horizon Qs answer, before the coverage gate, and is mutually exclusive with Qc(coverage); only when a Horizon hit makes the selected entry point stale (J_ref = rederive_route); else J_ref = continue_coverage; bounded to one re-derivation per task [Tool]
        → converge → Λ.active := false if all_tasks_completed  -- convergence evidence is terminal; no downstream gate required
        → deactivate(user_esc | user_cancel) → Λ.active := false
 Turn boundary invariant: While `Λ.active = true` at turn end, the last user-facing shape must be a TerminalShape. Relay metadata `C(·)` may precede a terminal shape, but cannot be the sole final shape while active. The `converge` emission is `deactivation(all_tasks_completed)`, sets `Λ.active := false`, and is terminal without an additional gate.
@@ -100,6 +106,7 @@ If correct: emit continuation closure, then Aspect summary — show probed vs un
   User selects "sufficient" → TaskUpdate completed, next pending task.
   User selects additional aspect → Resume with selected gap type.
   User provides proposal via Other → detected by Step 3b, ejected via TaskCreate, emit side-branch continuation closure, resume current loop position.
+If a Horizon probe answer reveals the selected entry point is stale under the user's revised framing (`horizon_reframes(A)`): re-derive the route map (`Fᵣ'` via ReassessRoute) and re-enter Phase 1. Task reconciliation: completed tasks stay completed; in-progress and pending tasks are preserved and carried into the re-derived route, re-anchored to the new entry points, and `Λ.selected` is remapped onto `Λ.entryPoints'` (a stale reference whose task already completed is dropped). Convergence is evaluated only after every entry of `Fᵣ'` — including the preserved tasks — is processed. Termination guard: at most one route re-derivation per task, so a reframed route cannot itself trigger an unbounded re-derivation cascade.
 Cursor lifecycle: Initialize `Λ.cursor` after Phase 2 task registration. Update it whenever the current task changes, the entry point changes, the active aspect changes, or the user-facing resume label changes. On proposal ejection, snapshot the pre-ejection cursor into the branch artifact; when a branch is present in the emitted closure, closure-level `return_pointer` equals `branch.return_pointer`.
 Continue until: all selected tasks completed OR user ESC/cancel.
 Convergence evidence: At all-tasks-completed, present transformation trace — for each t ∈ Λ.tasks, show (ResultUngrasped(t) → verified(t) with comprehension evidence). Convergence is demonstrated, not asserted.
@@ -120,7 +127,7 @@ Phase 2 B   (observe) → Internal analysis (artifact basis materialization)
 Phase 2 Tᵣ  (track)   → TaskCreate (entry point tracking)
 Phase 3 detect (sense) → Internal analysis (gap type relevance detection per entry point)
 Phase 3 Horizon (sense) → Internal analysis (admissible(HC) false-positive guard; opacity-preserving — never exposes the suspected edge, the answer, or the selection rationale)
-Phase 3 ReassessRoute (observe) → Internal analysis (conditional Fᵣ' re-derivation when horizon_reframes(A); reuses Phase 0 AssessRoute machinery, opacity-preserving)
+Phase 3 ReassessRoute (observe) → Internal analysis (conditional Fᵣ' re-derivation when horizon_reframes(A); reuses Phase 0 AssessRoute machinery, opacity-preserving). Transparency: the re-derivation itself is relay (Extension) — deterministic given A and the materialized basis — and exercises no constitutive authority; the constitutive choice is preserved downstream at the re-entered Phase 1 Qc, where the user re-selects the entry point against Fᵣ'
 Phase 3 Qs  (constitution)   → present (mandatory; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3 Qᵣs (constitution)  → present (misconception reasoning inquiry)
 Phase 3 Qc  (constitution)   → present (aspect coverage: sufficient/aspect)
@@ -428,7 +435,7 @@ For each task (entry point):
 
    When step 3c evaluates as Correct for the current gap type:
 
-   1. Compare probed vs. unprobed detected relevant gap types (canonical + Emergent) for this entry point
+   1. Compare probed vs. unprobed detected relevant gap types (canonical + Emergent) for this entry point. The presented option set excludes `Horizon`: `GT_presented = unprobed(current_task) \ {Horizon}` — per Socratic opacity, `Horizon` is never surfaced as a user-facing coverage label; it is probed inline at detection, not offered as a routing option here.
    2. Emit continuation closure as relay text: verified aspect, current task/aspect status, branch artifact if one was just ejected, return pointer, and next available moves.
    3. If unprobed aspects exist, output a brief text nudge reminding the user they can share improvement ideas or unlisted comprehension gaps via the "Other" option (adapt wording to context, no fixed template).
 
@@ -499,4 +506,4 @@ For each task (entry point):
 12. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 13. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
 14. **Protocol-native route map**: Phase 0 produces a ComprehensionRouteMap before entry-point selection. The map is a pre-gate support object for entry-point adequacy, not a terminal status and not generic calibration. It annotates derived entry points; it does not create, filter, suppress, or terminalize entry-point tasks, and `VerifiedUnderstanding` is unchanged. `hidden_route` marks entries the user did not name while preserving their artifact anchors; `open` carries bounded discovery pressure only when the unknown could change which entry point the user selects. Socratic opacity is preserved — the map exposes why an entry point is useful, never the expected answer or reasoning path.
-14a. **Horizon boundary**: `Horizon` is a named *comprehension* gap — the AI surfaces a co-intended-but-unspoken edge required for `P' ≅ R` — NOT a Prothesis synthesis construct (`Horizontverschmelzung` fuses multiple *perspectives*; Horizon operates within one user's comprehension of one result). It is detected at Phase 3 *inside* an already-selected entry point and preserves `Fᵣ`/`Sₑ`/`Λ.entryPoints` unless `horizon_reframes(A)` triggers a route re-derivation. It is `Qs`, opacity-preserving (never names the edge, answer, or rationale before `A`), capped at one candidate per entry point (`scarce`), and forbidden when the edge is merely speculative, an entry-point-selection pressure (`hidden_route`/`open`), or a decision gap (`/gap`). It enters the taxonomy under the Revision-threshold *unmeasurable-by-construction amendment* and carries a demotion review.
+14a. **Horizon boundary**: `Horizon` is a named *comprehension* gap — the AI surfaces a co-intended-but-unspoken edge required for `P' ≅ R` — NOT a Prothesis synthesis construct (`Horizontverschmelzung` fuses multiple *perspectives*; Horizon operates within one user's comprehension of one result). It is detected at Phase 3 *inside* an already-selected entry point and preserves `Fᵣ`/`Sₑ`/`Λ.entryPoints` unless `horizon_reframes(A)` triggers a route re-derivation. It is `Qs`, opacity-preserving (never names the edge, answer, or rationale before `A`), capped at one candidate per entry point (`scarce`), and forbidden when the edge is merely speculative, an entry-point-selection pressure (`hidden_route`/`open`), or a decision gap (`/gap`). It enters the taxonomy under the Revision-threshold *unmeasurable-by-construction amendment* and carries a demotion review. When `horizon_reframes(A)` does fire, the route is fully re-derived rather than surgically augmented: a hermeneutic-circle reframe can shift which entry points are well-anchored across the whole map, not merely add one, so a single-entry-point insertion would under-capture the reframe; full re-derivation reuses the Phase 0 AssessRoute machinery instead of introducing a separate insertion path. Re-derivation is bounded to one per task (termination guard), and tasks are reconciled per LOOP (completed tasks stay completed; in-progress/pending tasks are preserved and carried into `Fᵣ'`).

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -58,7 +58,13 @@ Aᵣ = User's reasoning behind misconception (via Cognitive Partnership Move (Co
 Tᵤ = Task update (progress tracking)
 P' = Updated phantasia (refined understanding)
 J_cov = CoverageRouting ∈ {sufficient, aspect(GapType), proposal}
-GT = Relevant gap types per entry point ⊆ {Expectation, Causality, Scope, Sequence} ∪ Emergent(E, B)
+J_ref = ReframeRouting ∈ {continue_coverage, rederive_route}   -- after a Horizon hit: keep current coverage, or re-derive the route map
+GapType = {Expectation, Causality, Scope, Sequence, Horizon} ∪ Emergent(E, B)
+GT = Relevant gap types per entry point ⊆ GapType
+HC = HorizonCandidate { edge, anchors, failure_mode, probe_scenario }   -- a co-intended-but-unspoken edge the user did not name from within their framing
+admissible(HC) ≡ evidence_bound(HC, B) ∧ material(HC.failure_mode, P' ≅ R) ∧ unspoken(HC.edge, U ∪ prior A)
+              ∧ ¬route_selection_question(HC.edge) ∧ ¬decision_gap(HC.edge) ∧ scarce(HC)
+              -- false-positive guard: Horizon ∈ GT for an entry point only when some HC is admissible (else detect none)
 Cursor = ContinuationCursor { task: TaskId, entry_point: EntryPoint, aspect: Optional(GapType), resume_target: String }
        -- resume_target is a short user-facing phase label, not a serialized cursor; structural position is task × entry_point × aspect
 BranchKind = {Proposal} ∪ Emergent(BranchKind)
@@ -74,13 +80,14 @@ Phase 0: (R, U) → Orient(R, U) → I → DeriveEntries(I, R) → E → AssessR
 Phase 1: Fᵣ → Present(entry_point enriched by route-adequacy metadata; hidden_route + open when non-empty) → Qc(intent entry points) → Stop → Sₑ       -- entry point selection; default single, ordered multi when user names 2+ concerns [Tool]
 Phase 2: Sₑ → Materialize(Sₑ, R) → B → TaskCreate[selected] → Tᵣ  -- task registration; initialize Λ.cursor from first current task, entry point, and active aspect before Phase 3 [Tool]
 Phase 3: Tᵣ → TaskUpdate(current) → detect(E, B) → GT → P → Δ  -- comprehension check [Tool]
-       → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Emergent [Tool]
+       → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Horizon/Emergent [Tool]
        → TaskCreate[Proposal] if proposal(A)             -- proposal ejection (detected from Other) [Tool]
        → C(branch) if proposal(A)                         -- side-branch continuation closure [Tool]
        → Qᵣs(Aᵣ) → Stop if misconception(A)             -- reasoning inquiry [Tool]
        → Read(source) if eval(A, Aᵣ) requires           -- AI-determined reference [Tool]
        → C(correct) if correct(A)                         -- verified-aspect continuation closure [Tool]
        → Qc(coverage) → Stop if correct(A)               -- aspect summary [Tool]
+       → ReassessRoute(R, U, P') → Fᵣ' → Phase 1 if horizon_reframes(A)  -- hermeneutic-circle re-derivation: only when a Horizon hit makes the selected entry point stale (J_ref = rederive_route); else J_ref = continue_coverage [Tool]
        → converge → Λ.active := false if all_tasks_completed  -- convergence evidence is terminal; no downstream gate required
        → deactivate(user_esc | user_cancel) → Λ.active := false
 Turn boundary invariant: While `Λ.active = true` at turn end, the last user-facing shape must be a TerminalShape. Relay metadata `C(·)` may precede a terminal shape, but cannot be the sole final shape while active. The `converge` emission is `deactivation(all_tasks_completed)`, sets `Λ.active := false`, and is terminal without an additional gate.
@@ -112,6 +119,8 @@ Phase 1 Qc  (constitution)   → present (entry point selection enriched by Fᵣ
 Phase 2 B   (observe) → Internal analysis (artifact basis materialization)
 Phase 2 Tᵣ  (track)   → TaskCreate (entry point tracking)
 Phase 3 detect (sense) → Internal analysis (gap type relevance detection per entry point)
+Phase 3 Horizon (sense) → Internal analysis (admissible(HC) false-positive guard; opacity-preserving — never exposes the suspected edge, the answer, or the selection rationale)
+Phase 3 ReassessRoute (observe) → Internal analysis (conditional Fᵣ' re-derivation when horizon_reframes(A); reuses Phase 0 AssessRoute machinery, opacity-preserving)
 Phase 3 Qs  (constitution)   → present (mandatory; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3 Qᵣs (constitution)  → present (misconception reasoning inquiry)
 Phase 3 Qc  (constitution)   → present (aspect coverage: sufficient/aspect)
@@ -236,12 +245,23 @@ Comprehension gaps within each entry point:
 | **Causality** | User doesn't understand why something happens | "Do you understand why this value comes from here?" | Non-obvious causal chains (architecture, dependency) |
 | **Scope** | User doesn't see full impact | "Did you notice this also affects Y?" | Cross-cutting impact (architecture, refactoring) |
 | **Sequence** | User doesn't understand execution order | "Do you see that A happens before B?" | Order-sensitive changes (initialization, dependency) |
+| **Horizon** | A co-intended but unspoken edge of the selected entry point the user did not name from within their framing, required for `P' ≅ R`; admitted only when the false-positive guard `admissible(HC)` passes | Scenario-based open probe that tests the edge without naming it | The unknown-unknown that drives the largest comprehension gains but the user cannot request; blind-spot verification inside the current entry point — not route selection (cf. `hidden_route`/`open`), not a decision gap (→ `/gap`) |
 | **Emergent** | Gap outside canonical types | Adapted to specific comprehension deficit | Must satisfy morphism `ResultUngrasped → VerifiedUnderstanding`; boundary: comprehension verification (in-scope) vs. decision gaps (→ `/gap`) |
 
 **Emergent gap detection**: Named types are working hypotheses, not exhaustive categories. Detect Emergent gaps when:
 - User's comprehension difficulty spans multiple named types (e.g., understanding both causality and scope simultaneously in a cross-cutting change)
 - User selects "Other" or pushes back on all presented gap types in the coverage check
 - The AI work involves domain-specific patterns where canonical comprehension dimensions are insufficient (e.g., concurrency reasoning, security implications)
+
+**Horizon gap detection** (false-positive guarded): A Horizon gap is the AI surfacing a co-intended-but-unspoken edge the user could not name from within their own framing — the unknown-unknown that often drives the largest comprehension gains yet that the user cannot request, because from inside their frame it is invisible. Because it originates with the AI (not the user), it is admitted ONLY when every guard condition holds (`admissible(HC)`), so it reveals real blind spots rather than manufacturing clever ones ("insight theater"):
+- **Evidence-bound**: the edge's `anchors` name concrete artifacts in `B`; pure speculation disqualifies it
+- **Material**: missing the edge makes `P' ≅ R` false — it is necessary for verified understanding, not merely interesting
+- **Unspoken**: absent from `U`, the entry-point labels, and the user's prior answers (otherwise it is not a horizon)
+- **Non-route**: not an entry-point-selection question (that is `hidden_route`/`open` at Phase 0/1)
+- **Non-decision**: not a decision or commitment gap (that is `/gap`)
+- **Scarcity**: at most one Horizon candidate per entry point; if several weak candidates compete, detect none
+
+**Socratic opacity (Horizon)**: the probe exposes only the scenario/question — never the suspected edge, the expected answer, or the selection rationale before `A` is received; it uses everyday scenario language and never the words "horizon"/"blind spot"/"unspoken edge"; `Horizon` is recorded only internally in `Λ.detected`/`Λ.probed`, never surfaced as a label. This is consistent with the intentional absence of the `Basis:` marker — surfacing the suspected blind spot would compromise probe authenticity.
 
 ## Protocol
 
@@ -261,7 +281,9 @@ Analyze the AI work result and the user's signal to infer likely comprehension i
 
 **Cross-session enrichment**: Verified understanding domains surfaced via Anamnesis's hypomnesis store may adjust Phase 0 entry point prioritization — areas with established comprehension receive lower priority while novel or previously-failed comprehension areas are flagged. v2+ Katalepsis records are treated as entry-point evidence. v1 category-based records are weak hints only; do not directly map `Category` to `ComprehensionIntent`. This heuristic may bias detection toward previously observed patterns, but Phase 1 user selection remains constitutive.
 
-**Revision threshold**: When accumulated Emergent gap detections across 3+ sessions cluster around a recognizable pattern outside the named types {Expectation, Causality, Scope, Sequence}, the Gap Taxonomy warrants promotion to a new named type. When accumulated probe misclassifications across 3+ sessions cluster around a specific gap type's probe kind boundary (Qc vs Qs), that type's probe kind assignment warrants revision.
+**Revision threshold**: When accumulated Emergent gap detections across 3+ sessions cluster around a recognizable pattern outside the named types {Expectation, Causality, Scope, Sequence, Horizon}, the Gap Taxonomy warrants promotion to a new named type. When accumulated probe misclassifications across 3+ sessions cluster around a specific gap type's probe kind boundary (Qc vs Qs), that type's probe kind assignment warrants revision.
+
+**Unmeasurable-by-construction amendment**: The 3+-session clustering rule assumes the system can *observe* the candidate pattern. A pattern with no representational slot — no gap type, no recall-store category — can never accumulate the cluster; its absence is a silent failure (an unknown-unknown), not evidence of rarity. For such a category, a named *instrumentation* type may be added BEFORE 3 prior detections, but only when it (a) satisfies the morphism `ResultUngrasped → VerifiedUnderstanding`, (b) carries an explicit false-positive guard, and (c) defines a demotion review. `Horizon` is added under this amendment (its guard is `admissible(HC)`). **Demotion review**: after 3+ applicable Horizon opportunities, demote or revise `Horizon` if detections are consistently absent, are user-rejected as speculative, or fail to improve verified understanding. This keeps promotion falsifiable rather than permanent — the bootstrap exists to make the pattern measurable, and commits to reversing it if measurement shows no value.
 
 ### Phase 1: Intent-Scented Entry Point Selection
 
@@ -345,9 +367,10 @@ For each task (entry point):
    | **Sequence** | Qc (classificatory) | Answer space is enumerable — user selects from finite ordering options |
    | **Causality** | Qs (constitutive) | Causal reasoning requires model-discriminating options where the user’s own reasoning is diagnostic |
    | **Scope** | Qs (constitutive) | Impact enumeration requires user-generated content — scope awareness cannot be tested by selection alone |
+   | **Horizon** | Qs (constitutive) | The edge is not enumerable without leaking the blind spot; user-generated reasoning is diagnostic, and the scenario must test the edge without naming it |
    | **Emergent** | Qs (constitutive) | Unknown structure favors open response — no pre-enumerable answer space |
 
-   Estimated split: ~40–50% Type F (Expectation, Sequence → Qc probes), ~50–60% Type M (Causality, Scope, Emergent → Qs probes). The split reflects that comprehension verification often involves causal and scope understanding, which resist reduction to finite option sets.
+   Estimated split: ~40–50% Type F (Expectation, Sequence → Qc probes), ~50–60% Type M (Causality, Scope, Horizon, Emergent → Qs probes). The split reflects that comprehension verification often involves causal and scope understanding, which resist reduction to finite option sets.
 
    Then **present** the probe question with understanding-level options:
    ```
@@ -476,3 +499,4 @@ For each task (entry point):
 12. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 13. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
 14. **Protocol-native route map**: Phase 0 produces a ComprehensionRouteMap before entry-point selection. The map is a pre-gate support object for entry-point adequacy, not a terminal status and not generic calibration. It annotates derived entry points; it does not create, filter, suppress, or terminalize entry-point tasks, and `VerifiedUnderstanding` is unchanged. `hidden_route` marks entries the user did not name while preserving their artifact anchors; `open` carries bounded discovery pressure only when the unknown could change which entry point the user selects. Socratic opacity is preserved — the map exposes why an entry point is useful, never the expected answer or reasoning path.
+14a. **Horizon boundary**: `Horizon` is a named *comprehension* gap — the AI surfaces a co-intended-but-unspoken edge required for `P' ≅ R` — NOT a Prothesis synthesis construct (`Horizontverschmelzung` fuses multiple *perspectives*; Horizon operates within one user's comprehension of one result). It is detected at Phase 3 *inside* an already-selected entry point and preserves `Fᵣ`/`Sₑ`/`Λ.entryPoints` unless `horizon_reframes(A)` triggers a route re-derivation. It is `Qs`, opacity-preserving (never names the edge, answer, or rationale before `A`), capped at one candidate per entry point (`scarce`), and forbidden when the edge is merely speculative, an entry-point-selection pressure (`hidden_route`/`open`), or a decision gap (`/gap`). It enters the taxonomy under the Revision-threshold *unmeasurable-by-construction amendment* and carries a demotion review.

--- a/katalepsis/skills/grasp/SKILL.md
+++ b/katalepsis/skills/grasp/SKILL.md
@@ -13,8 +13,7 @@ Achieve certain comprehension of AI work through structured verification, enabli
 
 ```
 ── FLOW ──
-(R, U) → I → E → Fᵣ → Sₑ → B → Tᵣ → detect(E, B) → GT → P → Δ → Q → A → Q(coverage) → Tᵤ → P' → (loop until katalepsis)
-   back-edge: A → ReassessRoute(R, U, P') → Fᵣ' → E (re-enter Phase 1) when horizon_reframes(A); bounded to one re-derivation per task
+(R, U) → I → E → Fᵣ → Sₑ → B → Tᵣ → detect(E, B) → GT → P → Δ → Q → A → P' → Tᵤ → Q(coverage) → (loop until katalepsis)
 
 ── MORPHISM ──
 Result
@@ -25,7 +24,6 @@ Result
   → materialize(artifact_basis)        -- derive concrete artifact anchors for the chosen intent
   → register(tasks)                   -- track selected entry points as tasks
   → verify(comprehension)             -- Socratic probing per gap type
-  → reassess_route(R, U, P')          -- conditional back-edge: when a Horizon answer reframes (horizon_reframes(A)), re-derive the route map (Fᵣ') and re-enter at select(); bounded to one re-derivation per task
   → confirm(coverage)                 -- aspect coverage check per entry point
   → VerifiedUnderstanding
 requires: result_exists(R)              -- AI work output must exist in context
@@ -60,17 +58,15 @@ Aᵣ = User's reasoning behind misconception (via Cognitive Partnership Move (Co
 Tᵤ = Task update (progress tracking)
 P' = Updated phantasia (refined understanding)
 J_cov = CoverageRouting ∈ {sufficient, aspect(GapType), proposal}
-J_ref = ReframeRouting ∈ {continue_coverage, rederive_route}   -- after a Horizon hit: keep current coverage, or re-derive the route map
 GapType = {Expectation, Causality, Scope, Sequence, Horizon} ∪ Emergent(E, B)
 GT = Relevant gap types per entry point ⊆ GapType
 HC = HorizonCandidate { edge, anchors, failure_mode, probe_scenario }   -- a co-intended-but-unspoken edge the user did not name from within their framing; probe_scenario is the opacity-preserving scenario text, materialized at Phase 3 detection and consumed when the Qs probe is emitted, then discarded after A is received (it carries the scenario only — never the edge, answer, or rationale)
 admissible(HC) ≡ qualifies(HC) ∧ scarce(HC)
               -- false-positive guard: Horizon ∈ GT for an entry point only when some HC is admissible (else detect none)
-qualifies(HC) ≡ evidence_bound(HC, B) ∧ material(HC.failure_mode, P' ≅ R) ∧ unspoken(HC.edge, U ∪ prior A)
+qualifies(HC) ≡ evidence_bound(HC, B) ∧ material(HC.failure_mode) ∧ unspoken(HC.edge, U ∪ entry_point_labels ∪ prior A)
               ∧ ¬route_selection_question(HC.edge) ∧ ¬decision_gap(HC.edge)   -- the five non-scarcity guards
+              -- material(HC.failure_mode): leaving HC.edge unprobed is predicted to keep the achievable understanding short of R (P' ≇ R) — a counterfactual evaluated at detection against the current P and R, before A produces the realized P'
 scarce(HC) ≡ |{ HC' : qualifies(HC') for this entry_point }| ≤ 1   -- at most one qualifying Horizon candidate per entry point; if several weak candidates compete, detect none
-horizon_reframes(A) ≡ answers_horizon_probe(A) ∧ reframed(P', Fᵣ)   -- A answers a Horizon probe AND the answer shifts P' so the selected entry_point is no longer well-anchored to the user's intent; gates route re-derivation (J_ref = rederive_route), else continue_coverage
-Fᵣ' : ComprehensionRouteMap   -- temporal successor of Fᵣ (prime = succession per notation convention); the re-derived route map output of ReassessRoute, same structure as Fᵣ
 Cursor = ContinuationCursor { task: TaskId, entry_point: EntryPoint, aspect: Optional(GapType), resume_target: String }
        -- resume_target is a short user-facing phase label, not a serialized cursor; structural position is task × entry_point × aspect
 BranchKind = {Proposal} ∪ Emergent(BranchKind)
@@ -86,14 +82,14 @@ Phase 0: (R, U) → Orient(R, U) → I → DeriveEntries(I, R) → E → AssessR
 Phase 1: Fᵣ → Present(entry_point enriched by route-adequacy metadata; hidden_route + open when non-empty) → Qc(intent entry points) → Stop → Sₑ       -- entry point selection; default single, ordered multi when user names 2+ concerns [Tool]
 Phase 2: Sₑ → Materialize(Sₑ, R) → B → TaskCreate[selected] → Tᵣ  -- task registration; initialize Λ.cursor from first current task, entry point, and active aspect before Phase 3 [Tool]
 Phase 3: Tᵣ → TaskUpdate(current) → detect(E, B) → GT → P → Δ  -- comprehension check [Tool]
-       → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Horizon/Emergent [Tool]
+       → Qs(HC) → Stop → A → P' → Tᵤ ; Λ.detected[current] += Horizon ; Λ.probed[current] += Horizon  if Horizon ∈ GT ∧ admissible(HC) ∧ Horizon ∉ Λ.probed[current]  -- Horizon probe: fires immediately at detection (mandatory once), preempts the start-aspect selector; scenario-only, opacity-preserving (never the edge/answer/rationale, never a Horizon label); the answer is then evaluated as a normal probe answer (→ 3c eval → coverage), never a return to the start selector [Tool]
+       → Qs(Δ) → Stop → A → P' → Tᵤ                     -- verification loop; Qc for Expectation/Sequence gaps, Qs for Causality/Scope/Emergent (Horizon handled by the preempting edge above) [Tool]
        → TaskCreate[Proposal] if proposal(A)             -- proposal ejection (detected from Other) [Tool]
        → C(branch) if proposal(A)                         -- side-branch continuation closure [Tool]
        → Qᵣs(Aᵣ) → Stop if misconception(A)             -- reasoning inquiry [Tool]
        → Read(source) if eval(A, Aᵣ) requires           -- AI-determined reference [Tool]
        → C(correct) if correct(A)                         -- verified-aspect continuation closure [Tool]
        → Qc(coverage) → Stop if correct(A)               -- aspect summary [Tool]
-       → ReassessRoute(R, U, P') → Fᵣ' → Phase 1 if horizon_reframes(A)  -- hermeneutic-circle re-derivation: fires after the Horizon Qs answer, before the coverage gate, and is mutually exclusive with Qc(coverage); only when a Horizon hit makes the selected entry point stale (J_ref = rederive_route); else J_ref = continue_coverage; bounded to one re-derivation per task [Tool]
        → converge → Λ.active := false if all_tasks_completed  -- convergence evidence is terminal; no downstream gate required
        → deactivate(user_esc | user_cancel) → Λ.active := false
 Turn boundary invariant: While `Λ.active = true` at turn end, the last user-facing shape must be a TerminalShape. Relay metadata `C(·)` may precede a terminal shape, but cannot be the sole final shape while active. The `converge` emission is `deactivation(all_tasks_completed)`, sets `Λ.active := false`, and is terminal without an additional gate.
@@ -106,7 +102,6 @@ If correct: emit continuation closure, then Aspect summary — show probed vs un
   User selects "sufficient" → TaskUpdate completed, next pending task.
   User selects additional aspect → Resume with selected gap type.
   User provides proposal via Other → detected by Step 3b, ejected via TaskCreate, emit side-branch continuation closure, resume current loop position.
-If a Horizon probe answer reveals the selected entry point is stale under the user's revised framing (`horizon_reframes(A)`): re-derive the route map (`Fᵣ'` via ReassessRoute) and re-enter Phase 1. Task reconciliation: completed tasks stay completed; in-progress and pending tasks are preserved and carried into the re-derived route, re-anchored to the new entry points, and `Λ.selected` is remapped onto `Λ.entryPoints'` (a stale reference whose task already completed is dropped). Convergence is evaluated only after every entry of `Fᵣ'` — including the preserved tasks — is processed. Termination guard: at most one route re-derivation per task, so a reframed route cannot itself trigger an unbounded re-derivation cascade.
 Cursor lifecycle: Initialize `Λ.cursor` after Phase 2 task registration. Update it whenever the current task changes, the entry point changes, the active aspect changes, or the user-facing resume label changes. On proposal ejection, snapshot the pre-ejection cursor into the branch artifact; when a branch is present in the emitted closure, closure-level `return_pointer` equals `branch.return_pointer`.
 Continue until: all selected tasks completed OR user ESC/cancel.
 Convergence evidence: At all-tasks-completed, present transformation trace — for each t ∈ Λ.tasks, show (ResultUngrasped(t) → verified(t) with comprehension evidence). Convergence is demonstrated, not asserted.
@@ -127,7 +122,6 @@ Phase 2 B   (observe) → Internal analysis (artifact basis materialization)
 Phase 2 Tᵣ  (track)   → TaskCreate (entry point tracking)
 Phase 3 detect (sense) → Internal analysis (gap type relevance detection per entry point)
 Phase 3 Horizon (sense) → Internal analysis (admissible(HC) false-positive guard; opacity-preserving — never exposes the suspected edge, the answer, or the selection rationale)
-Phase 3 ReassessRoute (observe) → Internal analysis (conditional Fᵣ' re-derivation when horizon_reframes(A); reuses Phase 0 AssessRoute machinery, opacity-preserving). Transparency: the re-derivation itself is relay (Extension) — deterministic given A and the materialized basis — and exercises no constitutive authority; the constitutive choice is preserved downstream at the re-entered Phase 1 Qc, where the user re-selects the entry point against Fᵣ'
 Phase 3 Qs  (constitution)   → present (mandatory; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3 Qᵣs (constitution)  → present (misconception reasoning inquiry)
 Phase 3 Qc  (constitution)   → present (aspect coverage: sufficient/aspect)
@@ -338,7 +332,7 @@ For each task (entry point):
 
 1. **TaskUpdate** to `in_progress`
 
-2. **Present overview**: Brief summary of the selected intent and its artifact basis, then show everyday aspect labels derived from detected gap types (GT) and let user select starting aspect:
+2. **Present overview**: Brief summary of the selected intent and its artifact basis, then show everyday aspect labels derived from detected gap types (`GT \ {Horizon}` — Horizon is never surfaced as a selectable aspect label; per Socratic opacity it is probed inline at detection, never offered in the start selector or any routing option) and let user select starting aspect:
 
    Present the detected aspects as text output:
    - What this path covers: [plain-language aspect list]
@@ -355,6 +349,8 @@ For each task (entry point):
    ```
 
    This lightweight `select_start` prevents AI-imposed framing on the first probe without requiring full pre-authorization of the detection set. User picks starting direction; remaining aspects surface in step 3d. Use everyday labels like "what changed", "why this path", "what it affects", or "what happens first"; keep raw gap-type names internal unless the user already uses that vocabulary.
+
+   **Horizon preemption (precedes the start selector)**: Before presenting the start-aspect selector above, check for a detected admissible Horizon: if `Horizon ∈ GT ∧ admissible(HC) ∧ Horizon ∉ Λ.probed[current]`, fire the scenario-only `Qs` Horizon probe immediately (per the Horizon probe exception in step 3) — it preempts this selector and is mandatory once per admissible detection, never surfacing a Horizon label. On the answer, record `Λ.detected[current] += Horizon` and `Λ.probed[current] += Horizon`. The scenario answer is then evaluated per step 3c and the entry point proceeds to the coverage check (step 3d) — never back to this start selector; any remaining non-Horizon aspects surface through the coverage check (step 3d), consistent with the formal transition. If Horizon was the only detected gap (`GT \ {Horizon} = ∅`), the coverage check finds no remaining aspect and completes the entry point.
 
 3. **Verify comprehension** by **presenting** a Socratic probe via Cognitive Partnership Move (Constitution):
 
@@ -379,7 +375,9 @@ For each task (entry point):
 
    Estimated split: ~40–50% Type F (Expectation, Sequence → Qc probes), ~50–60% Type M (Causality, Scope, Horizon, Emergent → Qs probes). The split reflects that comprehension verification often involves causal and scope understanding, which resist reduction to finite option sets.
 
-   Then **present** the probe question with understanding-level options:
+   **Horizon probe exception**: a Horizon probe never uses the labeled understanding-level option template below — enumerating a `Correct understanding`/`Misconception` option would expose the edge before `A`. Present only the scenario as an open question (free-response; the "Other"-style open path is the entire probe), and never name the edge, the expected answer, or the rationale. Evaluate the free answer for whether the user independently reaches the edge.
+
+   Then **present** the probe question with understanding-level options (non-Horizon gap types):
    ```
    question: "[Essential verification question]"
    options:
@@ -506,4 +504,4 @@ For each task (entry point):
 12. **Plain emit discipline**: User-facing emit (Phase 2 surfacing prose, convergence traces, gate options, and any text shown to the user) uses everyday language to reduce the user's cognitive load — every emit token should carry decision-relevant meaning, not project-internal overhead. SKILL.md formal-block vocabulary — variable names with subscripts, Greek-rooted terms in narrative, formal type labels inline, and code-style backtick tokens — stays in the formal block. What the user reads is the action, observation, or question in their idiom.
 13. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
 14. **Protocol-native route map**: Phase 0 produces a ComprehensionRouteMap before entry-point selection. The map is a pre-gate support object for entry-point adequacy, not a terminal status and not generic calibration. It annotates derived entry points; it does not create, filter, suppress, or terminalize entry-point tasks, and `VerifiedUnderstanding` is unchanged. `hidden_route` marks entries the user did not name while preserving their artifact anchors; `open` carries bounded discovery pressure only when the unknown could change which entry point the user selects. Socratic opacity is preserved — the map exposes why an entry point is useful, never the expected answer or reasoning path.
-14a. **Horizon boundary**: `Horizon` is a named *comprehension* gap — the AI surfaces a co-intended-but-unspoken edge required for `P' ≅ R` — NOT a Prothesis synthesis construct (`Horizontverschmelzung` fuses multiple *perspectives*; Horizon operates within one user's comprehension of one result). It is detected at Phase 3 *inside* an already-selected entry point and preserves `Fᵣ`/`Sₑ`/`Λ.entryPoints` unless `horizon_reframes(A)` triggers a route re-derivation. It is `Qs`, opacity-preserving (never names the edge, answer, or rationale before `A`), capped at one candidate per entry point (`scarce`), and forbidden when the edge is merely speculative, an entry-point-selection pressure (`hidden_route`/`open`), or a decision gap (`/gap`). It enters the taxonomy under the Revision-threshold *unmeasurable-by-construction amendment* and carries a demotion review. When `horizon_reframes(A)` does fire, the route is fully re-derived rather than surgically augmented: a hermeneutic-circle reframe can shift which entry points are well-anchored across the whole map, not merely add one, so a single-entry-point insertion would under-capture the reframe; full re-derivation reuses the Phase 0 AssessRoute machinery instead of introducing a separate insertion path. Re-derivation is bounded to one per task (termination guard), and tasks are reconciled per LOOP (completed tasks stay completed; in-progress/pending tasks are preserved and carried into `Fᵣ'`).
+14a. **Horizon boundary**: `Horizon` is a named *comprehension* gap — the AI surfaces a co-intended-but-unspoken edge required for `P' ≅ R` — NOT a Prothesis synthesis construct (`Horizontverschmelzung` fuses multiple *perspectives*; Horizon operates within one user's comprehension of one result). It is detected at Phase 3 *inside* an already-selected entry point and preserves `Fᵣ`/`Sₑ`/`Λ.entryPoints`. It is `Qs`, opacity-preserving (never names the edge, answer, or rationale before `A`), capped at one candidate per entry point (`scarce`), and forbidden when the edge is merely speculative, an entry-point-selection pressure (`hidden_route`/`open`), or a decision gap (`/gap`). It enters the taxonomy under the Revision-threshold *unmeasurable-by-construction amendment* and carries a demotion review. **Surfacing, not fusion**: Katalepsis' role is to *surface* the Horizon edge — making the blind spot visible is what resolves the unknown, and that surfacing is the *basis* for a later fusion of horizons (`Horizontverschmelzung`), which belongs to Prothesis' synthesis layer. Katalepsis does not itself re-derive the route or re-frame the comprehension on a Horizon hit; the user's own reframing and any cross-perspective fusion are left to the user and to Prothesis. A surfaced Horizon answer is evaluated as a normal probe answer (step 3c) and proceeds to the coverage check — keeping the Katalepsis/Prothesis boundary sharp and the comprehension loop strictly terminating.


### PR DESCRIPTION
## Summary

Promotes **`Horizon`** to a named Katalepsis gap type — the AI surfacing a *co-intended-but-unspoken edge* the user could not name from within their own framing, required for `P' ≅ R` — as a **disciplined instrument** guarded against "insight theater", not a license.

## Why (decision arc — full detail in #493)

1. **1st codex (GPT-5.5 xhigh) review → option (b)** (Emergent-adjacent heuristic), on Revision-threshold + cascade-cost grounds.
2. **Northstar re-examination**: cascade cost is not a Northstar argument (the hermeneutic circle licenses morphism change); decision reduces to the evidence question.
3. **Inductive scan of 33 past `/grasp` sessions**: both recurrence signals were **measurement artifacts** — `ResultUngrasped`/`VerifiedUnderstanding` (grasp endpoints) and `GapUnnoticed` (a Syneidesis `/gap` marker), not horizon moments. Hand-verified genuine rate ~0–5%.
4. **Decisive finding**: the recall store has *no category* to record a horizon moment → ~0% is an **unknown-unknowns silent failure**, not rarity. The Revision threshold becomes a **catch-22** (it demands clustering evidence the instrumentation cannot emit).
5. **2nd codex review** (corrected evidence + silent-failure reframing) → **reversed to guarded (c)**.

## What

- `GapType = {Expectation, Causality, Scope, Sequence, Horizon} ∪ Emergent`
- **6-condition false-positive guard** `admissible(HC)`: evidence-bound · material (`P'≅R`) · unspoken · non-route · non-decision · scarcity (≤1/entry)
- `Qs` probe + **Socratic opacity** (never names the edge/answer/rationale before the answer; no `Basis:`)
- **Revision-threshold "unmeasurable-by-construction" amendment** + **demotion review** → a *falsifiable bootstrap*: promote to make the pattern measurable, and demote if it proves consistently empty / user-rejected / non-improving
- Conditional **hermeneutic-circle re-derivation** (`ReassessRoute`, gated by `horizon_reframes(A)`) — route map re-derived only when a Horizon hit makes the selected entry point stale
- **Rule 14a** bounds Horizon vs Prothesis `Horizontverschmelzung` (multi-perspective synthesis layer), vs `hidden_route`/`open` (entry-selection layer), vs `/gap` (decision layer)
- Philosophical grounding: Husserl empty horizon (Leerhorizont) / Iser Leerstellen + Gadamer hermeneutic circle — `docs/philosophical-anchors.md` §Katalepsis

## Files

- `katalepsis/skills/grasp/SKILL.md`
- `katalepsis/.claude-plugin/plugin.json` (`2.3.1` → `2.4.0`)
- `docs/philosophical-anchors.md`

Closes #493

> codex: *"promote `Horizon`, but make it a disciplined instrument, not a license for the AI to perform insight theater."*
