### PR TITLE
refactor(euporia): Phase -1 감지 phase를 Phase 0에 흡수 병합 (#522)

### DIFF
--- a/euporia/.claude-plugin/plugin.json
+++ b/euporia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "euporia",
   "description": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/euporia/.codex-plugin/plugin.json
+++ b/euporia/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "euporia",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Resolve via Extended-Mind reverse induction — /elicit (εὐπορία: way through)",
   "author": {
     "name": "Jongwon Choi",

--- a/euporia/skills/elicit/SKILL.md
+++ b/euporia/skills/elicit/SKILL.md
@@ -15,13 +15,11 @@ Resolve abstract aporia through Extended-Mind reverse induction. Type: `(Abstrac
 
 ```
 ── FLOW ──
-Euporia(I) → pre-detect(I, S) → signal? →
-  true:  Detect(I) → aporia? →
-           true:  (I, S, ctx) → Substrate access → ReverseTrace(I, S, ctx) → (D[], context) →
-                  Qs(D[], cycle_n) → Stop → A → integrate(A, I) → I' →
-                  loop until resolved(I') ∨ user_esc ∨ user_dismiss
-           false: deactivate
-  false: surface scan result, invite user to articulate or withdraw
+Euporia(I) → Detect(I, S) → aporia? →
+  true:  (I, S, ctx) → Substrate access → ReverseTrace(I, S, ctx) → (D[], context) →
+         Qs(D[], cycle_n) → Stop → A → integrate(A, I) → I' →
+         loop until resolved(I') ∨ user_esc ∨ user_dismiss
+  false: surface scan result; route to axis-specific protocol (axis-determined) or invite user to articulate or withdraw (substrate empty)
 
 ── MORPHISM ──
 IntentSeed
@@ -60,7 +58,7 @@ R              = ResolvedEndpoint { intent_resolved: I', residual: Set(Axis) }
                  -- residual = unresolved axes delegated to downstream protocols
 resolved(I')   = ∂(intent) ≈ 0 (user constitutive judgment)
 cycle_n        = Nat                            -- current cycle counter; surfaced at every Phase 2
-Phase          ∈ {-1, 0, 1, 2, 3}
+Phase          ∈ {0, 1, 2, 3}
 Axis           = String                         -- emergent label; examples: "intent", "goal", "form", "scope", "framework"
 Initiator      ∈ {UserInvoked, AIDetected}      -- bound at activation; informs Hybrid Phase 2 first-surface semantics
 Qs             = Cycle-emergent surfacing interaction with D[] + cycle counter [Tool: Constitution interaction]
@@ -75,12 +73,11 @@ Priority: explicit_arg > recent_intent_seed > surfaced_aporia
 "I want to..."             → I = utterance under discussion
 
 If no aporia signal is detectable (intent is fully axis-determined, or substrate is empty):
-pause activation and surface the scan result before Phase 0, inviting the user to either
-articulate further or withdraw.
+Phase 0 detection surfaces the scan result instead of proceeding to Phase 1, inviting the
+user to either articulate further or withdraw.
 
 ── PHASE TRANSITIONS ──
-Phase -1: I → pre-detect(aporia signal | substrate availability)     -- pre-activation scan; if no signal: surface result and invite user to articulate or withdraw before Phase 0
-Phase 0: I → Detect(I) → aporia?                                     -- detection checkpoint (silent)
+Phase 0: I → Detect(I, S) → aporia?                                  -- detection checkpoint; aporia=true → silent proceed to Phase 1; aporia=false → surface scan result (axis-determined → routing recommendation; substrate empty → invite articulate-or-withdraw), no activation
 Phase 1: (I, S, ctx) → Substrate access [Tool] → ReverseTrace [Internal] → (D[], context)
 Phase 2: (D[], cycle_n, initiator) → Qs(D[], cycle_n) → Stop → A     -- Constitution; cycle counter visible
                                                                        -- Hybrid contract: cycle_n=1 ∧ initiator=AIDetected → first surfacing = implicit confirm-or-decline
@@ -106,6 +103,7 @@ progress(Λ) = cycle_n (running counter; not bounded by a target)
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
 Phase 0 Detect       (sense)        → Internal analysis (no external tool)
+Phase 0 Surface      (extension)    → TextPresent+Proceed (aporia=false: surface scan result; routing recommendation when axis-determined, or invite articulate-or-withdraw when substrate empty; no activation, no constitutive gate)
 Phase 1 Substrate    (observe)      → Read, Grep, Bash (read-only substrate access — codebase / rules / session history / Environment queries: machine-setup metadata only — uname, pwd, version probes, git config public fields; MUST NOT execute env/printenv/set/echo $VAR or read .env* files)
 Phase 1 Utterance    (observe)      → Internal analysis of I.utterance for in-text semantic ambiguity (citation quotes actual utterance fragments only)
 Phase 1 ReverseTrace (observe)      → Internal analysis (axis inference + coordinate construction)
@@ -208,17 +206,19 @@ Euporia activates when (a) the user's intent is articulated as an utterance, (b)
 
 ## Protocol
 
-### Phase 0: Aporia Detection Checkpoint (Silent)
+### Phase 0: Aporia Detection Checkpoint
 
-Analyze the intent seed for abstract aporia. Silent — no user interaction.
+Analyze the intent seed for abstract aporia. Detection is silent on the aporia-confirmed path — it proceeds to Phase 1 with no user interaction; on no signal it surfaces the scan result before deactivating.
 
 1. Bind seed `I` per A-BINDING priority
 2. Check axis determination: scan utterance for axis-specific markers (intent verbs / goal nouns / abstraction signals / boundary phrases)
 3. Check substrate availability: confirm read-only access to codebase / rules / session history / environment
-4. If `aporia(I)` predicate satisfied: proceed to Phase 1 with `(I, S, ctx)`
-5. If intent is axis-determined: deactivate, surface routing recommendation to the matching axis-specific protocol
+4. If `aporia(I)` predicate satisfied: proceed to Phase 1 with `(I, S, ctx)` — silent, no user interaction
+5. If no aporia signal (predicate unsatisfied), surface the scan result and deactivate without proceeding to Phase 1:
+   - **Intent is axis-determined**: surface a routing recommendation to the matching axis-specific protocol
+   - **Substrate is empty**: surface the empty-substrate result and invite the user to articulate further or withdraw (fall back to direct execution or Aitesis)
 
-**Scope restriction**: Detection is silent. Does NOT modify files or call external services beyond read-only substrate scan.
+**Scope restriction**: Detection does NOT modify files or call external services beyond read-only substrate scan. The no-signal surface is a relay presentation — no constitutive gate.
 
 ### Phase 1: Substrate Access + Reverse Trace
 

--- a/euporia/skills/elicit/SKILL.md
+++ b/euporia/skills/elicit/SKILL.md
@@ -72,9 +72,10 @@ Priority: explicit_arg > recent_intent_seed > surfaced_aporia
 /elicit (alone)            → I = most recent intent seed in session
 "I want to..."             → I = utterance under discussion
 
-If no aporia signal is detectable (intent is fully axis-determined, or substrate is empty):
-Phase 0 detection surfaces the scan result instead of proceeding to Phase 1, inviting the
-user to either articulate further or withdraw.
+If no aporia signal is detectable, Phase 0 detection surfaces the scan result instead of
+proceeding to Phase 1: when the intent is fully axis-determined it routes to the matching
+axis-specific protocol; when the substrate is empty it invites the user to articulate
+further or withdraw.
 
 ── PHASE TRANSITIONS ──
 Phase 0: I → Detect(I, S) → aporia?                                  -- detection checkpoint; aporia=true → silent proceed to Phase 1; aporia=false → surface scan result (axis-determined → routing recommendation; substrate empty → invite articulate-or-withdraw), no activation
@@ -138,13 +139,13 @@ Per cycle, the trio `(D[step], A[step], I'[step])` is recorded pairwise into `D_
 
 ### Activation
 
-AI detects abstract aporia OR user calls `/elicit`. Detection is silent (Phase 0); dimension surfacing always requires user interaction via Cognitive Partnership Move (Constitution) (Phase 2).
+AI detects abstract aporia OR user calls `/elicit`. Detection is silent on the aporia-confirmed path (Phase 0); dimension surfacing always requires user interaction via Cognitive Partnership Move (Constitution) (Phase 2).
 
 **Hybrid confirmation contract**: For AI-detected activation paths, the first Phase 2 surfacing (cycle_n=1) serves as the user-confirmation moment — Esc at the first surface deactivates without coordinate state change, satisfying the Hybrid initiator's "AI-detected trigger path requires user confirmation" contract via implicit-acknowledge-or-decline at the first dimension surface. Phase 1 substrate scan precedes this confirmation under the substrate read-only constraint; no externalized state is mutated before user judgment.
 
 **Activation layers**:
 - **Layer 1 (User-invocable)**: `/elicit` slash command or description-matching input. Always available.
-- **Layer 2 (AI-guided)**: Abstract aporia detected via in-protocol heuristics (axis-undetermined intent + substrate-implicit coordinates). Detection is silent.
+- **Layer 2 (AI-guided)**: Abstract aporia detected via in-protocol heuristics (axis-undetermined intent + substrate-implicit coordinates). Detection is silent on the aporia-confirmed path.
 
 **Abstract aporia** = intent is articulated as utterance but its decision coordinates are not axis-determined; the substrate carries implicit values that can be reverse-traced into surfaceable dimensions.
 
@@ -203,6 +204,7 @@ Euporia activates when (a) the user's intent is articulated as an utterance, (b)
 | user_judges_resolved(I') | Return ResolvedEndpoint with per-cycle coordinate trace |
 | User Esc | Return to normal operation; intent remains in-process |
 | Dismiss + residual | Return ResolvedEndpoint with residual axes annotated for downstream delegation |
+| No aporia signal at Phase 0 (axis-determined or substrate empty) | Surface scan result without activating — routing recommendation when axis-determined, articulate-or-withdraw invitation when substrate empty |
 
 ## Protocol
 


### PR DESCRIPTION
## 배경

Closes #522 — 스캐폴딩 phase 전수 감사 4/4(구조적 중복).

Euporia의 Phase -1(`pre-detect`)과 Phase 0(`Detect`)이 **동일한 aporia 술어**를 평가하던 중복을 제거. 14개 프로토콜 중 감지 phase가 둘로 분리된 유일 사례였고, Phase -1은 TOOL GROUNDING 항목이 없어 형식 블록 anatomy 상 불완전했음.

## 변경

`euporia/skills/elicit/SKILL.md`:

- **FLOW**: `pre-detect(I,S) → signal?` 분기를 `Detect(I,S) → aporia?`로 단일화. no-signal surfacing을 `aporia? false` 분기에 통합.
- **TYPES**: `Phase ∈ {-1,0,1,2,3}` → `{0,1,2,3}`
- **PHASE TRANSITIONS**: Phase -1 제거. Phase 0가 두 하위경로 흡수 — axis-determined → routing recommendation, substrate empty → invite articulate-or-withdraw.
- **A-BINDING**: no-signal 경로를 단일 서술로 정리, Phase 0 지칭.
- **TOOL GROUNDING**: `Phase 0 Surface (extension)` 추가 — Phase -1이 결여했던 grounding을 회복.
- **Phase 0 prose**: 흡수된 surfacing을 step 5에 두 하위경로로 명시.
- **Hybrid confirmation contract**(cycle 1 implicit confirm-or-decline) 보존.
- `euporia/.claude-plugin/plugin.json` + `.codex-plugin/plugin.json` lockstep 0.2.14 → 0.2.15.

## 검증

- semantic-closure sweep: FLOW / TYPES / PHASE TRANSITIONS / LOOP / MODE STATE 정렬 확인.
- `node .claude/skills/verify/scripts/static-checks.js .` → **0 fail** (euporia morphism verified). 잔여 warn 2건은 anamnesis/hermeneutic-cycle 기존 항목으로 본 변경과 무관.
- 교차 계약: graph.json edge는 euporia를 deficit/resolution 의미로 참조(phase 번호 무관) — 무손상.
- README/README_ko: Euporia는 phase 서술 없이 한 줄 표 항목만 존재 — 동기화 불필요.

## Out of scope (#522 준수)

- 타 프로토콜 phase 재구성
- 감지 술어 `aporia(I)` 의미 변경
