### PR TITLE
docs(induce): first-class-citizen everyday-language lens

### DIFF
--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -132,6 +132,8 @@ converge           (extension)   → TextPresent+Proceed (convergence evidence t
 
 **Calibrative Induction through Dialectical Triangulation over Unilateral Correction**: When an instance set has converged toward an unnamed essence but the abstraction has not located itself, neither AI nor user alone can crystallize the form. AI first shows how the instance set calibrates the user's in-process concept — what it preserves, sharpens, prunes, and leaves open — then proposes a candidate paired with a personalized grounding example drawn from the user's own domain. The user shapes the candidate through Socratic moves — widening (Synagoge), narrowing (Diairesis), fusing with an adjacent abstraction, or reorienting onto an orthogonal axis. The abstraction turns toward its crystallized form through the exchange, not by unilateral AI correction.
 
+**First-class citizen (everyday-language lens)**: In software-engineering terms, locating the abstraction is promoting a recurring concept to a *first-class citizen* — lifting it from scattered ad-hoc handling (a condition added at the nearest call site) to a named unit the system manages, references, and composes. Periagoge names the *act* — turning an instance set toward its crystallized form; "first-class" names the *resulting status* the promotion confers, where the unit is carried forward, routed, and composed rather than re-derived in place. The two are the same arrow's ends: use "first-class" as the plain-language handle for the promoted unit's standing, and Periagoge for the promotion itself.
+
 ## Mode Activation
 
 ### Activation


### PR DESCRIPTION
## What

Adds one prose paragraph under periagoge's **Core Principle** — a
"first-class citizen (everyday-language lens)" note. No formal-block
change; prose only.

## Why

A `/ground` session validated that the software-engineering notion of a
**first-class citizen** maps onto periagoge, and that the two sit at
opposite ends of the *same arrow*:

- **periagoge** = the *act* — locating/promoting an abstraction from its
  instance set toward its crystallized form.
- **first-class** = the *resulting status* the promotion confers — the
  unit is now carried forward, routed, and composed rather than
  re-derived at the nearest call site.

Grounding evidence: the "first-class" status predicate already recurs
across the protocol texts but had never been *located* as its own named
concept, e.g.

- reduced-space-test: *"Residual — a first-class output, carried forward,
  never dropped"*, *"routed to a follow-up protocol"*
- conduct: *"OutputShape = the first-class unit the synthesis output is
  organized around"*
- comment-review: *"Multi-artifact variants are first-class"*

This note gives that recurring predicate a plain-language handle under
the protocol that names the promotion act — surfacing an implicit concept
without adding a new protocol or formal machinery.

## Scope

- Minimal: one paragraph, `periagoge/skills/induce/SKILL.md`.
- Merge is user-held.
