### PR TITLE
feat(anamnesis): /recollect Phase 2 고신뢰 단일 후보 게이트를 확인→발산 전용으로 재설계

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anamnesis",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Resolve vague recall into recognized context — /recollect",
   "author": {
     "name": "Jongwon Choi",

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anamnesis",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Resolve vague recall into recognized context — /recollect",
   "author": {
     "name": "Jongwon Choi",

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -21,7 +21,7 @@ Anamnesis(V) → Detect(V) →
     |C[]| = 0 ∧ attempts = 0: Probe(V, Σ) → Qs(probe) → Stop → H → enrich(V, H) → re-scan
     |C[]| = 0 ∧ attempts > 0: NullMatch → inform(V, Σ) → deactivate
     |C[]| > 0: backtrace_parent(c) ∀ c ∈ C[] : fork_marker(c) → parent_pointer, parent_cwd   -- deterministic: a fork candidate's parent is recoverable from its own record, not inferred (mechanism in TOOL GROUNDING; ≠ user-described Reorient)
-               SingleObvious(C[]): emit(ClueVector_prose(C[top]) ⊕ divergence_affordance) → recall_complete(C[top]) → converge   -- Extension (relay): high-confidence single candidate, no turn yield; silence = Recognize, divergence in the next turn re-enters Refine/Reorient below (no re-activation machinery)
+               SingleObvious(C[]): emit(ClueVector_prose(C[top]) ⊕ divergence_affordance) → recall_complete(C[top]) → converge   -- Extension (relay): high-confidence single candidate, no turn yield; silence = Recognize. Convergence is notional (inline skill prose persists), so a next-turn divergence re-engages via fresh re-detection (Layer 1/2 activation) — not an encoded transition out of the converged state — then routes to Refine/Reorient (no dedicated re-activation machinery added)
                ¬SingleObvious(C[]): Qc(C[top], evidence, framing) → Stop → R →
       Recognize(c): recall_complete(c) → emit(ClueVector_prose(c)) → converge      -- fork: emitted pointer = parent (or, when the parent record is absent, non-resumable + recoverable artifacts)
       Refine: Probe(V, Σ) → Qs(probe) → Stop → H → enrich(V, H) → re-scan
@@ -69,7 +69,7 @@ Candidate        = { session_id: Optional(SessionId),
                      keywords: Set(String),
                      fingerprint: Prose,
                      cross_refs: List(Anchor),
-                     confidence: ∈ {low, medium, high},
+                     confidence: ∈ {low < medium < high},   -- totally ordered tier (cf. EvidenceMode); grounds the SingleObvious confidence = high guard and the confidence < high gate
                      evidence_mode: Optional(EvidenceMode),       -- highest tier among the signals that matched this candidate at scan time; Null ⇒ INDEX entry predates evidence-mode capture — Null is NEUTRAL in ranking (no contribution), never a penalty
                      fork_marker: Bool,                          -- true ⇒ the id is a sidechain/fork with no top-level SSOT (SidechainNoSSOT); its own id is not a valid resume handle. Invariants: fork_marker = false ⇒ parent_pointer = Null ∧ parent_cwd = Null ; parent_pointer = Null ⇒ parent_cwd = Null (parent_cwd requires parent_pointer; parent_pointer present with parent_cwd = Null is valid — parent identified but its cwd is unknown)
                      parent_pointer: Optional(SessionId),        -- orchestrating parent session for a fork candidate, read directly from the fork's own record; the resumable handle when the parent's top-level SSOT still exists (Null ⇒ parent record absent → non-resumable)
@@ -88,6 +88,7 @@ SocraticQuestion = { dimension: ∈ {temporal, associative, contextual}, questio
 R                = Recognition ∈ {Recognize(Candidate), Refine, Reorient(description)}
 SingleObvious    = predicate; SingleObvious(C[]) ≡ |C[]| = 1 ∧ confidence(C[top]) = high   -- Light-only Extension guard: the one candidate is the single dominant option (option-set entropy → 0 → relay), so Qc is absorbed into the emit; Medium (|C[]| ≥ 2) and Heavy (confidence < high) keep the Qc gate
 divergence_affordance = the mismatch channel folded into the non-yielding SingleObvious emit: names concrete adjacent candidates (Refine) AND offers an open free-response invitation (Reorient), keeping the full R = {Recognize, Refine, Reorient} coproduct reachable without a gate — Recognize is realized as silence-default
+emitted(x)       = predicate; the relay emit(x) has fired in session text — the Extension-path convergence witness (event predicate; satisfied by the non-yielding SingleObvious emit, no turn yield)
 H                = Hint     -- answer from Socratic probe gate (Qs)
 ClueVector_prose = String
 RecalledContext  = session text containing ClueVector_prose
@@ -117,14 +118,14 @@ Phase 1: V → Scan_{Track}(Store, trace(V)) → Rank(C[]) → C[ranked]  -- tra
            |C[ranked]| = 0 ∧ attempts > 0 → NullMatch → inform → deactivate
 Phase 2: SingleObvious(C[ranked]) → emit(ClueVector_prose(C[top]) ⊕ divergence_affordance) → recall_complete(C[top]) → converge   -- Extension: high-confidence single candidate, no turn yield, no [Tool] Stop; silence = Recognize
          ¬SingleObvious(C[ranked]) → C[top] → Qc(C[top], evidence, framing) → Stop → R    -- recognition gate [Tool]
-Phase 3: R → integrate(R, V, Σ) →                                -- integration (sense); a divergence after a SingleObvious emit enters here via Refine/Reorient on the next user turn
+Phase 3: R → integrate(R, V, Σ) →                                -- integration (sense); after a SingleObvious emit, a next-turn divergence reaches these paths through fresh re-activation (Layer 1/2), not a transition from the converged state
            Recognize(c) → ClueVector_prose(c) → emit → converge
            Refine → Probe(V, Σ) → Qs(probe) → Stop → H          -- Socratic probing [Tool]
                   → enrich(V, H) → Phase 1
            Reorient(d) → rebind(V, d, Σ) → Phase 1               -- orthogonal re-scan (sense)
 
 ── LOOP ──
-Phase 1 → Phase 2 → Phase 3 →                              -- Phase 2 SingleObvious shortcut: emit ⊕ divergence affordance → converge (Extension, skips the Phase 3 gate; a divergence in the next turn → Refine/Reorient)
+Phase 1 → Phase 2 → Phase 3 →                              -- Phase 2 SingleObvious shortcut: emit ⊕ divergence affordance → converge (Extension, skips the Phase 3 gate; convergence is notional, so a next-turn divergence re-engages via fresh re-activation → Refine/Reorient)
   Recognize: converge
   Refine: Socratic probing → enrich → Phase 1
   Reorient: rebind V with orthogonal description → Phase 1
@@ -134,7 +135,7 @@ Convergence evidence: (VagueRecall → [enrichments] → Candidate(recognized) �
 
 ── CONVERGENCE ──
 recall_complete = Recognize(c) for some c ∈ C[]                                        -- gated path (¬SingleObvious)
-               ∨ SingleObvious(C[]) ∧ emitted(ClueVector_prose(C[top]) ⊕ divergence_affordance)   -- Extension path: the inline emit converges immediately (no turn yield); non-divergence (silence) realizes user-constituted recognition, a later divergence re-enters Refine/Reorient
+               ∨ SingleObvious(C[]) ∧ emitted(ClueVector_prose(C[top]) ⊕ divergence_affordance)   -- Extension path: the inline emit converges immediately (no turn yield); non-divergence (silence) realizes user-constituted recognition. Convergence is notional — a later divergence re-engages via fresh re-activation (Layer 1/2), not a transition out of the converged state
 NullMatch = |C[]| = 0 ∧ attempts > 0 ∧ (attempts = max ∨ enrichments exhausted)
 progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 
@@ -405,7 +406,7 @@ Dispatch the scan on the classified `Track`, execute track-appropriate lookup ov
 
 ### Phase 2: Narrative Recognition (Constitution; Extension on a high-confidence single candidate)
 
-**Present** the highest-priority candidate as a discussion narrative for user recognition. Branch on the candidate set: a **high-confidence single candidate** (`|C[]| = 1` at high confidence — `SingleObvious`) absorbs the gate into the presentation — emit the recognized context inline as **Extension** (no turn yield, converge immediately): essential output first (narrative + `Resume` handle + currency≠fidelity caveat), then a **divergence-only affordance** that names the concrete adjacent candidates (Refine) and invites an open redescription of the target (Reorient), keeping the full Recognize / Refine / Reorient set reachable. Silence (the user moving on) constitutes recognition; only divergence is explicit, and a divergence in the next turn continues into the existing Refine / Reorient paths (no gate, no re-activation step). One dominant candidate collapses the option set to a single option, so this is relay, not a gate. **Otherwise** (candidates ≥ 2, or confidence < high) the recognition gate runs as a Constitution interaction (turn yield). Both branches share the narrative format below.
+**Present** the highest-priority candidate as a discussion narrative for user recognition. Branch on the candidate set: a **high-confidence single candidate** (`|C[]| = 1` at high confidence — `SingleObvious`) absorbs the gate into the presentation — emit the recognized context inline as **Extension** (no turn yield, converge immediately): essential output first (narrative + `Resume` handle + currency≠fidelity caveat), then a **divergence-only affordance** that names the concrete adjacent candidates (Refine) and invites an open redescription of the target (Reorient), keeping the full Recognize / Refine / Reorient set reachable. Silence (the user moving on) constitutes recognition; only divergence is explicit. Convergence here is notional — the inline skill prose persists as a standing instruction, so a next-turn divergence re-engages the protocol through fresh empty-intention re-detection (Layer 1/2 activation), which routes to the existing Refine / Reorient handling — there is no encoded transition out of the converged state, and no dedicated re-activation machinery is added. One dominant candidate collapses the option set to a single option, so this is relay, not a gate. **Otherwise** (candidates ≥ 2, or confidence < high) the recognition gate runs as a Constitution interaction (turn yield). Both branches share the narrative format below.
 
 **Selection criterion**: Choose the candidate whose recognition would maximally resolve the user's empty intention. When priority is equal, prefer the candidate with richer narrative context and adjacent vectors.
 
@@ -422,7 +423,7 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Framing**: how many recall tries remain before the cap, and the size of the candidate space still in scope — stated as the budget you reason with, not a numeric attempt fraction
 
-For the **SingleObvious** path the inline emit renders the narrative format above as plain session text (narrative + `Resume` handle + currency≠fidelity caveat) and ends with the divergence-only affordance (named adjacents + open channel), no gate. **Gated path** (`¬SingleObvious`) — then **present**:
+For the **SingleObvious** path the inline emit renders the narrative format above as plain session text — the convergence trace folded in (narrative + `Resume` handle + currency≠fidelity caveat) — and ends with the divergence-only affordance (named adjacents + open channel), no gate. **Gated path** (`¬SingleObvious`) — then **present**:
 
 ```
 Does this match the discussion you are recalling?
@@ -485,7 +486,7 @@ After integration: `recall_complete` → present convergence evidence trace (Vag
 
 7. **Convergence persistence and early exit**: Mode active until recall_complete, NullMatch after exhausted attempts, or user Esc; user recognition or rejection of a candidate is final for that candidate in the current session, and Esc is accepted immediately regardless of remaining attempts.
 
-8. **Convergence evidence**: Present transformation trace (VagueRecall → enrichments → Candidate(recognized) → ClueVector_prose) before declaring recall_complete — convergence is demonstrated, not asserted.
+8. **Convergence evidence**: Present transformation trace (VagueRecall → enrichments → Candidate(recognized) → ClueVector_prose) before declaring recall_complete — convergence is demonstrated, not asserted. The SingleObvious Extension path folds this trace into its non-yielding inline emit (degenerate — a single candidate with no enrichments collapses the trace to VagueRecall → Candidate(recognized) → ClueVector_prose), satisfying this rule within the emit rather than via a separate Phase 3 step.
 
 9. **Context-Question Separation**: Present narrative context, evidence, and adjacent vectors as text before the Constitution interaction; the interaction contains only the recognition question and options with differential implications. Embedding context inside the question field violates this invariant.
 

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -21,7 +21,8 @@ Anamnesis(V) → Detect(V) →
     |C[]| = 0 ∧ attempts = 0: Probe(V, Σ) → Qs(probe) → Stop → H → enrich(V, H) → re-scan
     |C[]| = 0 ∧ attempts > 0: NullMatch → inform(V, Σ) → deactivate
     |C[]| > 0: backtrace_parent(c) ∀ c ∈ C[] : fork_marker(c) → parent_pointer, parent_cwd   -- deterministic: a fork candidate's parent is recoverable from its own record, not inferred (mechanism in TOOL GROUNDING; ≠ user-described Reorient)
-               Qc(C[top], evidence, framing) → Stop → R →
+               SingleObvious(C[]): emit(ClueVector_prose(C[top]) ⊕ divergence_affordance) → recall_complete(C[top]) → converge   -- Extension (relay): high-confidence single candidate, no turn yield; silence = Recognize, divergence in the next turn re-enters Refine/Reorient below (no re-activation machinery)
+               ¬SingleObvious(C[]): Qc(C[top], evidence, framing) → Stop → R →
       Recognize(c): recall_complete(c) → emit(ClueVector_prose(c)) → converge      -- fork: emitted pointer = parent (or, when the parent record is absent, non-resumable + recoverable artifacts)
       Refine: Probe(V, Σ) → Qs(probe) → Stop → H → enrich(V, H) → re-scan
       Reorient(d): rebind(V, d, Σ) → Phase 1                 -- orthogonal dimension shift
@@ -34,8 +35,8 @@ VagueRecall
   → scan(Store, Track, recall_trace)     -- track-specific scan (see STORE TOPOLOGY)
   → rank(candidates, recall_trace)       -- order by relevance
   → backtrace_parent(candidate)          -- when fork_marker: deterministic parent identification → parent_pointer, parent_cwd (recovered from the candidate's own record; ≠ user-described Reorient)
-  → present(candidate, Socratic)         -- Socratic candidate presentation
-  → recognize(candidate, user)           -- synthesis of identification (Husserl CM §§38-39)
+  → present(candidate, Socratic)         -- Socratic candidate presentation; absorbed into the emit for SingleObvious (high-confidence single candidate) — Extension, no turn yield
+  → recognize(candidate, user)           -- synthesis of identification (Husserl CM §§38-39); for SingleObvious, realized as silence-default behind a divergence-only affordance (non-divergence constitutes recognition)
   → emit(ClueVector_prose)               -- NL rendering to session text
   → RecalledContext
 requires: empty_intention(V)              -- phenomenological trigger
@@ -85,6 +86,8 @@ Rank             = List(Candidate) → List(Candidate)   -- track-primary signal
 Probe            = (V, Σ) → List(SocraticQuestion)
 SocraticQuestion = { dimension: ∈ {temporal, associative, contextual}, question: String }
 R                = Recognition ∈ {Recognize(Candidate), Refine, Reorient(description)}
+SingleObvious    = predicate; SingleObvious(C[]) ≡ |C[]| = 1 ∧ confidence(C[top]) = high   -- Light-only Extension guard: the one candidate is the single dominant option (option-set entropy → 0 → relay), so Qc is absorbed into the emit; Medium (|C[]| ≥ 2) and Heavy (confidence < high) keep the Qc gate
+divergence_affordance = the mismatch channel folded into the non-yielding SingleObvious emit: names concrete adjacent candidates (Refine) AND offers an open free-response invitation (Reorient), keeping the full R = {Recognize, Refine, Reorient} coproduct reachable without a gate — Recognize is realized as silence-default
 H                = Hint     -- answer from Socratic probe gate (Qs)
 ClueVector_prose = String
 RecalledContext  = session text containing ClueVector_prose
@@ -112,15 +115,16 @@ Phase 1: V → Scan_{Track}(Store, trace(V)) → Rank(C[]) → C[ranked]  -- tra
            backtrace_parent(c) ∀ c ∈ C[ranked] : fork_marker(c) → parent_pointer, parent_cwd  -- fork (SidechainNoSSOT): parent recovered deterministically from the candidate's own record [Tool]
            |C[ranked]| = 0 ∧ attempts = 0 → Probe(V, Σ) → Qs → Stop → H → enrich(V, H) → Phase 1
            |C[ranked]| = 0 ∧ attempts > 0 → NullMatch → inform → deactivate
-Phase 2: C[top] → Qc(C[top], evidence, framing) → Stop → R    -- recognition gate [Tool]
-Phase 3: R → integrate(R, V, Σ) →                                -- integration (sense)
+Phase 2: SingleObvious(C[ranked]) → emit(ClueVector_prose(C[top]) ⊕ divergence_affordance) → recall_complete(C[top]) → converge   -- Extension: high-confidence single candidate, no turn yield, no [Tool] Stop; silence = Recognize
+         ¬SingleObvious(C[ranked]) → C[top] → Qc(C[top], evidence, framing) → Stop → R    -- recognition gate [Tool]
+Phase 3: R → integrate(R, V, Σ) →                                -- integration (sense); a divergence after a SingleObvious emit enters here via Refine/Reorient on the next user turn
            Recognize(c) → ClueVector_prose(c) → emit → converge
            Refine → Probe(V, Σ) → Qs(probe) → Stop → H          -- Socratic probing [Tool]
                   → enrich(V, H) → Phase 1
            Reorient(d) → rebind(V, d, Σ) → Phase 1               -- orthogonal re-scan (sense)
 
 ── LOOP ──
-Phase 1 → Phase 2 → Phase 3 →
+Phase 1 → Phase 2 → Phase 3 →                              -- Phase 2 SingleObvious shortcut: emit ⊕ divergence affordance → converge (Extension, skips the Phase 3 gate; a divergence in the next turn → Refine/Reorient)
   Recognize: converge
   Refine: Socratic probing → enrich → Phase 1
   Reorient: rebind V with orthogonal description → Phase 1
@@ -129,7 +133,8 @@ Max 3 recall attempts. Exhausted: surface best candidate → deactivate.
 Convergence evidence: (VagueRecall → [enrichments] → Candidate(recognized) → ClueVector_prose).
 
 ── CONVERGENCE ──
-recall_complete = Recognize(c) for some c ∈ C[]
+recall_complete = Recognize(c) for some c ∈ C[]                                        -- gated path (¬SingleObvious)
+               ∨ SingleObvious(C[]) ∧ emitted(ClueVector_prose(C[top]) ⊕ divergence_affordance)   -- Extension path: the inline emit converges immediately (no turn yield); non-divergence (silence) realizes user-constituted recognition, a later divergence re-enters Refine/Reorient
 NullMatch = |C[]| = 0 ∧ attempts > 0 ∧ (attempts = max ∨ enrichments exhausted)
 progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 
@@ -153,7 +158,8 @@ Phase 1 Scan_salience (observe)  → Read, Grep, Glob (MarkerProfile match over 
 Phase 1 Scan_hybrid   (observe)  → union of above
 Phase 1 Rank        (sense)    → Internal analysis (conditional: haiku scoring for large candidate sets)
 Phase 1 backtrace_parent (observe) → Read (fork candidate only: read the orchestrating parent's session_id directly from the fork's substitute capture, then check parent SSOT existence for resumability; deterministic and citable to the capture entry — hence (observe); read-only)
-Phase 2 Qc          (constitution)     → present (narrative Socratic candidate; mandatory)
+Phase 2 Qc          (constitution)     → present (narrative Socratic candidate; gated path — ¬SingleObvious: candidates ≥ 2 OR confidence < high)
+Phase 2 emit        (extension)    → TextPresent+Proceed (SingleObvious path only: high-confidence single candidate emitted inline with a divergence-only affordance, no turn yield, converge immediately). Relay basis: one dominant candidate collapses the recognition option set to a single option (Refine/Reorient are foils), so the option set is relay rather than a gate; this conditional Constitution→Extension specialization within Phase 2 is the sanctioned revision of Rule 12's Safeguard-tier mandatory-Qc tag, motivated by observed binary-confirm abandonment friction. It is the relay-collapse kind of (extension), NOT a Standing-authority migration.
 Phase 3 integrate   (track)    → Internal state update
 Phase 3 Probe       (sense)    → Internal (gap detection)
 Phase 3 Qs          (constitution)     → present (Socratic probing with structured navigation; mandatory on Refine)
@@ -303,7 +309,7 @@ The scan finds candidates; the narrative Qc enables recognition; the user consti
 
 ### Activation
 
-AI detects empty intention in user expression (Layer 2, silent Phase 0) OR user calls `/recollect` (Layer 1, always available). Recognition always requires user interaction at Phase 2 gate. On direct `/recollect`, bind `V` from current/recent context; if none recoverable, request the recall target before Phase 0.
+AI detects empty intention in user expression (Layer 2, silent Phase 0) OR user calls `/recollect` (Layer 1, always available). Recognition requires user interaction at the Phase 2 gate, except for a high-confidence single candidate — there the gate is absorbed into an inline Extension emit with a divergence-only affordance, and non-divergence (silence) constitutes recognition. On direct `/recollect`, bind `V` from current/recent context; if none recoverable, request the recall target before Phase 0.
 
 **Empty intention** — user has vague memory of prior context but cannot locate/specify it (knows-that ∃ something, not what/where).
 
@@ -321,7 +327,7 @@ When Anamnesis is active:
 
 **Retained**: Safety boundaries, tool restrictions, user explicit instructions
 
-**Action**: At Phase 2, present narrative candidate for user recognition via Cognitive Partnership Move (Constitution).
+**Action**: At Phase 2, present the narrative candidate for user recognition — a Constitution gate when candidates ≥ 2 or confidence < high; for a high-confidence single candidate, an Extension inline emit with a divergence-only affordance (silence constitutes recognition).
 </system-reminder>
 
 Anamnesis completes before context-dependent work; loaded instructions resume after recall resolves or dismisses.
@@ -351,7 +357,7 @@ Heuristic signals for empty intention detection (not hard gates):
 
 | Trigger | Effect |
 |---------|--------|
-| recall_complete (Recognize) | Emit ClueVector_prose; proceed with the recognized context as recalled past context requiring re-verification against current state before commit (not confirmed current context) |
+| recall_complete (Recognize, or SingleObvious inline emit) | Emit ClueVector_prose; proceed with the recognized context as recalled past context requiring re-verification against current state before commit (not confirmed current context) |
 | NullMatch (all attempts exhausted) | Surface search scope + accumulated trace, offer Aitesis handoff for SSOT search, deactivate |
 | User Esc key | Accept current state without further recall assistance |
 
@@ -397,9 +403,9 @@ Dispatch the scan on the classified `Track`, execute track-appropriate lookup ov
 
 **Scope restriction**: Investigation uses Read, Grep, Glob exclusively.
 
-### Phase 2: Narrative Recognition (Constitution)
+### Phase 2: Narrative Recognition (Constitution; Extension on a high-confidence single candidate)
 
-**Present** the highest-priority candidate as a discussion narrative for user recognition via Cognitive Partnership Move (Constitution).
+**Present** the highest-priority candidate as a discussion narrative for user recognition. Branch on the candidate set: a **high-confidence single candidate** (`|C[]| = 1` at high confidence — `SingleObvious`) absorbs the gate into the presentation — emit the recognized context inline as **Extension** (no turn yield, converge immediately): essential output first (narrative + `Resume` handle + currency≠fidelity caveat), then a **divergence-only affordance** that names the concrete adjacent candidates (Refine) and invites an open redescription of the target (Reorient), keeping the full Recognize / Refine / Reorient set reachable. Silence (the user moving on) constitutes recognition; only divergence is explicit, and a divergence in the next turn continues into the existing Refine / Reorient paths (no gate, no re-activation step). One dominant candidate collapses the option set to a single option, so this is relay, not a gate. **Otherwise** (candidates ≥ 2, or confidence < high) the recognition gate runs as a Constitution interaction (turn yield). Both branches share the narrative format below.
 
 **Selection criterion**: Choose the candidate whose recognition would maximally resolve the user's empty intention. When priority is equal, prefer the candidate with richer narrative context and adjacent vectors.
 
@@ -416,7 +422,7 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Framing**: how many recall tries remain before the cap, and the size of the candidate space still in scope — stated as the budget you reason with, not a numeric attempt fraction
 
-Then **present**:
+For the **SingleObvious** path the inline emit renders the narrative format above as plain session text (narrative + `Resume` handle + currency≠fidelity caveat) and ends with the divergence-only affordance (named adjacents + open channel), no gate. **Gated path** (`¬SingleObvious`) — then **present**:
 
 ```
 Does this match the discussion you are recalling?
@@ -459,13 +465,13 @@ After integration: `recall_complete` → present convergence evidence trace (Vag
 
 | Level | When | Format |
 |-------|------|--------|
-| Light | High specificity trace, single obvious candidate | Abbreviated narrative (origin + outcome) + gate with Recognize default |
+| Light | High specificity trace, single obvious candidate (high confidence) | Recognized context folded inline — narrative (origin → outcome) + resume handle + currency≠fidelity caveat — in one non-yielding (Extension) emit, then converge immediately; divergence-only affordance (named adjacents + open channel), no confirmation gate |
 | Medium | Moderate specificity, 2-3 candidates in scope | Full narrative + adjacent vectors in Refine option |
 | Heavy | Low specificity, Refine path expected, high ambiguity trace | Full narrative + adjacent vectors + Socratic probing with structured navigation + hypomnesis overview on initial scan |
 
 ## Rules
 
-1. **AI-guided detection, user-constituted recognition**: AI detects empty intention, scans stores, and presents narrative candidates as recognition options; user identification via Cognitive Partnership Move (Constitution) at Phase 2 constitutes the identity match. Detection, presentation, and constitution are separate acts — AI detection is implicitly confirmed when the user engages with recognition (Phase 2 response, not Esc).
+1. **AI-guided detection, user-constituted recognition**: AI detects empty intention, scans stores, and presents narrative candidates as recognition options; user identification via Cognitive Partnership Move (Constitution) at Phase 2 constitutes the identity match. Detection, presentation, and constitution are separate acts — AI detection is implicitly confirmed when the user engages with recognition (Phase 2 response, not Esc). For a high-confidence single candidate (SingleObvious), recognition is constituted by non-divergence: the inline Extension emit carries a divergence-only affordance, and silence (the user moving on) realizes the identity match — the user's constitutive freedom is the divergence channel, not a forced confirm.
 
 2. **Recognition over Retrieval**: Present structured narrative options with anticipatable post-selection state (Recognize / Refine / Reorient) — Constitution interaction requires turn yield before proceeding; recognition options enable user evaluation, not blank-canvas recall.
 
@@ -487,11 +493,11 @@ After integration: `recall_complete` → present convergence evidence trace (Vag
 
 11. **Probe-first NullMatch**: At least one Socratic probe enrichment precedes any NullMatch declaration — first scan returning zero → probe → enriched re-scan → NullMatch declaration only if still empty.
 
-12. **Mandatory Qc, separate Qs and Qc** *(Safeguard tier — revisitable as instruction-following improves)*: Phase 2 Constitution interaction (Qc recognition) runs for every cycle including single high-confidence candidates — synthesis of identification is constitutive; confidence governs intensity (Light/Medium/Heavy), not whether the gate runs. On Refine, Socratic probing (Qs) and recognition (Qc) run as two distinct Constitution interactions — Qs deepens recall context first, Qc verifies identity second.
+12. **Conditional Qc, separate Qs and Qc** *(Safeguard tier — revisitable as instruction-following improves)*: Phase 2 runs the Constitution Qc gate when candidates ≥ 2 OR confidence < high (Medium / Heavy). A high-confidence single candidate (SingleObvious) instead **absorbs Qc into the presentation**: the recognized context is emitted inline as Extension (no turn yield) with a divergence-only affordance, and convergence is immediate — silence / the user moving on constitutes recognition, only divergence is explicit. One dominant candidate collapses the recognition option set to a single option (the others are foils), so the interaction is relay, not a gate; this absorption is the sanctioned revision of this rule's own Safeguard-tier tag, motivated by observed binary-confirm abandonment friction, and it does not touch Qs. On Refine (always gated), Socratic probing (Qs) and recognition (Qc) run as two distinct Constitution interactions — Qs deepens recall context first, Qc verifies identity second.
 
 13. **Cross-LOOP narrative persistence**: Narrative format and adjacent vector enrichment persist across LOOP iterations; subsequent attempts reference prior candidates and explain the differential.
 
-14. **Framing-signal visibility**: Every Phase 2 presentation states the remaining recall-try budget and the candidate space still in scope as framing prose — the budget the user reasons with, not a numeric attempt fraction.
+14. **Framing-signal visibility**: Every gated Phase 2 presentation and Refine probe states the remaining recall-try budget and the candidate space still in scope as framing prose — the budget the user reasons with, not a numeric attempt fraction. The SingleObvious inline emit converges immediately, so attempt-budget framing is moot there; its only forward branch is the divergence affordance.
 
 15. **Substrate non-coupling**: Phase prose names epistemic operations only — tool and path bindings belong exclusively to TOOL GROUNDING.
 


### PR DESCRIPTION
## 요약

Anamnesis `/recollect` Phase 2의 **고신뢰 단일 후보** 케이스를 확인(confirm) 게이트에서 **발산(divergence) 전용** 어포던스로 재설계한다. 확정 스펙은 이슈 #557 본문이다.

고신뢰 단일 후보(`SingleObvious = |C[]| = 1 ∧ confidence = high`)일 때 확인 Qc 게이트를 표현으로 흡수한다:

- 인식된 맥락(서사 + `Resume` 핸들 + currency≠fidelity 단서)을 **턴을 넘기지 않는 단일 Extension emit**으로 먼저 내보내고 **즉시 수렴**한다.
- 뒤에 **발산 전용 어포던스**(호명된 인접 후보 = Refine + 개방 채널 = Reorient)만 남긴다. 전체 `R = {Recognize, Refine, Reorient}` coproduct는 게이트 없이 도달 가능하게 유지된다.
- **침묵 / 사용자 이탈 = 인식**으로 수용하고, **발산만 명시적**이다.

## 스코프 (Light 한정)

흡수는 **Light = 단일 후보 ∧ 고신뢰**에만 적용된다. **Medium(2-3 후보)/Heavy(저신뢰)는 명시적 게이트 유지** — 실질 대안은 사용자 선택을 요구하며(A5), 사용자는 진짜 선택은 이탈하지 않는다(관측). 흡수 경계 = 이탈위험 경계 = 단일후보 경계가 일치한다.

## 근거 (durable axiom basis)

- **A5 옵션집합 relay 테스트**: 단일 지배 후보는 옵션집합 엔트로피를 0으로 붕괴시켜 relay가 된다(Refine/Reorient는 foil). 따라서 "게이트로 오분류"된 것을 relay로 제시.
- **Rule 12 Safeguard-tier**: Rule 12 자체가 "instruction-following 개선에 따라 개정 가능"으로 자기-태깅 — 이 흡수가 그 정당한 개정 경로.
- **관측된 마찰**: 이항 확인("맞아요?")은 이탈률이 높아 명시적 Recognize 대기는 실무에서 ClueVector emission을 잃는다.
- A2의 configurable relay/constitution boundary에 따라 Phase 2 내 **조건부 Constitution→Extension 특화**를 별도 `(extension)` 항목으로 기록. 이는 **A5-collapse 종류**이며, project-profile가 "연기"로 표시한 bounded-zone(Horismos/Syneidesis/Prosoche)의 Standing-authority 마이그레이션과는 구별된다.

재활성화/immunity-override/re-seed 기계는 **추가하지 않음** (#557 `/gap` 검증: inline skill은 지속 프롬프트 주입이라 "수렴/deactivate"는 notional; 발산은 다음 턴에 기존 Refine/Reorient로 자연 연속).

## 편집 사이트 (3곳)

1. **Intensity · Light row** — 확정 맥락 인라인 폴딩 + 발산 전용 어포던스, 확인 게이트 없음.
2. **Rule 12** — `Mandatory Qc` → `Conditional Qc`: 후보 ≥ 2 OR 저신뢰일 때만 게이트, 고신뢰 단일 후보는 Qc를 표현으로 흡수. Qs(Refine)는 분리 유지.
3. **Phase 2 (Narrative Recognition)** — 단일-명백 후보 분기 추가(Extension 인라인 emit + 발산 어포던스, 턴-yield 게이트 생략); 그 외는 기존 게이트.

## 정합성 의무

- **FLOW / MORPHISM / PHASE TRANSITIONS** 스레딩: Phase 2 present/Qc 단계에 조건부 Extension 분기 추가.
- **의미-폐합 스윕**: 새 Extension 분기에 type(`SingleObvious`, `divergence_affordance`) · guard(`|C[]| = 1 ∧ confidence = high`) · state update(`recall_complete`) · termination(`→ converge`) · result equation(CONVERGENCE `recall_complete` 분기) 정렬. TYPES/PHASE TRANSITIONS/LOOP/CONVERGENCE/TOOL GROUNDING/Rules 동기.
- **TOOL GROUNDING**: 기존 Phase 2 Qc `(constitution)` 유지(게이트 경로) + 조건부 `Phase 2 emit (extension)` 항목 추가(A5 relay 근거).
- **버전 범프**: `0.7.0 → 0.8.0` (claude/codex 매니페스트 동기).

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — **123 pass, 0 fail** (잔여 경고 2건은 선재·무관: `DerivedFrom` dead-type, 타 파일 한국어 문자).
- `node --test scripts/package.test.js` — **49 pass, 0 fail** (anamnesis SKILL.md 507줄, 510 가이드라인 이내).
- pre-commit hook 통과.

Refs #557

---
🤖 머지는 사용자가 웹에서 직접 수행합니다 (이 PR은 머지하지 않음).
