### PR TITLE
docs(release): v2026.06.22 릴리스 노트 초안 (v2026.06.17..main)

### DIFF
--- a/docs/releases/v2026.06.22.md
+++ b/docs/releases/v2026.06.22.md
@@ -1,0 +1,110 @@
+# Epistemic Protocols v2026.06.22
+
+> _Draft release notes, staged for review in a PR. The canonical publish path remains the `/release` skill (tag push → CI `release.yml` builds the draft via `scripts/package.js` → narrative prepend via `gh release edit`). This file is the reviewable narrative + commit body for `v2026.06.17..main`; the owner runs `/release` to cut the actual GitHub Release. Range: `v2026.06.17..HEAD` (60 commits). Body below `## Highlights` is generated verbatim by `scripts/package.js`._
+
+> **Background**
+>
+> 지난 릴리스가 "프로토콜은 컴파일하고, 실행·검증은 substrate가 맡는다"는 축을 세웠다면, 이번 사이클의 물음은 한 단계 더 안쪽이었습니다 — 게이트는 *언제* 떠야 하는가?
+>
+> 그동안 프로토콜은 결정 지점마다 게이트를 띄워 사용자에게 물었습니다. 그런데 되돌릴 수 있고 방향이 이미 정해진 결정까지 일일이 묻는 것은, Recognition(인식)을 지키려다 오히려 매 턴 인지 부하를 더하는 over-gating이었습니다. 그래서 먼저 메타 규칙을 세웠습니다 — 게이트를 렌더링하기 전에 reversibility tier를 먼저 돌립니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해진(settled) 결정이면 게이트를 띄우지 않고 바로 실행·요약(relay)하고, 게이트는 되돌릴 수 없거나 되돌릴 수 있어도 방향이 진짜 갈리는 결정에만 남깁니다.
+>
+> 이 한 가지 원칙이 곧바로 여러 프로토콜을 차례로 다시 손보게 만들었습니다. `/bound`는 경계 종류가 단일-dominant로 좁혀지면(Phase 0b), `/misuse`는 안전 기본값이 명백하면(Phase 0), `/ascend`는 후보가 하나뿐이면(SingleObvious, Phase 2) — 모두 게이트 대신 relay로 떨어집니다. `/recollect`는 고신뢰 단일 후보 게이트를 "확인"이 아니라 "발산(divergence)" 전용으로 재설계해, 맞다고 확인만 받던 동작을 다른 후보로 갈라질 여지가 있을 때만 묻도록 바꿨습니다.
+>
+> 같은 사이클에 새 프로토콜 `/ascend` (Anagoge)가 합류했습니다. 회상 단위의 granularity가 부족할 때, 흩어진 deposit을 더 높은 차원의 단위로 끌어올리는(RecallGranularityInsufficient → HigherGranularityUnit) 프로토콜입니다. 구성 과정에서 각 deposit의 출처와 재진입 명령을 노출해, 끌어올린 단위가 어디서 왔는지 되짚을 수 있게 했습니다. 돌아보면 이번 사이클도 프로토콜을 써서 프로토콜을 다듬은 기록입니다 — 여러 라운드의 review-loop 수렴이 그 흔적입니다.
+>
+> ---
+>
+> **무엇이 새로운가요?**
+>
+> 이번 릴리스의 핵심은 **게이트 규율 — 되돌릴 수 있고 방향이 이미 정해진 결정은 게이트로 다시 묻지 않는다** — reversibility tier 선행조건을 세우고, 그 원칙을 `/bound`·`/misuse`·`/ascend`·`/recollect`에 일괄 적용하면서 새 프로토콜 `/ascend`까지 더한 릴리스입니다.
+>
+> - 🚦 **게이트 발화 선행조건 (epistemic-ink Output Style)** — 게이트를 띄우기 전에 reversibility tier를 먼저 돌립니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해진(settled) 결정은 게이트 없이 바로 relay로 실행·요약하고, 게이트는 되돌릴 수 없거나 방향이 진짜 갈리는 결정에만 남습니다.
+> - 🧩 **단일-dominant / 안전기본값 relay 일괄 적용 (`/bound`·`/misuse`·`/ascend`·`/recollect`)** — 경계 종류가 하나로 좁혀지거나(`/bound` Phase 0b), 안전 기본값이 명백하거나(`/misuse` Phase 0), 후보가 하나뿐이면(`/ascend` SingleObvious) 게이트 대신 relay로 떨어집니다. `/recollect`의 고신뢰 단일 후보 게이트는 "확인"이 아니라 "발산" 전용으로 재설계됐습니다.
+> - 🆙 **신규 `/ascend` (Anagoge 0.1.7)** — 회상 단위의 granularity가 부족할 때 흩어진 deposit을 더 높은 차원의 단위로 끌어올립니다(RecallGranularityInsufficient → HigherGranularityUnit). 구성 deposit마다 출처와 재진입 명령을 노출해 끌어올린 단위의 출처를 되짚을 수 있습니다.
+> - 📐 **형식 블록은 runtime-normative (14개 프로토콜)** — formal block이 기여자용 명세가 아니라 런타임 계약의 일부, 즉 프로토콜 정체성을 타입 짓는 규범임을 14개 프로토콜 Rules에 명시했습니다.
+>
+> 그 외 함께 들어온 변경:
+>
+> - 🔌 **`/forge` PromptArtifact 개명 + Dia 어댑터** — forge 엔드포인트를 PromptArtifact로 개명하고 Dia 어댑터를 추가했으며, 형제 어댑터를 거명하지 않는 어댑터 격리 원칙을 forge 어댑터 전반에 일관 적용했습니다.
+> - 🔍 **시맨틱 감사 엔진 추출 + white-bear·zero-shot 게시 승격** — epistemic-cooperative의 감사 엔진을 별도로 추출하고 white-bear·zero-shot 스킬을 게시 승격했습니다.
+> - 🎯 **review-loop design-intent harvest** — 리뷰 라운드마다 design-intent를 수확·갱신하도록 review-loop를 보강했습니다.
+> - 📦 **project-profile 압축** — 6변수 테이블을 압축하고 `(extension)` 마이그레이션 posture를 분리했습니다.
+>
+> ---
+
+## Highlights
+
+### New
+
+- **horismos**: /bound Phase 0b 단일-dominant kind relay — over-gate 해소
+- **anagoge**: /ascend Phase 2 SingleObvious relay — 단일후보 over-gate 해소
+- **anagoge**: 상승 단위 구성 deposit마다 출처와 재진입 명령 노출
+- **anagoge**: Anagoge 프로토콜 추가 (/ascend)
+- **epistemic-cooperative**: /misuse Phase 0 안전 기본값 relay — scope over-gate 해소
+- **epistemic-cooperative**: forge 엔드포인트를 PromptArtifact로 개명하고 Dia 어댑터 추가
+- **epistemic-cooperative**: 시맨틱 감사 엔진 추출 및 white-bear·zero-shot 게시 승격
+- **epistemic-cooperative**: review-loop에 design-intent harvest 추가
+- **epistemic-ink**: gate firing precondition — reversibility tier before render
+- **core-protocols**: formal blocks가 runtime-normative임을 14개 프로토콜 Rules에 인스크립션
+- **anamnesis**: /recollect Phase 2 고신뢰 단일 후보 게이트를 확인→발산 전용으로 재설계
+
+### Fixed
+
+- **horismos**: /bound relay redirect 갭 해소 + route/ambiguous 정정 (review-loop r2 수렴)
+- **horismos**: review-loop 정합성 수정 — Phase 0b relay 의미 폐쇄 + 프로필 de-volatilize
+- **misuse**: Phase 0 형식 블록 타입 정합성 + TOOL GROUNDING 자족성 정리
+- **anagoge**: ascend SingleObvious framing 예외 명시 (recollect Rule 14 parity)
+- **anagoge**: review-loop 정합성 수정 (Rule 13 일원화 + 의미 폐쇄)
+- **anagoge**: 리뷰 라운드4 — presented 상태 갱신 wiring
+- **anagoge**: 리뷰 라운드3 — NullMatch Rule 12 구조적 보장
+- **anagoge**: 리뷰 라운드2 — attempt-cap 재구성의 미전파 마감
+- **anagoge**: 리뷰 수렴 — 형식 블록 정합성 + probe 카탈로그 등록
+- **epistemic-cooperative**: codex-goals 어댑터의 형제 거명 잔존 제거
+- **epistemic-cooperative**: 어댑터 격리 원칙을 forge 어댑터 전반에 일관 적용
+- **epistemic-cooperative**: dia 어댑터에서 형제 어댑터 거명 제거
+- **epistemic-cooperative**: forge PromptArtifact 개명 완결성 보강 + README 어댑터 목록 동기화
+- **epistemic-cooperative**: marketplace에 /lens-review 누락 보강 및 audit-engine sync 의무 정확화
+- **epistemic-cooperative**: review-loop의 C-scope를 SKILL.md에 명시
+- **epistemic-cooperative**: formal block을 기여자용 명세로 오해할 여지 차단
+- **epistemic-cooperative**: review-loop codex 프롬프트에 project-guide intent 슬롯 추가
+- **epistemic-cooperative**: review-loop intent 번들 어휘 전 site 일괄 정리
+- **epistemic-cooperative**: review-loop intent 정의·소스 일관성 정리
+- **epistemic-cooperative**: review-loop design-intent 지시 정밀화 + 라운드별 intent 갱신
+- **epistemic-cooperative**: review-loop 소스 인터페이스 시그니처 표기 일관성 정리
+- **epistemic-ink**: gate 발화 선행조건 리뷰 반영 — floor 가드 + settled 범위 정정
+- **core-protocols**: formal-blocks Rule을 Definition 블록 자기참조로 교체
+- **anamnesis**: /recollect SingleObvious 경로 형식 폐합 보강
+
+### Improved
+
+- **project-profile**: A5-collapse first-instance를 #557 제안/미구현으로 시제 교정 (codex r1)
+- **project-profile**: A5-collapse 축 독립성을 긍정 서술로 재서술 (white-bear)
+- **project-profile**: 6변수 테이블 압축 + (extension) 마이그레이션 posture 분리
+
+### docs
+
+- **triage**: distinguish intake load from downstream deliverable load
+
+### Other
+
+- offload write skill
+
+## Protocols
+
+| Protocol | Command | Deficit → Resolution | Version |
+|----------|---------|---------------------|---------|
+| Anamnesis | `/recollect` | RecallAmbiguous → RecalledContext | 0.8.2 |
+| Anagoge | `/ascend` | RecallGranularityInsufficient → HigherGranularityUnit | 0.1.7 |
+| Horismos | `/bound` | BoundaryUndefined → DefinedBoundary | 2.0.4 |
+| Aitesis | `/inquire` | ContextInsufficient → InformedExecution | 5.1.2 |
+| Prothesis | `/frame` | FrameworkAbsent → FramedInquiry | 7.0.1 |
+| Analogia | `/ground` | MappingUncertain → ValidatedMapping | 1.7.2 |
+| Periagoge | `/induce` | AbstractionInProcess → CrystallizedAbstraction | 0.3.3 |
+| Euporia | `/elicit` | AbstractAporia → ResolvedEndpoint | 0.3.1 |
+| Syneidesis | `/gap` | GapUnnoticed → AuditedDecision | 2.22.4 |
+| Prosoche | `/attend` | ExecutionBlind → SituatedExecution | 2.0.3 |
+| Epharmoge | `/contextualize` | ApplicationDecontextualized → ContextualizedExecution | 1.0.1 |
+| Elenchus | `/sublate` | ContextSuspect → VettedContext | 0.3.1 |
+| Diylisis | `/distill` | ContextTethered → PortableHandoff | 0.4.13 |
+| Hyphegesis | `/conduct` | MethodUnderdetermined → ConductedMethod | 0.2.5 |
+| Katalepsis | `/grasp` | ResultUngrasped → VerifiedUnderstanding | 2.4.4 |

--- a/docs/releases/v2026.06.22.md
+++ b/docs/releases/v2026.06.22.md
@@ -1,34 +1,34 @@
 # Epistemic Protocols v2026.06.22
 
-> _Draft release notes, staged for review in a PR. The canonical publish path remains the `/release` skill (tag push → CI `release.yml` builds the draft via `scripts/package.js` → narrative prepend via `gh release edit`). This file is the reviewable narrative + commit body for `v2026.06.17..main`; the owner runs `/release` to cut the actual GitHub Release. Range: `v2026.06.17..HEAD` (60 commits). Body below `## Highlights` is generated verbatim by `scripts/package.js`._
+> _PR 메모 (릴리스 본문 아님) — 범위 `v2026.06.17..HEAD` (60 commits). `## Highlights` 이하는 `scripts/package.js` 생성물 그대로입니다. 정식 게시는 owner가 `/release`로 진행합니다(태그 push → CI 초안 생성 → 내러티브 prepend)._
 
 > **Background**
 >
-> 지난 릴리스가 "프로토콜은 컴파일하고, 실행·검증은 substrate가 맡는다"는 축을 세웠다면, 이번 사이클의 물음은 한 단계 더 안쪽이었습니다 — 게이트는 *언제* 떠야 하는가?
+> 이 프로젝트의 프로토콜들은 사람과 AI가 함께 일할 때의 인지 부담을 줄이려고, 결정 지점마다 **게이트**(gate, 즉 AI가 작업을 잠시 멈추고 선택지를 제시한 뒤 사용자의 답을 기다리는 확인 지점)를 띄워 왔습니다. 지난 릴리스가 "프로토콜은 *무엇을 어떻게 할지*만 컴파일해 건네고, 실제 실행·검증은 **substrate**(즉 프로토콜 바깥의 실제 실행 환경 — 코드베이스·파일·세션 기록처럼 다음 판단의 재료가 되는 표면)가 맡는다"는 축을 세웠다면, 이번 사이클의 물음은 한 단계 더 안쪽이었습니다 — *게이트는 **언제** 떠야 하는가?*
 >
-> 그동안 프로토콜은 결정 지점마다 게이트를 띄워 사용자에게 물었습니다. 그런데 되돌릴 수 있고 방향이 이미 정해진 결정까지 일일이 묻는 것은, Recognition(인식)을 지키려다 오히려 매 턴 인지 부하를 더하는 over-gating이었습니다. 그래서 먼저 메타 규칙을 세웠습니다 — 게이트를 렌더링하기 전에 reversibility tier를 먼저 돌립니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해진(settled) 결정이면 게이트를 띄우지 않고 바로 실행·요약(relay)하고, 게이트는 되돌릴 수 없거나 되돌릴 수 있어도 방향이 진짜 갈리는 결정에만 남깁니다.
+> 그동안은 결정마다 게이트를 띄워 물었습니다. 그런데 되돌릴 수 있고 방향이 이미 정해진 결정까지 일일이 묻는 것은, **Recognition**(인식 — 사용자가 답을 맨바닥에서 떠올리게 하는 대신, 제시된 선택지에서 *알아보게* 하는 원칙)을 지키려다 오히려 매 턴 인지 부하를 더하는 **과잉 게이트(over-gating)**였습니다. 그래서 메타 규칙을 하나 세웠습니다 — 게이트를 띄우기 전에 **그 결정이 되돌릴 수 있는지부터 먼저 따지는 단계(reversibility tier)**를 거칩니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해졌다면(settled), 묻지 않고 바로 **relay**(즉 판단을 새로 구성하지 않고 사실을 그대로 전달하며 실행·요약하는 처리)로 넘기고, 게이트는 *되돌릴 수 없거나, 되돌릴 수 있어도 방향이 진짜 갈리는* 결정에만 남깁니다.
 >
-> 이 한 가지 원칙이 곧바로 여러 프로토콜을 차례로 다시 손보게 만들었습니다. `/bound`는 경계 종류가 단일-dominant로 좁혀지면(Phase 0b), `/misuse`는 안전 기본값이 명백하면(Phase 0), `/ascend`는 후보가 하나뿐이면(SingleObvious, Phase 2) — 모두 게이트 대신 relay로 떨어집니다. `/recollect`는 고신뢰 단일 후보 게이트를 "확인"이 아니라 "발산(divergence)" 전용으로 재설계해, 맞다고 확인만 받던 동작을 다른 후보로 갈라질 여지가 있을 때만 묻도록 바꿨습니다.
+> 이 한 가지 원칙이 곧바로 여러 프로토콜을 차례로 손보게 만들었습니다. 경계의 종류가 하나로 압도적으로 좁혀지면(`/bound`), 안전한 기본값이 명백하면(`/misuse`), 떠오른 후보가 하나뿐이고 확신이 높으면(`/ascend`) — 모두 게이트 대신 relay로 떨어집니다. `/recollect`(과거의 한 세션 맥락을 되찾아 주는 프로토콜)는 "이게 맞습니까?"라고 확인만 받던 고신뢰 단일 후보 게이트를, *다른 후보로 갈라질 여지가 있을 때만 묻는* **발산(divergence) 방식**으로 다시 설계했습니다 — 확신이 높을 땐 사용자의 침묵이 곧 동의입니다.
 >
-> 같은 사이클에 새 프로토콜 `/ascend` (Anagoge)가 합류했습니다. 출발은 한 줄의 회상이었습니다 — 예전 `/conduct`를 개선하며 나왔던 "Span 관리·링크 그래프" 논의와 "종합 결손"을 다시 떠올리다, *`Anamnesis`의 해소집합이 한 세션이 아니라 연결세션·토픽·추상화된 개념으로 확장되면 어떨까* 라는 한 문장이 본질을 통째로 담아냈습니다(이게 곧 `RecallGranularityInsufficient → HigherGranularityUnit`입니다). 이 착상을 `/induce`(Periagoge)로 깎는 과정에서, 처음의 "엮음(Symploke)" 축이 "알갱이를 끌어올림"으로 재정향되며 이름이 따라붙었습니다 — *ana-mnesis(회상) ↔ ana-goge(상승)*, 회상의 형제. 그렇게 굳은 프로토콜은 구성 deposit마다 출처와 재진입 명령을 노출해, 끌어올린 단위가 어디서 왔는지 되짚게 합니다. 돌아보면 이번 사이클도 프로토콜을 써서 프로토콜을 다듬은 기록입니다 — `/ascend`는 `/recollect`→`/induce`→`/bound`을 거쳐 깎였고, 그 자체가 over-gate를 줄이는 이번 릴리스의 한 사례입니다.
+> 같은 사이클에 새 프로토콜 **`/ascend`** (Anagoge)가 합류했습니다. 출발은 한 줄의 회상이었습니다 — 예전 `/conduct`를 다듬다 나온 "여러 세션에 걸친 작업 범위(Span)를 어떻게 잇고 관리할지(세션·토픽을 잇는 링크 그래프)" 논의와 "종합이 안 되는 결손"(즉 세션마다 회상은 되찾아지지만, 그 조각들이 더 큰 하나의 단위로는 묶이지 않는 문제)을 다시 떠올리다, *`/recollect`가 한 세션을 되찾아 주는 거라면, 그 해소 범위를 한 세션이 아니라 **연결된 세션들·하나의 토픽·이미 굳어진 개념** 같은 더 높은 단위로 넓히면 어떨까* 라는 한 문장이 본질을 통째로 담아냈습니다. 이 착상을 `/induce`(Periagoge — 흩어진 사례에서 공통 추상을 결정화하는 프로토콜)로 깎는 과정에서, 처음의 "엮음(Symploke)" 축이 "흩어진 조각을 더 높은 알갱이로 끌어올림"으로 재정향되며 이름이 따라붙었습니다 — `/recollect`의 본래 이름 **Anamnesis**(ana-mnesis, "회상")와 접두사 `ana-`를 나눠 갖는 **Anagoge**(ana-goge, "상승"), 곧 회상의 형제입니다. 그렇게 굳은 `/ascend`는, 세션마다 남겨 둔 회상 조각(**deposit**)을 읽어 연결하되 각 조각의 출처와 그 세션으로 되돌아가는 명령을 함께 노출해, 끌어올린 단위가 어디서 왔는지 되짚게 합니다. 돌아보면 이번 사이클도 프로토콜로 프로토콜을 깎은 기록입니다 — `/ascend`는 `/recollect`→`/induce`→`/bound`을 거쳐 다듬어졌고, 그 과정 자체가 과잉 게이트를 줄이는 이번 릴리스의 한 사례가 됐습니다.
 >
 > ---
 >
 > **무엇이 새로운가요?**
 >
-> 이번 릴리스의 핵심은 **게이트 규율 — 되돌릴 수 있고 방향이 이미 정해진 결정은 게이트로 다시 묻지 않는다** — reversibility tier 선행조건을 세우고, 그 원칙을 `/bound`·`/misuse`·`/ascend`·`/recollect`에 일괄 적용하면서 새 프로토콜 `/ascend`까지 더한 릴리스입니다.
+> 이번 릴리스의 핵심은 **게이트 규율 — 되돌릴 수 있고 방향이 이미 정해진 결정은 게이트로 다시 묻지 않는다** — 입니다. "그 결정이 되돌릴 수 있는지 먼저 따진다"는 선행조건을 세우고, 그 원칙을 `/bound`·`/misuse`·`/ascend`·`/recollect`에 일괄 적용하면서, 새 프로토콜 `/ascend`까지 더했습니다.
 >
-> - 🚦 **게이트 발화 선행조건 (epistemic-ink Output Style)** — 게이트를 띄우기 전에 reversibility tier를 먼저 돌립니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해진(settled) 결정은 게이트 없이 바로 relay로 실행·요약하고, 게이트는 되돌릴 수 없거나 방향이 진짜 갈리는 결정에만 남습니다.
-> - 🧩 **단일-dominant / 안전기본값 relay 일괄 적용 (`/bound`·`/misuse`·`/ascend`·`/recollect`)** — 경계 종류가 하나로 좁혀지거나(`/bound` Phase 0b), 안전 기본값이 명백하거나(`/misuse` Phase 0), 후보가 하나뿐이면(`/ascend` SingleObvious) 게이트 대신 relay로 떨어집니다. `/recollect`의 고신뢰 단일 후보 게이트는 "확인"이 아니라 "발산" 전용으로 재설계됐습니다.
-> - 🆙 **신규 `/ascend` (Anagoge 0.1.7)** — 회상 단위의 granularity가 부족할 때 흩어진 deposit을 더 높은 차원의 단위로 끌어올립니다(RecallGranularityInsufficient → HigherGranularityUnit). 구성 deposit마다 출처와 재진입 명령을 노출해 끌어올린 단위의 출처를 되짚을 수 있습니다.
-> - 📐 **형식 블록은 runtime-normative (14개 프로토콜)** — formal block이 기여자용 명세가 아니라 런타임 계약의 일부, 즉 프로토콜 정체성을 타입 짓는 규범임을 14개 프로토콜 Rules에 명시했습니다.
+> - 🚦 **게이트 발화 선행조건** — 게이트를 띄우기 전에 *그 결정이 되돌릴 수 있는지(reversibility tier)*부터 확인합니다. 되돌릴 수 있고 방향이 분명하거나 이미 정해진 결정은 묻지 않고 바로 처리(relay, 즉 사실을 그대로 전달·실행·요약)하고, 게이트는 *되돌릴 수 없거나 방향이 진짜 갈리는* 결정에만 남깁니다.
+> - 🧩 **"후보가 하나면 묻지 않는다"를 일괄 적용 (`/bound`·`/misuse`·`/ascend`·`/recollect`)** — 경계 종류가 하나로 좁혀지거나, 안전 기본값이 명백하거나, 떠오른 후보가 하나뿐이고 확신이 높으면(SingleObvious, 즉 단일·고신뢰 후보) 게이트 대신 relay로 넘어갑니다. 특히 `/recollect`는 "맞습니까?(확인)" 게이트를 *틀렸을 때만 갈라져 나오는* 발산(divergence) 방식으로 바꿔, 확신이 높을 땐 침묵이 곧 동의가 되게 했습니다.
+> - 🆙 **신규 `/ascend` (Anagoge 0.1.7)** — 한 세션을 되찾는 것(`/recollect`)만으로는 부족할 때, *여러 세션에 흩어진 회상 조각(deposit)을 연결된 세션 묶음·하나의 토픽·이미 굳어진 개념 같은 더 높은 단위로 끌어올리는* 프로토콜입니다(이게 곧 `RecallGranularityInsufficient → HigherGranularityUnit`, 즉 "회상 단위가 너무 잘아서 안 풀림 → 더 높은 단위로"). 끌어올린 단위에 쓰인 조각마다 출처와 그 세션으로 되돌아가는 명령을 붙여, 어디서 왔는지 추적할 수 있습니다.
+> - 📐 **형식 블록은 런타임 계약이다 (14개 프로토콜)** — 각 프로토콜의 *형식 블록*(formal block — 타입과 흐름을 기호로 적은 정의부)이 기여자용 참고 명세가 아니라, 런타임에 실제로 작동하며 프로토콜의 정체성을 규정하는 *계약의 일부*임을 14개 프로토콜의 Rules에 못 박았습니다.
 >
 > 그 외 함께 들어온 변경:
 >
-> - 🔌 **`/forge` PromptArtifact 개명 + Dia 어댑터** — forge 엔드포인트를 PromptArtifact로 개명하고 Dia 어댑터를 추가했으며, 형제 어댑터를 거명하지 않는 어댑터 격리 원칙을 forge 어댑터 전반에 일관 적용했습니다.
-> - 🔍 **시맨틱 감사 엔진 추출 + white-bear·zero-shot 게시 승격** — epistemic-cooperative의 감사 엔진을 별도로 추출하고 white-bear·zero-shot 스킬을 게시 승격했습니다.
-> - 🎯 **review-loop design-intent harvest** — 리뷰 라운드마다 design-intent를 수확·갱신하도록 review-loop를 보강했습니다.
-> - 📦 **project-profile 압축** — 6변수 테이블을 압축하고 `(extension)` 마이그레이션 posture를 분리했습니다.
+> - 🔌 **`/forge` 정비 — PromptArtifact 개명 + Dia 어댑터** — `/forge`(작업 맥락을 외부 도구로 내보내는 스킬)의 산출 단위를 *PromptArtifact*로 개명하고 Dia용 어댑터를 추가했으며, *한 어댑터가 다른 형제 어댑터를 직접 거명하지 않는* 격리 원칙을 어댑터 전반에 일관 적용했습니다.
+> - 🔍 **시맨틱 감사 엔진 분리 + 스킬 두 개 게시 승격** — 의미 기반 감사 로직을 별도 엔진으로 추출하고, `white-bear`·`zero-shot` 두 스킬을 정식 게시 대상으로 올렸습니다.
+> - 🎯 **`review-loop` 설계 의도 수확** — 리뷰를 돌릴 때마다 *원래 설계 의도(design-intent)*를 함께 모아 갱신하도록 보강해, 리뷰가 표면 결함만이 아니라 의도와의 어긋남까지 잡게 했습니다.
+> - 📦 **`project-profile` 압축** — 프로젝트 보정 프로파일의 6변수 표를 압축하고, 향후 자동화 위임과 관련된 서술을 본문에서 분리했습니다.
 >
 > ---
 

--- a/docs/releases/v2026.06.22.md
+++ b/docs/releases/v2026.06.22.md
@@ -10,7 +10,7 @@
 >
 > 이 한 가지 원칙이 곧바로 여러 프로토콜을 차례로 다시 손보게 만들었습니다. `/bound`는 경계 종류가 단일-dominant로 좁혀지면(Phase 0b), `/misuse`는 안전 기본값이 명백하면(Phase 0), `/ascend`는 후보가 하나뿐이면(SingleObvious, Phase 2) — 모두 게이트 대신 relay로 떨어집니다. `/recollect`는 고신뢰 단일 후보 게이트를 "확인"이 아니라 "발산(divergence)" 전용으로 재설계해, 맞다고 확인만 받던 동작을 다른 후보로 갈라질 여지가 있을 때만 묻도록 바꿨습니다.
 >
-> 같은 사이클에 새 프로토콜 `/ascend` (Anagoge)가 합류했습니다. 회상 단위의 granularity가 부족할 때, 흩어진 deposit을 더 높은 차원의 단위로 끌어올리는(RecallGranularityInsufficient → HigherGranularityUnit) 프로토콜입니다. 구성 과정에서 각 deposit의 출처와 재진입 명령을 노출해, 끌어올린 단위가 어디서 왔는지 되짚을 수 있게 했습니다. 돌아보면 이번 사이클도 프로토콜을 써서 프로토콜을 다듬은 기록입니다 — 여러 라운드의 review-loop 수렴이 그 흔적입니다.
+> 같은 사이클에 새 프로토콜 `/ascend` (Anagoge)가 합류했습니다. 출발은 한 줄의 회상이었습니다 — 예전 `/conduct`를 개선하며 나왔던 "Span 관리·링크 그래프" 논의와 "종합 결손"을 다시 떠올리다, *`Anamnesis`의 해소집합이 한 세션이 아니라 연결세션·토픽·추상화된 개념으로 확장되면 어떨까* 라는 한 문장이 본질을 통째로 담아냈습니다(이게 곧 `RecallGranularityInsufficient → HigherGranularityUnit`입니다). 이 착상을 `/induce`(Periagoge)로 깎는 과정에서, 처음의 "엮음(Symploke)" 축이 "알갱이를 끌어올림"으로 재정향되며 이름이 따라붙었습니다 — *ana-mnesis(회상) ↔ ana-goge(상승)*, 회상의 형제. 그렇게 굳은 프로토콜은 구성 deposit마다 출처와 재진입 명령을 노출해, 끌어올린 단위가 어디서 왔는지 되짚게 합니다. 돌아보면 이번 사이클도 프로토콜을 써서 프로토콜을 다듬은 기록입니다 — `/ascend`는 `/recollect`→`/induce`→`/bound`을 거쳐 깎였고, 그 자체가 over-gate를 줄이는 이번 릴리스의 한 사례입니다.
 >
 > ---
 >


### PR DESCRIPTION
## 무엇

`v2026.06.17 → main` 구간(60 commits)의 릴리스 노트 **초안**입니다. 새 파일 하나만 추가합니다: `docs/releases/v2026.06.22.md`.

- **범위**: `v2026.06.17..HEAD` — HEAD = `389d8c2` (Merge PR #568), 60 commits
- **선택 버전**: **`v2026.06.22`** — CalVer(`v{YYYY.MM.DD}`), 오늘 날짜 기준, 동일 날짜 태그 없음 → 접미사 `.N` 불필요. 마지막 태그는 `v2026.06.17`.

## ⚠️ 퍼블리시 경로 (병합 전 확인)

이 레포의 정식 릴리스 컨벤션은 in-repo 파일이 아니라 **GitHub Releases**입니다. `/release` 스킬이 **태그 push → CI(`release.yml`)가 `scripts/package.js`로 draft 생성 → 내러티브 prepend(`gh release edit`)** 흐름을 인코딩합니다.

이번 작업의 하드 제약(“PR을 열고, main에 push 금지, 릴리스 노트 파일만 건드림, 퍼블리시는 owner가 수동”)은 `/release`의 **태그 push(환경 변경 + CI 릴리스 생성)**와 충돌하므로, 태그를 push하지 않았습니다. 대신:

- 본문(`## Highlights` / `## Protocols`)은 `scripts/package.js`가 생성한 결과를 **그대로** 사용했고,
- 그 위에 레포의 GitHub Release 내러티브 포맷(Background + 무엇이 새로운가요?)을 동일하게 얹었습니다.

→ 실제 릴리스 컷은 owner가 `/release`로 진행하면 됩니다. 이 PR은 **검토용 초안 스테이징**입니다. (이 파일을 기록으로 머지할지, `/release` 입력으로만 쓸지는 owner 판단.) **이 PR은 머지하지 않습니다.**

## 핵심 하이라이트

이번 사이클의 지배적 테마는 **게이트 규율 — 되돌릴 수 있고 방향이 이미 정해진 결정은 게이트로 다시 묻지 않는다**입니다.

- 🚦 **게이트 발화 선행조건**(epistemic-ink): 게이트 렌더 전에 reversibility tier를 먼저 평가 → settled/clear 결정은 relay로 자동 처리.
- 🧩 **단일-dominant / 안전기본값 relay 일괄 적용**: `/bound`(Phase 0b) · `/misuse`(Phase 0) · `/ascend`(SingleObvious) · `/recollect`(확인→발산 재설계).
- 🆙 **신규 `/ascend` (Anagoge 0.1.7)**: RecallGranularityInsufficient → HigherGranularityUnit. 구성 deposit마다 출처·재진입 명령 노출.
- 📐 **형식 블록 runtime-normative 명시**: 14개 프로토콜 Rules에 인스크립션.
- 🔌 그 외: forge PromptArtifact 개명 + Dia 어댑터, 시맨틱 감사 엔진 추출, review-loop design-intent harvest, project-profile 압축.

## 대안 테마 축 (owner 선택용)

초안은 “게이트 규율”을 전면에 뒀습니다. 다른 프레이밍도 가능합니다:

- **A. 게이트 규율 중심**(현재 초안) — 커밋 분포에 가장 충실(최대 클러스터). `/ascend`는 동반 신기능.
- **B. 신규 프로토콜 중심** — `/ascend` 추가를 헤드라인으로, 게이트 규율을 후속 정렬로.

테마/내러티브는 owner의 구성적 판단이므로, 검토 시 축·문구·이모지 자유롭게 조정해 주세요.

## 체크

- [x] 범위 검증: `git log --oneline v2026.06.17..HEAD` = 60 commits
- [x] 본문은 `scripts/package.js` 생성물 그대로 (Highlights/Protocols)
- [x] `dist/`는 gitignore — 커밋되지 않음. 변경은 `docs/releases/v2026.06.22.md` 1개뿐
- [ ] (owner) `/release`로 실제 GitHub Release 컷
