### PR TITLE
fix(epistemic-cooperative): goal-research 타임아웃 60분으로 상향 (2.22.16 → 2.22.17)

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "2.22.16",
+  "version": "2.22.17",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "2.22.16",
+  "version": "2.22.17",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /compose, /write, /comment-review, /review-ensemble, /review-loop, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/goal-research/SKILL.md
+++ b/epistemic-cooperative/skills/goal-research/SKILL.md
@@ -51,13 +51,13 @@ Report:
 - Residual uncertainty when sources contradict or coverage is incomplete
 ```
 
-Launch via `Bash(run_in_background: true, timeout: 1000000)`. `--color never` + redirecting
+Launch via `Bash(run_in_background: true, timeout: 4500000)`. `--color never` + redirecting
 **stdout only** (no `2>&1`) keeps the events file pure JSONL — the codex banner stays on stderr:
 
 ```bash
 codex exec --ephemeral --json --color never --skip-git-repo-check -m gpt-5.5 \
   --config model_reasoning_effort="high" \
-  --config mcp_servers.tavily.tool_timeout_sec=900 \
+  --config mcp_servers.tavily.tool_timeout_sec=3600 \
   < /tmp/goal_research_${SUFFIX}.txt > /tmp/goal_research_events_${SUFFIX}.jsonl
 ```
 
@@ -65,10 +65,12 @@ Sandbox flag is omitted intentionally — Tavily verification requires network a
 
 The background Bash timeout controls the delegated Codex session envelope and
 must exceed the Tavily MCP per-call budget. The
-`mcp_servers.tavily.tool_timeout_sec=900` override controls the per-call MCP
+`mcp_servers.tavily.tool_timeout_sec=3600` override controls the per-call MCP
 timeout for Tavily tools inside that delegated session, allowing long-form
-`tavily_research` calls to run for up to 15 minutes while still surfacing the
-raw timeout error if the call exceeds that limit.
+`tavily_research` calls (e.g. `pro` depth over multi-branch topics) to run for
+up to 60 minutes while still surfacing the raw timeout error if the call exceeds
+that limit. The 4,500,000 ms (75 min) session envelope exceeds this per-call
+budget with margin for additional searches and reasoning within the session.
 
 ## Phase 3: Collection
 

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -237,7 +237,7 @@ describe('goal-research runtime contract', () => {
     assert.ok(Number.isFinite(bashMs), 'Bash session timeout must be documented');
     assert.ok(Number.isFinite(mcpSec), 'Tavily MCP per-call timeout must be configured');
     assert.ok(bashMs > mcpSec * 1000, 'Bash envelope must exceed MCP per-call budget');
-    assert.equal(mcpSec, 900);
+    assert.equal(mcpSec, 3600);
     assert.match(skill, /per-call MCP\s+timeout/i);
     assert.match(skill, /tavily_research/);
   });


### PR DESCRIPTION
## 배경

스크린샷 증거상 `/n` pro 깊이 + 다분기 토픽(측정 도구 + 최적화 전략)의 `tavily_research`가 **11m 12s에 26%** → 단일 호출 약 **43분**으로 투영됩니다. 기존 한도(Tavily per-call 15분, Codex 세션 봉투 16.7분) **둘 다** 곧 초과되어 research가 중단됩니다.

두 타임아웃은 규약상 종속 관계(`세션 봉투 > Tavily per-call`)라 함께 올려야 합니다.

## 변경

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| Tavily per-call (`tool_timeout_sec`) | 900s (15분) | **3600s (60분)** |
| Codex 세션 봉투 (`Bash timeout`) | 1,000,000ms (≈16.7분) | **4,500,000ms (75분)** |

- 세션 봉투가 per-call보다 15분 큰 여유 → 한 세션 내 추가 검색·추론 수용
- 설명 산문을 새 값에 동기화
- `scripts/package.test.js` 런타임 계약 테스트 pin 값 동기화 (900 → 3600)

## Test plan

- [ ] `node scripts/package.test.js`로 goal-research 런타임 계약 테스트 통과 확인
- [ ] `node .claude/skills/verify/scripts/static-checks.js .` 정적 검사 통과 확인
- [ ] 다음 세션에서 `/n` pro 깊이 호출이 15분 경계를 넘어 완주하는지 확인 (post-merge, 장시간 실행)
