### PR TITLE
fix(epistemic-cooperative): review-loop의 C-scope를 SKILL.md에 명시

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /write, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Utility skills layered on top of the core 14 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /write, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, and /image-companion. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -41,6 +41,8 @@ The review source is pluggable: any source satisfying the `(diff, design-intent)
 
 The loop is the skill's identity; the review source is a parameter behind it. Loop control (verify → classify → apply → re-review) is fixed; the source that produces `{ findings[], verdict }` is swappable.
 
+**Scope:** the loop resolves every source-surfaced, verification-passing finding on the changed code — including pre-existing issues in touched files and methodology concerns — not only defects the diff introduced.
+
 ## When to Use
 
 - Driving code/PR review findings all the way to resolution and convergence (verdict=approve)
@@ -51,6 +53,7 @@ The loop is the skill's identity; the review source is a parameter behind it. Lo
 
 - Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets code/PR diffs)
 - Wanting a one-shot review with no apply phase — call a source directly (the codex CLI or `/code-review`); for a cross-model composition, assemble it with `/conduct` (frame supplies the lenses, conduct arranges the review topology) — `/review-loop` is the loop that drives findings to approve
+- Wanting to resolve ONLY findings your PR's own changes introduced (not pre-existing issues surfaced in the touched files) — `/review-loop` drives the whole changed surface to convergence; for a PR-introduced-only pass, use a one-shot reviewer (the codex CLI or `/code-review`) and triage manually
 - Trivial single-line edits where a direct Edit is faster than a review loop
 
 ## Phase 0: Source Designation + Scope Detection


### PR DESCRIPTION
## 무엇을

`/review-loop`(review-resolve 루프)의 **범위(scope)**를 SKILL.md에 명시.

## 왜

루프는 정의상 verdict=approve까지 수렴하는 resolve 루프이므로, 변경된 코드 표면에서 소스가 surface하고 verify를 통과한 **모든** finding을 해소한다 — touched 파일의 pre-existing 이슈와 methodology 우려를 포함하며, diff가 도입한 결함만이 아니다(C-scope). 그러나 이 범위가 문서에 한 번도 적혀 있지 않아, 실제 PR 리뷰 세션에서 운영자가 pre-existing 발견을 scope drift로 재고하는 모호함이 발생했다. (설계상 범위 내가 맞다.)

## 변경

- **Scope 선언 한 줄 추가** (Pipeline Overview 직후): 루프는 변경된 코드 표면의 모든 source-surfaced·verify-통과 finding을 수렴 처리(pre-existing·methodology 포함), diff 도입 결함만이 아님.
- **When NOT to Use 항목 추가**: PR 자체 변경이 도입한 finding만 처리하려면 `/review-loop`가 아니라 one-shot 리뷰어(codex CLI 또는 `/code-review`) + 수동 triage.
- `plugin.json`(claude/codex) 3.10.2 → 3.10.3.

기존 voice/구조 유지, 무관 섹션 미변경. `node .claude/skills/verify/scripts/static-checks.js .` 통과(FAIL 없음).
