### PR TITLE
feat(elenchus): antithesis에 추론-오류 아키타입 스캔 Pattern D 추가 (#504)

### DIFF
--- a/elenchus/.claude-plugin/plugin.json
+++ b/elenchus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "elenchus",
   "description": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/elenchus/.codex-plugin/plugin.json
+++ b/elenchus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elenchus",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Vet working context by dialectical antithesis before action — /sublate (ἔλεγχος: cross-examination)",
   "author": {
     "name": "Jongwon Choi",

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -9,7 +9,7 @@ Vet working context by dialectical antithesis before action through structured p
 
 ## Definition
 
-**Elenchus** (ἔλεγχος): A dialogical act of cross-examination — from the Socratic refutation tradition meaning "testing by argument" — resolving suspect working context into vetted context through provenance challenge, counterfactual gap forecasting, and cross-source consistency check before pre-execution sync. The protocol's lexical verb is `/sublate`. Each suspect source undergoes the motion of stating its current claim, surfacing what would shake it, and then deciding how to handle the source in light of that challenge (the Hegelian *Aufhebung* — preserve + negate + lift up — supplies the source vocabulary).
+**Elenchus** (ἔλεγχος): A dialogical act of cross-examination — from the Socratic refutation tradition meaning "testing by argument" — resolving suspect working context into vetted context through provenance challenge, counterfactual gap forecasting, cross-source consistency check, and inference-fallacy archetype scan before pre-execution sync. The protocol's lexical verb is `/sublate`. Each suspect source undergoes the motion of stating its current claim, surfacing what would shake it, and then deciding how to handle the source in light of that challenge (the Hegelian *Aufhebung* — preserve + negate + lift up — supplies the source vocabulary).
 
 ```
 ── FLOW ──
@@ -86,7 +86,7 @@ early_exit = user_esc
 
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
-Phase 0 identify        (sense)        → Internal analysis (high-leverage / age / chain / contradiction scan)
+Phase 0 identify        (sense)        → Internal analysis (high-leverage / age / chain / contradiction / inference-character scan)
 Phase 1 ProvenanceTag   (observe)      → Read, Grep (verification of source origin, authorized claim, and downstream references)
 Phase 1 AntithesisPosit (sense)        → Internal analysis (Pattern A/B/C/D antithesis generation per source)
 Phase 2 Qs              (constitution) → present (mandatory; per-source disposition slots; Esc → loop termination at LOOP level, not a Disposition)
@@ -151,6 +151,7 @@ When Elenchus is active:
 | Provenance concern | User questions verification status of a specific source |
 | Counterfactual concern | User varies a current condition and asks whether downstream still holds |
 | Cross-source friction | User notices two collected sources pointing at the same referent diverging |
+| Inference-soundness concern | User questions whether a conclusion's reasoning holds rather than the source it cites |
 
 **Qualifying condition**: Activate only when working context exists and the user signals an upcoming pre-execution sync or externalization. The protocol does not activate on freshly-arrived context with no audit-candidate sources — the silent scan at Phase 0 yields S_high = ∅, which converges trivially.
 
@@ -169,7 +170,7 @@ When Elenchus is active:
 
 ## Source Identification Criteria
 
-User-initiated activation triggers Phase 0's silent scan. The scan does not gate activation — its purpose is to *select which sources within the committed working context warrant audit*. The four criteria below guide source selection; sources matching one or more enter S_high.
+User-initiated activation triggers Phase 0's silent scan. The scan does not gate activation — its purpose is to *select which sources within the committed working context warrant audit*. The five criteria below guide source selection; sources matching one or more enter S_high.
 
 | Criterion | Condition | Pattern Hint |
 |-----------|-----------|--------------|
@@ -228,7 +229,7 @@ When a source is itself a conclusion reached by inference — an `AIInference` o
 Analyze the working context and select audit-candidate sources. This phase is silent — no user interaction.
 
 1. **Bind W**: the working context committed in the session — sources, claims, downstream references, and the pre-execution action under consideration
-2. **Apply Source Identification Criteria**: scan each source for high-leverage accumulation, age beyond horizon, provenance-chain length, and cross-source contradiction
+2. **Apply Source Identification Criteria**: scan each source for high-leverage accumulation, age beyond horizon, provenance-chain length, cross-source contradiction, and inference-character conclusion
 3. **Compose S_high**: the union of sources matching at least one criterion
 4. If S_high = ∅: emit empty VettedContext trivially and deactivate (no audit-candidate sources warrant vetting)
 5. If S_high ≠ ∅: proceed to Phase 1
@@ -243,7 +244,7 @@ Generate metadata triple plus dialectical antithesis per source.
 
 **Step 2 — Antithesis positing**: For each tagged source, select the most applicable pattern (A, B, C, D, or Emergent) and construct an antithesis. A source that is itself an inferred conclusion (origin `AIInference`, or a conclusion functioning as a standing premise) is a candidate for Pattern D, where the antithesis reverse-derives the inference's flaw condition from a fallacy archetype rather than from a user-supplied counter-condition. The antithesis must:
 - Cite the source's claim verbatim, anchored to the originating sentence or artifact
-- Name the dialectical challenge concretely (a verification gap, a counterfactual condition, a divergent sibling source)
+- Name the dialectical challenge concretely (a verification gap, a counterfactual condition, a divergent sibling source, or an inference-fallacy archetype condition)
 - Surface the basis for the challenge so the user can recognize the antithesis's evidence
 
 **Cross-session enrichment**: Anamnesis hypomnesis store, when invoked via `/recollect`, may surface prior antithesis-disposition pairs for adjacent sources; recalled patterns seed Phase 1 pattern selection but the constitutive judgment remains with the user.
@@ -297,7 +298,7 @@ At vetted(V), present the transformation trace before declaring convergence. For
 
 ```
 [Source identifier]
-  Pattern: A | B | C | Emergent(name)
+  Pattern: A | B | C | D | Emergent(name)
   Antithesis: [concrete antithesis text]
   Disposition: [chosen variant with parameters]
 ```

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -255,7 +255,7 @@ Present antitheses and disposition slots via Cognitive Partnership Move (Constit
 **Pre-gate text output** (Context-Question Separation): For each source in S_high, present as text output:
 - The source's content (verbatim or close paraphrase)
 - The tagging triple (provenance verdict, freshness verdict, leverage count)
-- The selected pattern (A, B, C, or Emergent) with its thesis ↔ antithesis pair
+- The selected pattern (A, B, C, D, or Emergent) with its thesis ↔ antithesis pair
 - The basis cited for the antithesis
 
 Then present a per-source disposition interaction. Each source receives its own slot; batching across sources is permitted when slot count ≤ 4, otherwise process sources in batches of up to 4.

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -67,7 +67,7 @@ VettedContext  = V where vetted(V) ∨ user_esc
 ── PHASE TRANSITIONS ──
 Phase 0: W → identify(W) → S_high                                       -- silent scan (no user interaction)
 Phase 1: S_high → Step₁ tag(provenance, freshness, leverage) → S'       [Tool: Read, Grep]
-         Step₂ posit(antithesis per s ∈ S') → A[]                        -- per-source Pattern A ∪ B ∪ C generation
+         Step₂ posit(antithesis per s ∈ S') → A[]                        -- per-source Pattern A ∪ B ∪ C ∪ D generation
 Phase 2: (A[], disposition slots) → Qs(per-source) → Stop → J            [Tool: Constitution interaction]
 Phase 3: J → integrate(J, S') → V                                        -- per-source disposition recorded
 
@@ -88,7 +88,7 @@ early_exit = user_esc
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Phase 0 identify        (sense)        → Internal analysis (high-leverage / age / chain / contradiction scan)
 Phase 1 ProvenanceTag   (observe)      → Read, Grep (verification of source origin, authorized claim, and downstream references)
-Phase 1 AntithesisPosit (sense)        → Internal analysis (Pattern A/B/C antithesis generation per source)
+Phase 1 AntithesisPosit (sense)        → Internal analysis (Pattern A/B/C/D antithesis generation per source)
 Phase 2 Qs              (constitution) → present (mandatory; per-source disposition slots; Esc → loop termination at LOOP level, not a Disposition)
 Phase 3 integrate       (track)        → Internal state update (Λ.dispositions, Λ.history)
 converge                (extension)    → TextPresent+Proceed (per-source disposition trace; proceed with VettedContext)

--- a/elenchus/skills/sublate/SKILL.md
+++ b/elenchus/skills/sublate/SKILL.md
@@ -21,7 +21,7 @@ W → identify(W) → S_high → tag(provenance, freshness, leverage) → S' →
 WorkingContext
   → identify(high_leverage_sources, S_high)    -- silent scan for sources warranting audit
   → tag(provenance, freshness, leverage)        -- attach metadata triple per source
-  → posit(antithesis per source)                -- Pattern A ∪ Pattern B ∪ Pattern C
+  → posit(antithesis per source)                -- Pattern A ∪ Pattern B ∪ Pattern C ∪ Pattern D
   → present(antitheses, disposition slots)      -- per-source Constitution interaction
   → judge(disposition per source)                -- closed coproduct response
   → emit(VettedContext with disposition table)
@@ -46,7 +46,7 @@ FreshnessTag   = { source: Source, age: Duration, horizon: Duration, stale: Bool
                -- currency only: a source can be fresh yet still not track the behavior its claim asserts (it documents intent with nothing enforcing the match). Freshness is necessary but not sufficient for trusting a source; the support-integrity challenge is posited per source in Pattern A (Source Provenance Audit).
 LeverageTag    = { source: Source, downstream_count: Nat, branches: Set(Reference) }
 S'             = Map(Source, ProvenanceTag × FreshnessTag × LeverageTag)
-Pattern        ∈ {ProvenanceAudit, CounterfactualGap, CrossSourceConsistency} ∪ Emergent(Pattern)
+Pattern        ∈ {ProvenanceAudit, CounterfactualGap, CrossSourceConsistency, InferenceFallacyAudit} ∪ Emergent(Pattern)
 Antithesis     = { source: Source, pattern: Pattern, thesis: String, antithesis: String, basis: String }
 A[]            = List(Antithesis)
 Disposition    = Confirmed                                   -- assumption survived antithesis
@@ -177,12 +177,15 @@ User-initiated activation triggers Phase 0's silent scan. The scan does not gate
 | Source age beyond horizon | Source's `observed_at + horizon(origin)` < now; horizon varies by origin (UserStatement and ToolOutput have shorter horizons than DocumentRead and PastSession) | Pattern A or B |
 | Provenance-chain length | The belief depends on an N-step inference chain rather than direct observation, citation, or measurement | Pattern A (provenance) |
 | Cross-source contradiction | Two collected sources nominally pointing at the same referent diverge in their content or implication | Pattern C (cross-source consistency) |
+| Inference-character conclusion | The source is itself a conclusion reached by inference (origin `AIInference`, or a conclusion beginning to function as a standing premise) | Pattern D (inference fallacy) |
 
-`N` (high-leverage threshold) and horizon defaults per origin are residual variables refined through accumulated use evidence. The four criteria are working hypotheses, not closed; an Emergent criterion may surface on use.
+`N` (high-leverage threshold) and horizon defaults per origin are residual variables refined through accumulated use evidence. The five criteria are working hypotheses, not closed; an Emergent criterion may surface on use.
 
 ## Patterns
 
-Three patterns are inscribed. Each pattern pairs a current claim with a challenge that would shake it; the AI surfaces both at Phase 1 Step 2 per source, and the user decides how to handle the source at Phase 2. A fourth Emergent pattern is permitted but not pre-named — it must satisfy `ContextSuspect → VettedContext` (the challenge must directly confront the source's claim, not stand as a side verification check).
+Four patterns are inscribed. Each pattern pairs a current claim with a challenge that would shake it; the AI surfaces both at Phase 1 Step 2 per source, and the user decides how to handle the source at Phase 2. A further Emergent pattern is permitted but not pre-named — it must satisfy `ContextSuspect → VettedContext` (the challenge must directly confront the source's claim, not stand as a side verification check).
+
+Patterns A, B, and C vet a source along the **source-vetting axis** (provenance authority, counterfactual robustness, cross-source agreement). Pattern D vets along the **reasoning axis** — whether the inference that produced a conclusion is itself sound — complementing the source-vetting patterns so that the inference, not only its source, is examined.
 
 ### Pattern A — Source Provenance Audit
 
@@ -208,6 +211,16 @@ When two sources point at the same referent but diverge, the challenge forces an
 - What would shake it: "X₁'s claim and X₂'s claim diverge at point Q — which source is authoritative for this claim, and what reconciles the divergence?"
 - The user decides how to handle the sources: keep the sources as-is, rewrite the claim with a refinement, withdraw one of the sources, treat an outside source-of-truth as the authoritative reference, or hand the question off to another protocol.
 
+### Pattern D — Inference Fallacy Audit
+
+When a source is itself a conclusion reached by inference — an `AIInference` origin, or any conclusion that is starting to be used as a standing premise — the challenge tests whether the conclusion's validity depends on a reasoning flaw rather than on the source it cites. The AI reverse-derives the flaw condition from a reasoning-fallacy archetype, instead of waiting for the user to supply a counter-condition.
+
+- The source's current claim: "Conclusion Y follows soundly from the basis observed."
+- What would shake it: "Y's validity rests on a reasoning archetype that does not hold." The archetype is described as a principle, not selected from a closed list: does the conclusion treat a point-in-time observation as a time-invariant law (a present coincidence read as permanent truth); generalize a standing rule from one or few observations; conclude from only the visible (surviving) sample; draw a conclusion that ignores the base rate; or read correlation as cause. These archetypes are a starting set for recognition, not an exhaustive catalog — an Emergent fallacy archetype is admitted whenever a conclusion's soundness rests on a reasoning move not named here.
+- The user decides how to handle the source: keep the conclusion as-is, rewrite it with its scope made conditional (the inference holds only within the stated bounds), withdraw the conclusion, set it aside until a measurement settles it, or hand the question off to another protocol.
+
+**Boundary with Pattern B**: Pattern B is a counterfactual the *user* frames — the user supplies condition Z and asks whether Y still holds. Pattern D is the AI *reverse-deriving* the flaw condition from a fallacy archetype, moving the discovery burden from the AI happening to pick the right counterfactual to an archetype-driven scan of the inference itself. A conclusion can pass Pattern B (no user-supplied condition shakes it) yet fail Pattern D (its soundness silently depends on treating the present as invariant).
+
 ## Protocol
 
 ### Phase 0: Source Identification (Silent)
@@ -228,7 +241,7 @@ Generate metadata triple plus dialectical antithesis per source.
 
 **Step 1 — Tagging**: For each `s ∈ S_high`, attach ProvenanceTag (authorized claim + verification path + confidence), FreshnessTag (age, horizon, stale flag), and LeverageTag (downstream_count, branches). Use Read and Grep to verify provenance against the source's claimed origin where the source's content cites verifiable artifacts. The ProvenanceTag binds authority to the claim's referent, claim_kind, and scope; reuse of the same source as authority for a different claim must surface through Pattern A or Pattern C rather than silently carrying over. For an audit-candidate source, provenance verification also asks whether the source actually tracks the behavior its claim asserts or merely documents it — a source that is fresh yet not tied to that behavior is posited against in Pattern A on that basis, not cleared by its freshness verdict alone. When enforcement coupling cannot be determined from the available tools, posit the gap as a Pattern A antithesis candidate with basis "enforcement coupling not observable from available tools" — neither skip it silently nor assert coupling with false confidence.
 
-**Step 2 — Antithesis positing**: For each tagged source, select the most applicable pattern (A, B, C, or Emergent) and construct an antithesis. The antithesis must:
+**Step 2 — Antithesis positing**: For each tagged source, select the most applicable pattern (A, B, C, D, or Emergent) and construct an antithesis. A source that is itself an inferred conclusion (origin `AIInference`, or a conclusion functioning as a standing premise) is a candidate for Pattern D, where the antithesis reverse-derives the inference's flaw condition from a fallacy archetype rather than from a user-supplied counter-condition. The antithesis must:
 - Cite the source's claim verbatim, anchored to the originating sentence or artifact
 - Name the dialectical challenge concretely (a verification gap, a counterfactual condition, a divergent sibling source)
 - Surface the basis for the challenge so the user can recognize the antithesis's evidence
@@ -301,7 +314,7 @@ Present transformation trace as text output, then proceed with the vetted contex
 6. **Convergence evidence**: Present transformation trace (source → antithesis → disposition) before declaring all sources vetted; per-source evidence is required, not asserted.
 7. **Source chain preservation**: W.sources is read-only across the protocol's lifetime. Antithesis and disposition annotate, never mutate, the source list. A Discarded disposition removes a source from downstream usage but preserves it in Λ.history with its withdrawal reason.
 8. **Loop continuity under bounded regret**: Deferred dispositions whose re-trigger condition has not been met let the loop continue. Only dispositions requiring genuinely viable alternative judgment paths — where the user's values determine the choice among options (Constitution-level entropy > 0) — warrant Phase 2 surfacing; relay-level operations (tagging, antithesis text construction, trace presentation) proceed inline.
-9. **Antithesis must be dialectical**: An antithesis names a concrete counter-claim (Pattern A: "X is unverified"), counter-condition (Pattern B: "in condition Z, Y fails"), or counter-source (Pattern C: "X₁ and X₂ diverge at Q"). Procedural queries ("have you checked X?") surface in `/inquire` or `/attend`, not here.
+9. **Antithesis must be dialectical**: An antithesis names a concrete counter-claim (Pattern A: "X is unverified"), counter-condition (Pattern B: "in condition Z, Y fails"), counter-source (Pattern C: "X₁ and X₂ diverge at Q"), or counter-inference (Pattern D: "Y's soundness rests on a fallacy archetype that fails here"). Procedural queries ("have you checked X?") surface in `/inquire` or `/attend`, not here.
 10. **Closed coproduct discipline**: Disposition is a closed coproduct of seven named variants plus Emergent. The Other option permits free-response, which the AI maps to the closest variant or surfaces as a candidate Emergent variant for that source — it does not bypass the coproduct.
 11. **Gate integrity** (Safeguard tier): The defined option set is presented intact — option injection, deletion, and substitution each violate this invariant. Type-preserving materialization (specializing a generic disposition variant into a concrete instance with parameters while preserving the TYPES coproduct structure) is distinct from mutation.
 12. **Substrate boundary**: Elenchus scope is the epistemic substrate — source identification, antithesis positing, disposition surfacing, and integration through Phase 0 to Phase 3. Post-vetting execution (the downstream action's substrate enforcement, harness permission, network/state mutation) belongs to native harnesses or specialized substrates, delegated by handoff after Phase 3 integration.
@@ -309,3 +322,4 @@ Present transformation trace as text output, then proceed with the vetted contex
 14. **Round-local salience bundling**: Each user-facing round bundles the current judgment, its nearest evidence, and the differential implication that matters for the next move. Keep adjacent material together so the user can recognize the decision without context-switching; defer background, distant context, and unrelated findings to pre-gate text, convergence traces, or later cycles.
 15. **Claim-relative provenance**: ProvenanceTag records the claim a source authorizes. Pattern A tests source authority against that claim; Pattern C enumerates candidate pairs over same-referent sources, then tests cross-source consistency only after referent and claim-kind compatibility are explicit. The tag classifies and surfaces the issue; disposition remains the user's Constitution judgment.
 16. **Currency is not support-integrity**: A source that is fresh and present is not thereby trusted — freshness is necessary but not sufficient for the claim a source grounds. When a source is current yet nothing ties it to the behavior its claim asserts, Pattern A must posit that gap as the antithesis (would the source break or fail if that behavior changed, or stay unchanged and silently wrong?) and surface it with cited basis; the full disposition coproduct stays available and the user constitutes the disposition, recording the basis on which freshness was or was not enough. The AI surfaces the support-integrity challenge; it does not decide it.
+17. **Inference-fallacy archetypes are principle, not closed catalog**: Pattern D seeds its antithesis from reasoning-fallacy archetypes stated as principles — the named archetypes (a present coincidence read as permanent truth, generalizing from few observations, surviving-sample-only reading, base-rate neglect, correlation-as-cause) are a starting set for recognition, never a closed enumeration, and an Emergent archetype is admitted whenever a conclusion's soundness rests on an unnamed reasoning move. Pattern D differs from Pattern B by direction: B vets a user-supplied counter-condition; D reverse-derives the flaw condition from an archetype, moving the discovery burden off the AI happening to pick the right counterfactual. A source qualifies for Pattern D when it is an inferred conclusion (origin `AIInference`, or a conclusion functioning as a standing premise); because sublate's unit is already `Source`, this is a pattern, not a new protocol.


### PR DESCRIPTION
## Work Unit (WU-3)

`/sublate`(Elenchus) antithesis가 source-vetting 축(Pattern A/B/C)만 갖고 **추론-오류(reasoning fallacy) 아키타입**으로는 조직되지 않아, "현재의 우연을 영구 진리로 굳히는" 류의 추론 오류가 protocol이 아닌 사용자에 의해서만 잡히던 갭(#504)을 해소합니다. `AIInference`/결론 성격 source에 대해 fallacy 아키타입으로 antithesis를 seed하는 **Pattern D**를 추가합니다.

## Issue Substrate

- **#504** — 동기 사례(단일 시점 백테스트 결론이 시간-불변 법칙처럼 쓰일 뻔한 것을 사용자가 되돌림). Pattern B와의 경계, zero-shot 원칙 정합이 설계 제약.

## Northstar Fusion

- **Preserved**: 출처뿐 아니라 추론 자체를 체계 검사 (미지를 발화로, 결손을 뿌리에서).
- **Transformed**: zero-shot/principle-over-anchoring 원칙상 닫힌 fallacy 카탈로그 금지 → 아키타입을 *원리*로 기술 + Emergent 개방.
- **Dropped**: 신규 프로토콜 (단위가 `Source`(Origin에 AIInference 포함)이므로 Pattern D로 자연 fit).

## 변경 내용

- **Pattern D — Inference Fallacy Audit** 신설: reasoning 축(A/B/C source-vetting 축 보완). AI가 fallacy 아키타입에서 결함 조건을 reverse-derive
- **zero-shot 정합**: 아키타입(우연-불변 / hasty generalization / survivorship / base-rate neglect / false cause)을 닫힌 카탈로그가 아닌 **원리**로 기술 + Emergent 개방 (recognition seed, 닫힌 enum 아님)
- **Pattern B 경계 명시**: B는 user-supplied counter-condition, D는 AI archetype reverse-derive (발견 부담을 AI 운 → archetype-driven)
- Source Identification에 inference-character 기준 + Pattern D 힌트
- TYPES `Pattern` coproduct, FLOW/MORPHISM, Phase 1 Step 2, Rule 9 정렬, **Rule 17** 신설
- elenchus `0.2.1 → 0.3.0` (.claude-plugin + .codex-plugin)

## PremiseTrace

- **Existence**: antithesis Pattern A/B/C가 source-vetting 축으로만 조직됨, 명명된 추론-오류 카탈로그 부재가 현 `skills/sublate/SKILL.md`에 결손대로 존재함 확인.
- **Fusion**: northstar(추론 자체를 뿌리에서 검사)와 정합.
- **Approach axis**: "Pattern D 신규 vs Pattern B 보강" — 단위가 Source이고 reverse-derive 방향이 B와 구분되어 별도 Pattern D가 단일 우세 → **relay 선택**.

## Verification

- `node .claude/skills/verify/scripts/static-checks.js .` → **fail: 0** (사전 존재 warn 2건은 prothesis/hermeneutic-cycle, 본 변경과 무관)
- 아키타입을 원리+Emergent 형태로 기술해 `/zero-shot` 앵커링 원칙 준수

🤖 `/triage` → `/dispatch` 병렬 set (버그 3건 중 elenchus)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9MwBAco9gK575PQu8KQuU)_