### PR TITLE
fix(epistemic-cooperative): epistemic-ink 채널 메타-prose 마크업 어휘 스크럽 (#581)

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 15 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
-  "version": "3.12.10",
+  "version": "3.12.11",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "3.12.10",
+  "version": "3.12.11",
   "description": "Utility skills layered on top of the core 15 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -10,7 +10,7 @@ You are an interactive CLI tool that helps users with software engineering tasks
 
 # Epistemic Protocol Formatting
 
-When executing epistemic protocols (/frame, /gap, /bound, /inquire, /ground, /induce, /elicit, /attend, /contextualize, /recollect, /grasp), produce Ink-formatted output using the element patterns defined below. Emit the structural content shown in each pattern directly; never wrap output in markdown code blocks or XML-like tags. **Render every user-facing emit in the user's everyday language to reduce cognitive load on the reader — formal labels, variable names with subscripts, and Greek-rooted terms belong in SKILL.md formal blocks, not in what the user reads.**
+When executing epistemic protocols (/frame, /gap, /bound, /inquire, /ground, /induce, /elicit, /attend, /contextualize, /recollect, /grasp), produce Ink-formatted output using the element patterns defined below. Emit the structural content shown in each pattern directly as literal terminal text. **Render every user-facing emit in the user's everyday language to reduce cognitive load on the reader — formal labels, variable names with subscripts, and Greek-rooted terms belong in SKILL.md formal blocks, not in what the user reads.**
 
 ## Ink Precedence
 
@@ -79,7 +79,7 @@ Rendered shape:
 1. **Option** — summary (axis value)
    → rationale (one of: temporal, branch, side-effect)
 
-**Channel boundary — text gate vs genuine tool call.** Two channels carry user-facing output: the *text channel* carries the Ink divider gate and prose; the *tool-use channel* carries every genuine tool invocation. Each interaction travels exactly one. An Ink gate is complete as text — the divider block plus turn-yield are the whole gate, and it satisfies `present` on its own. A genuine tool call — AskUserQuestion, or any tool a skill's SKILL.md directs — travels the tool-use channel, so it reaches the user as a rendered tool call; its call syntax (e.g., function-call XML) is that channel's payload, while the message text stays prose. The "no tool call wrapper" note on the Gate element scopes to the gate's own text rendering; the two realizations stay on their own channels.
+**Channel boundary — text gate vs genuine tool call.** Two channels carry user-facing output: the *text channel* carries the Ink divider gate and prose; the *tool-use channel* carries every genuine tool invocation. Each interaction travels exactly one. An Ink gate is complete as text — the divider block plus turn-yield are the whole gate, and it satisfies `present` on its own. A genuine tool call — AskUserQuestion, or any tool a skill's SKILL.md directs — is realized by invoking it on the tool-use channel, while the message text stays prose. The "no tool call wrapper" note on the Gate element scopes to the gate's own text rendering; the two realizations stay on their own channels.
 
 **Convergence** — emit each dimension's status between dividers, using ✓ for defined and ○ for pending. This is each dimension's resolution state — a framing readout, not a tally to sum. It is per-dimension and kind-separated; do not collapse it into a score or an "N/M done" fraction. Each line stands on its own as that dimension's resolution state.
 


### PR DESCRIPTION
## 문제 (#581)

Epistemic Ink 출력 스타일에서 **genuine 도구 호출이 tool-use 채널 대신 평문 텍스트로 렌더**되어 실행되지 않음. 시그니처: `court` 토큰 + 네임스페이스 없는 `<invoke name="...">`가 텍스트 블록 안에 박힘(`tool_use_blocks=0`). PR #579의 직전 수정 이후 **재발(회귀)**.

## 조사 (4-move: forensics ∥ 하네스 RE → 종합 → 어드버서리얼 검증)

**세션 forensics** (9ce5c44e, 10건 누수): 8/10이 Ink 마커 reply와 같은 턴 배치, 2/10 standalone. 같은 턴 배치는 **지배적 트리거이나 필요조건은 아님** → 수정은 emission 경계로 올려야 함.

**하네스 Q1 = `no_not_guaranteed` (Model B, 높은 확신)**: 모델이 도구 호출 콘텐츠(이름+JSON input, `input_json_delta`)를 **텍스트와 동일한 generative content_block 스트림에서 직접 author**. 하네스는 framing/transport/parse만 소유하며 **generation 시점에 채널을 격리하는 구조적 보장은 없음**("분리된 채널"은 SSE/전송 계층에만 존재). 바이너리 2.1.195 verbatim 다수 확인. → 출력 스타일의 literal-text prior가 도구 호출 emission에 간섭 가능(확인됨).

**어드버서리얼 검증**: 3 refuter 전원이 진단(emission 계층, Model B)은 견고하다고 동의하되, 초기 종합안(L13 스코프 + L82 유지)의 **수정 방향은 3/3 반증**. 핵심: 현재 softened L82의 `"its call syntax (e.g., function-call XML) is that channel's payload"` 문장이 **억제하려는 마크업 개념을 오히려 명명**(white-bear 프라이밍 표면). 반사실 분석은 L13/L63/L82 통째 삭제를 **UNSAFE**로 판정(게이트 렌더링 계약 파손 + L63→L82 dangling)하고, 더 좁은 **"마크업 어휘 스크럽"**으로 수렴.

## 수정 (마크업 어휘 스크럽)

substrate 메커니즘(마크업 어휘)은 위임 제거하고, 모델-대면 게이트 계약은 EP 고유 영토로 보존:

- **L13**: `"never wrap output in markdown code blocks or XML-like tags"` 제거 → 긍정형 `"as literal terminal text"` (코드블록 anti-fencing은 L17 Ink Precedence가 이미 명시적으로 커버)
- **L82**: `"its call syntax (e.g., function-call XML) is that channel's payload"` 마크업 예시 제거 → 채널-선택 원칙 `"is realized by invoking it on the tool-use channel"`
- **보존**: 채널분리 계약 / 게이트 렌더링 / L63 disambiguator / `Channel boundary` 교차참조

**정합 원칙**: Zero-Shot Instruction Preference(function-call-XML *예시*는 앵커링 few-shot — 원칙으로 표현), White Bear(긍정 프레이밍), A4 Semantic Autonomy(플랫폼 도구 마크업 거론 제거). northstar: substrate 메커니즘은 하네스에 위임, 한 누수를 닫으며 새 misalignment(dangling ref)는 만들지 않음.

`epistemic-cooperative` 3.12.10 → 3.12.11 (claude/codex 매니페스트 동기화).

## 회귀 가드 (정직한 한계)

Model B이므로 **어떤 출력 스타일 prose도 emission을 면역시키지 못함** — 본 수정은 재발 *확률을 낮출* 뿐 보장하지 않음. durable 보장이 가능한 곳은 둘:
1. **하네스** (이 리포 밖, Claude Code 소관): 기존 `malformed_tool_use_retry` 경로 확장 — text 블록 내 `<invoke name=...>` 감지 → 재라우팅. 단, 본 누수는 JSON_PARSE 경로를 안 탈 수 있음.
2. **라이브/통합 테스트** (정적검사 불가 — 런타임 emission 동작): 프로토콜을 Ink로 인접 도구호출과 함께 돌려 `tool_use_blocks>0` 단언. → **별도 follow-up**.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .  →  fail 0
```
(경고 2건은 기존·무관: recollect `DerivedFrom`, hermeneutic-cycle 한글)

## 검토 경로

`/conduct` forge 계획 → 워크플로우 조사 → `/sublate`(Elenchus)로 "통째 제거가 northstar 정합" 주장 반증 검증 → 지양(Aufhebung)으로 마크업 스크럽 수렴. 머지는 사용자 보류.
