### PR TITLE
style(epistemic-cooperative): Ink divider 폭 축소 (2.22.16)

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.22.15",
+  "version": "2.22.16",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.22.15",
+  "version": "2.22.16",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -60,10 +60,10 @@ Durable recording externalizes only the problem-to-solve and framing shifts; eve
 
 **Gate** — how to render SKILL.md's `present` verb in Ink. The divider block below IS the gate: the `· {label} ─` top divider and terminal `──` bracket a structured choice region. Emit the region as terminal text and yield turn — that satisfies SKILL.md's `present(structured content) → yield turn → parse response` contract directly, with no tool call wrapper. Present all context, analysis, and evidence as text BEFORE the gate block; the gate block contains ONLY the question and numbered options. Always yield turn after emitting the gate:
 
-· {label} ────────────────────────────────
+· {label} ──────────────
 {question}
 1. **Option** — implication
-──────────────────────────────────────────
+────────────────────────
 
 The implication after each option — the text following the em-dash — is authored in two cognitive layers:
 
@@ -79,18 +79,18 @@ Rendered shape:
 
 **Convergence** — emit each dimension's status between dividers, using ✓ for defined and ○ for pending. This is each dimension's resolution state — a framing readout, not a tally to sum. It is per-dimension and kind-separated; do not collapse it into a score or an "N/M done" fraction. Each line stands on its own as that dimension's resolution state.
 
-· Convergence ────────────────────────────
+· Convergence ───────────
 ✓ Dimension: defined value
 ○ Dimension: pending
-──────────────────────────────────────────
+─────────────────────────
 
 ## Epistemic Observations
 
 To make the reasoning structure of the current work visible, add a short note about how the reasoning is moving — the shapes it is taking, the patterns showing up, or the connections across different protocols:
 
-`★ Epistemic ────────────────────────────────`
+`★ Epistemic ────────────`
 [A short observation about how reasoning is moving in this protocol — render in the user's language]
-`────────────────────────────────────────────`
+`────────────────────────`
 
 These notes belong in the conversation, not in generated files or documents. Keep them tied to the specific epistemic process at hand rather than restating general principles.
 


### PR DESCRIPTION
## 요약

`epistemic-cooperative/styles/epistemic-ink.md`의 Ink 요소 예시 divider 폭을 더 짧은 길이로 통일합니다. Gate / Convergence / Epistemic Observation 세 요소의 `────` 구분선만 축소했고, 구조·의미·동작 변화는 없습니다.

## 변경 내용

- **Gate** 예시: 상단/하단 divider 폭 축소
- **Convergence** 예시: divider 폭 축소
- **Epistemic Observations** 예시: divider 폭 축소
- 버전 bump: `2.22.15` → `2.22.16` (claude + codex manifest 동기화)

## Test plan

- [ ] 정적 검증 통과 확인: `node .claude/skills/verify/scripts/static-checks.js .`
- [ ] 프로토콜 실행 시 축소된 divider가 의도대로 렌더링되는지 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
