### PR TITLE
fix(epistemic-cooperative): coverage-scanner에 conduct·ascend 분석 등록

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 16 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
-  "version": "3.12.14",
+  "version": "3.12.15",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "3.12.14",
+  "version": "3.12.15",
   "description": "Utility skills layered on top of the core 16 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/agents/coverage-scanner.md
+++ b/epistemic-cooperative/agents/coverage-scanner.md
@@ -35,7 +35,7 @@ You will receive:
    a. Glob `session_jsonl_glob` to get all JSONL paths on disk.
    b. **Single grep** with alternation pattern across all JSONL paths:
       ```
-      command-name|"skill":"(frame|gap|grasp|inquire|attend|contextualize|bound|ground|induce|elicit|recollect|sublate|distill|delimit|prothesis:|syneidesis:|katalepsis:|aitesis:|prosoche:|epharmoge:|horismos:|analogia:|periagoge:|euporia:|anamnesis:|elenchus:|diylisis:|diairesis:)
+      command-name|"skill":"(frame|gap|grasp|inquire|attend|contextualize|bound|ground|induce|elicit|recollect|sublate|distill|delimit|conduct|ascend|prothesis:|syneidesis:|katalepsis:|aitesis:|prosoche:|epharmoge:|horismos:|analogia:|periagoge:|euporia:|anamnesis:|elenchus:|diylisis:|diairesis:|hyphegesis:|anagoge:)
       ```
       This captures both slash commands (`<command-name>` tags) and Skill tool invocations (`"skill":"<name>"`) in one pass, pre-filtering to protocol skills only.
    c. **Map** matches to protocol names:
@@ -53,6 +53,8 @@ You will receive:
       - `sublate`, `elenchus:sublate` → Elenchus
       - `distill`, `diylisis:distill` → Diylisis
       - `delimit`, `diairesis:delimit` → Diairesis
+      - `conduct`, `hyphegesis:conduct` → Hyphegesis
+      - `ascend`, `anagoge:ascend` → Anagoge
    d. **De-duplicate**: Group matches by source file path (= session_id), then de-duplicate protocol names within each group. Same session + same protocol = 1 usage event.
 
 3. **Gate interaction scan**: From session JSONL paths (same as step 2a), grep for gate interaction patterns:


### PR DESCRIPTION
## 무엇을

`coverage-scanner` 분석 에이전트의 프로토콜 사용량 스캔(grep alternation + 매핑 표)에 누락돼 있던 두 프로토콜을 등록합니다:

- `anagoge` / `/ascend`
- `hyphegesis` / `/conduct`

## 왜

`graph.json`은 16개 프로토콜 노드를 정의하지만 `coverage-scanner.md`는 14개만 스캔하고 있었습니다. `anagoge`·`hyphegesis`는 처음부터 누락된 기존 결함으로, 이 두 프로토콜의 사용량이 커버리지 대시보드에서 집계되지 않았습니다.

PR #588(Diairesis) 스윕 중 발견했으나 범위 밖이라 파킹했던 후속 작업입니다.

## 어떻게

기존 14개 프로토콜과 동일한 패턴으로 보강:
- grep alternation에 `conduct|ascend` (베어 슬래시) + `hyphegesis:|anagoge:` (플러그인 프리픽스) 추가
- 매핑 표에 `conduct, hyphegesis:conduct → Hyphegesis` / `ascend, anagoge:ascend → Anagoge` 행 추가

`epistemic-cooperative` 버전 3.12.14 → 3.12.15. `static-checks.js` 통과(fail 0 / warn 0).

## 후속 (이 PR 범위 밖)

재발 방지책으로 `static-checks.js`에 "coverage-scanner enumeration이 graph.json 전체 노드를 커버하는지" 검사를 추가하는 안이 있습니다 — 별도 판단 필요.
