### PR TITLE
docs(analysis): 미커밋 분석 문서 2건 회수 — Codex-Claude 오케스트레이션 조사·리뷰 도구 비교

### DIFF
--- a/docs/analysis/codex-claude-orchestration-2026-05.md
+++ b/docs/analysis/codex-claude-orchestration-2026-05.md
@@ -1,0 +1,300 @@
+# Codex-Claude Orchestration 조사 메모 (2026-05)
+
+## 요약
+
+2026년 5월 기준으로 Claude Code/Claude Opus 4.7과 Codex/GPT-5.5는 모두 1M급 긴 컨텍스트, compaction, skills/plugins/MCP, subagents, 원격/자동화 표면을 갖춘 코딩 에이전트 플랫폼으로 수렴하고 있다. 다만 강점의 방향은 다르다.
+
+- Claude 쪽의 강점: Opus 4.7의 1M context와 server-side compaction, Claude Code의 성숙한 Remote Control/teleport/Slack/CI 표면, 넓은 Claude Code plugin/skill/MCP 생태계, subagent별 skill/MCP 스코핑.
+- Codex 쪽의 강점: GPT-5.5의 1M context와 128K 출력, Codex app의 병렬 에이전트/worktree/리뷰 중심 UI, CLI/SDK/non-interactive mode, remote connections, AGENTS.md 기반 다중 툴 portability, OS sandbox/approval 중심 실행 제어.
+- 커뮤니티 근거의 결론: "하나로 대체"보다 "역할 분리"가 더 강하게 관찰된다. 특히 Claude를 deep-context/planning/context hub로 두고 Codex를 실행/리뷰 worker로 쓰거나, Codex를 command center로 두되 Claude Code를 MCP/CLI/SDK로 호출하는 패턴이 모두 가능하다.
+
+실무 권고는 **Codex-first orchestrator + Claude deep-context specialist**를 기본으로 두되, Claude의 plugin/skill/MCP 생태계를 잃지 않기 위해 Claude를 단순 모델 API가 아니라 **Claude Code runtime**으로 보존하는 것이다. 연결 방식은 세 가지가 현실적이다: Claude Code MCP server, `claude -p`/SDK subprocess, shared handoff artifacts.
+
+## 공식 문서 근거
+
+### Anthropic / Claude
+
+1. Claude Opus 4.7 1M context와 compaction
+   - Anthropic context window 문서는 Claude Mythos Preview, Claude Opus 4.7, Opus 4.6, Sonnet 4.6이 1M-token context window를 가진다고 설명한다. 또한 장기 대화/agentic workflow에는 server-side compaction이 기본 전략이며 Opus 4.7/4.6/Sonnet 4.6에서 beta로 제공된다고 한다.
+   - URL: https://docs.anthropic.com/en/docs/build-with-claude/context-windows
+   - 신뢰도: 높음. 공식 API 문서.
+   - 한계: Claude Code 구독 UI의 실제 모델/계정별 context 제공 여부는 계정/플랜/릴리스 상태에 따라 달라질 수 있다. API capability와 제품 표면을 동일시하면 안 된다.
+
+2. Claude Code의 MCP/plugin/remote control 표면
+   - Claude Code overview는 터미널, IDE, desktop, browser, Slack/CI/CD, Remote Control, `claude --teleport`, `/desktop` handoff를 공식 표면으로 설명한다.
+   - URL: https://docs.anthropic.com/en/docs/claude-code/overview
+   - MCP 문서는 Claude Code가 MCP로 Google Drive/Jira/Slack/custom tooling에 연결될 수 있고, plugin이 MCP server를 번들링할 수 있으며, `claude mcp serve` 형태로 Claude Code 자체를 MCP server로 노출할 수 있음을 보여준다.
+   - URL: https://docs.anthropic.com/en/docs/claude-code/mcp
+   - 신뢰도: 높음.
+   - 한계: "수백 개 외부 도구"라는 표현은 생태계 폭을 말하지만 특정 plugin의 안정성/보안/유지보수를 보장하지 않는다.
+
+3. Claude Code subagents와 SDK
+   - subagents 문서는 subagent별 `skills`, `mcpServers`, `permissionMode`, `maxTurns` 설정을 제공한다. skill은 startup context에 full content가 injected되고, MCP server도 agent scope로 제한할 수 있다.
+   - URL: https://docs.anthropic.com/en/docs/claude-code/sub-agents
+   - Agent SDK는 session resume, MCP status/reconnect/toggle, plugins, skills, hooks, checkpointing, cost tracking 등을 제공한다.
+   - URL: https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-python
+   - 신뢰도: 높음.
+   - 한계: subagent/plugin 조합은 강력하지만 context pollution과 비용 증가가 생길 수 있다. 필요한 skill/MCP만 preload해야 한다.
+
+### OpenAI / Codex
+
+1. GPT-5.5와 context
+   - OpenAI model docs는 `gpt-5.5`의 context window를 1M, max output을 128K로 표시하고, tools로 functions/web search/file search/computer use를 listed한다.
+   - URL: https://developers.openai.com/api/docs/models
+   - GPT-5.5 guide는 장기 agent에는 compaction을 의도적으로 사용하고, 완료 작업/가정/ID/tool 결과/blocker/다음 목표를 보존하라고 권고한다.
+   - URL: https://developers.openai.com/api/docs/guides/latest-model
+   - 신뢰도: 높음.
+   - 한계: ChatGPT/Codex 제품 플랜별 GPT-5.5 context는 API docs와 다를 수 있다. Help Center 일부는 ChatGPT Thinking context를 별도 수치로 제시한다.
+
+2. Codex app/CLI/SDK/remote/non-interactive
+   - Codex app 문서는 command center, 병렬 coding agents, reusable skills/automations, plugins, app/CLI/IDE/Web 표면을 설명한다.
+   - URL: https://developers.openai.com/codex/app
+   - Codex changelog는 2026-04-23 GPT-5.5 availability, 2026-05 remote/mobile host connection, plugin management, hooks before/after compaction, MCP elicitation/auth flow 등을 언급한다.
+   - URL: https://developers.openai.com/codex/changelog
+   - Codex SDK 문서는 local Codex agents를 programmatically control하는 TypeScript SDK를 제공한다고 설명한다.
+   - URL: https://developers.openai.com/codex/sdk
+   - Non-interactive mode는 `codex exec`, JSONL output, read-only 기본 sandbox, `--full-auto`, `--sandbox danger-full-access`, required MCP failure behavior를 설명한다.
+   - URL: https://developers.openai.com/codex/noninteractive
+   - Remote connections 문서는 Codex를 SSH/remote machine의 project와 연결하는 표면이다.
+   - URL: https://developers.openai.com/codex/remote-connections
+   - 신뢰도: 높음.
+   - 한계: OpenAI 문서는 Codex가 Claude의 plugin marketplace를 직접 consume한다고 말하지 않는다. 보존하려면 bridge/handoff/runtime delegation이 필요하다.
+
+3. Codex subagents
+   - Codex subagents 문서는 Codex가 agent orchestration, spawn/routing/waiting/consolidation을 담당하고, 명시적으로 요청할 때만 subagent를 spawn한다고 설명한다. subagents는 parent sandbox/approval runtime overrides를 상속한다.
+   - URL: https://developers.openai.com/codex/subagents
+   - 신뢰도: 높음.
+   - 한계: Claude Code subagent처럼 plugin-sourced MCP/skill 생태계와 동일한 폭을 갖는다는 뜻은 아니다.
+
+## 커뮤니티 / GitHub / 블로그 근거
+
+### GitHub 사례
+
+1. Maestro: structured memory, handoffs, plan-approve-execute across Codex/Claude/Hermes
+   - `maestro handoff`가 repo state와 task continuation으로 self-contained markdown brief를 만들고 Codex/Claude/Hermes run을 launch한다. task는 `.maestro/tasks/tasks.jsonl`, mission은 `.maestro/missions/`에 저장된다.
+   - URL: https://github.com/ReinaMacCredy/maestro
+   - 관련 프레임: shared artifact/spec handoff, Claude/Codex worker routing.
+   - 신뢰도: 중간. 공개 repo의 실제 구현/문서 근거.
+   - 한계: 프로젝트 maturity, 사용자 규모, 장기 운영 안정성은 별도 검증 필요.
+
+2. Mercury: multi-agent GUI orchestrator with dual verify
+   - README는 `dual-verify`를 "Parallel Claude Code deep-review + Codex code-audit"로 설명하고, `handoff`를 session-to-session handoff document + ready-to-paste prompt로 둔다.
+   - URL: https://github.com/392fyc/Mercury
+   - 관련 프레임: independent dual-review loop, shared handoff.
+   - 신뢰도: 중간.
+   - 한계: 특정 개인/팀 workflow일 수 있고, 일반화 가능성은 제한된다.
+
+3. Luigi: Codex + Claude Code automated coding orchestrator
+   - Telegram/UI controlled orchestrator로 Claude/Codex reviewer/executor를 구성하고, worktree lifecycle, carry-forward workspace, approval/rejection loop를 제공한다.
+   - URL: https://github.com/RiccardoRomagnoli/luigi
+   - 관련 프레임: independent review, multi-agent execution, remote control.
+   - 신뢰도: 중간-낮음. 코드와 README는 있으나 commit 수/운영 사례가 제한적이다.
+
+4. claude-code-settings codex-skill
+   - Claude Code skill에서 Codex CLI를 non-interactive automation worker로 호출하는 `codex-skill`을 설명한다. "features/plans designed by Claude"를 Codex가 구현하는 구조다.
+   - URL: https://github.com/feiskyer/claude-code-settings
+   - 관련 프레임: Claude-first planning/context hub + Codex execution worker.
+   - 신뢰도: 중간.
+   - 한계: 개인 설정 repo 성격이 강하고, 모델명/설정은 시간이 지나며 쉽게 stale해진다.
+
+5. Claude handoff tips
+   - `HANDOFF.md`를 만들어 다음 fresh agent가 목표/진행/시도/실패/다음 단계를 읽고 이어가게 하는 방식이 설명된다.
+   - URL: https://github.com/ykdojo/claude-code-tips
+   - 관련 프레임: shared artifact/task.md/spec handoff.
+   - 신뢰도: 중간.
+   - 한계: Claude 중심 팁이지만 Codex/Claude 간 handoff에도 그대로 적용 가능한 패턴이다.
+
+### Reddit / HN 사례
+
+1. Reddit: Claude와 Codex를 "migration"보다 "load balancing"으로 병행
+   - r/codex의 migration thread는 일부 사용자가 Claude와 Codex를 역할별/한도별로 나눠 쓰며, Codex는 backend/general coding, Claude는 frontend/design-heavy/abstract task에 유리하다는 경험담을 포함한다.
+   - URL: https://www.reddit.com/r/codex/comments/1tao42q/did_anyone_here_moved_from_claude_to_codex/
+   - 신뢰도: 낮음-중간. 실사용 경험이지만 익명/선택 편향이 크다.
+   - 한계: Reddit 요약/댓글은 제품 버전, 플랜, 프롬프트 품질, 코드베이스 특성에 크게 좌우된다.
+
+2. Reddit: context checkpoint / project guidance file
+   - r/codex 비교 thread는 긴 thread가 느려질 때 "context checkpoint"를 만들거나 project guidance file을 둬 Codex가 프로젝트 navigation/standards를 알게 한다는 사례를 보여준다.
+   - URL: https://www.reddit.com/r/codex/comments/1s1btfx/codex_vs_claude_code_vs_antigravity_whats_your/
+   - 신뢰도: 낮음-중간.
+   - 한계: 기술적으로는 handoff artifact와 유사하지만 자동화된 orchestration 증거는 아니다.
+
+3. HN: compaction/context 경험은 엇갈림
+   - HN의 Opus 1M context thread에는 "Codex compaction이 더 낫다"는 경험담과 "Opus가 실제 bug context에 더 유용하다"는 반대 경험담이 공존한다.
+   - URL: https://news.ycombinator.com/item?id=47367129
+   - 신뢰도: 낮음-중간.
+   - 한계: 익명 경험담이고, Claude Code vs API, Codex CLI vs ChatGPT, 모델/플랜 차이가 섞여 있다.
+
+4. HN: multi Codex/Claude orchestrator 사용 언급
+   - HN 댓글에는 "some orchestrator of multiple Codex/Claude Codes"로 이동했다는 실사용 언급이 있다.
+   - URL: https://news.ycombinator.com/item?id=47619752
+   - 신뢰도: 낮음.
+   - 한계: 구체적 구현/성과 근거가 없어서 방향성 신호 정도로만 사용해야 한다.
+
+### 블로그 / 생태계 해설
+
+1. Driver/Worker guide
+   - Fountain City 글은 Codex와 Claude Code를 driver/worker topology로 연결하고, BEADS+Metaswarm, Archon, Citadel 같은 harness layer를 언급한다. shared context는 `CLAUDE.md`와 Codex skills/rules 쪽으로 별도 유지/번역해야 한다고 설명한다.
+   - URL: https://fountaincity.tech/resources/blog/codex-claude-code-harness-together/
+   - 신뢰도: 중간.
+   - 한계: vendor/consulting blog 성격이며, claims 일부는 별도 프로젝트 검증이 필요하다.
+
+2. 개인 비교: Claude runs agents, Codex improves agents
+   - Jock.pl 글은 Claude Code를 long-running agent orchestration과 persistent integration에, Codex를 refactor/deep review/existing code improvement에 쓰는 workflow를 제안한다.
+   - URL: https://thoughts.jock.pl/p/claude-code-vs-codex-real-comparison-2026
+   - 신뢰도: 중간-낮음.
+   - 한계: 개인 경험이며 GPT-5.3-Codex 기준이라 2026-05 GPT-5.5/Codex app 상태와 일부 차이가 있을 수 있다.
+
+3. Claude plugin ecosystem breadth
+   - Anthropic official/community plugin marketplace 관련 글과 GitHub는 Claude Code plugin이 skills, slash commands, agents, MCP servers, hooks를 묶는 생태계임을 보여준다.
+   - URLs:
+     - https://github.com/anthropics/claude-code
+     - https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json
+     - https://github.com/anthropics/knowledge-work-plugins
+   - 신뢰도: 공식 GitHub는 높음, 서드파티 해설은 중간.
+   - 한계: installable count와 quality는 다르다. marketplace index 수는 신뢰도 지표가 아니다.
+
+4. Codex plugin ecosystem growth
+   - OpenAI Academy는 Codex plugins/skills를 설명하고, Codex docs/changelog는 curated plugin directory와 plugin management를 공식화한다. New Stack은 launch 당시 20+ plugins와 Figma/Linear/Slack/Gmail/Hugging Face 등 third-party service plugin을 언급한다.
+   - URLs:
+     - https://openai.com/academy/codex-plugins-and-skills/
+     - https://developers.openai.com/codex/changelog
+     - https://thenewstack.io/openais-codex-gets-plugins/
+   - 신뢰도: OpenAI 공식은 높음, New Stack은 중간.
+   - 한계: Claude 생태계만큼의 breadth/legacy install base가 있는지는 아직 불확실하다.
+
+## 네 가지 프레임 검증
+
+### (1) Codex-first orchestrator + Claude as deep-context specialist
+
+판정: **가능하고 유망하지만, Claude를 API model이 아니라 Claude Code runtime으로 연결해야 생태계를 보존한다.**
+
+근거:
+- Codex app/SDK/subagents/non-interactive mode는 orchestration command center로 쓰기 좋다.
+- Claude Code는 `claude mcp serve`, SDK, `claude -p`, Remote Control, plugin-provided MCP/skills/subagents를 가진다.
+- Maestro/Luigi/Mercury는 Codex/Claude handoff 또는 dual-worker orchestration을 공개적으로 구현한다.
+
+실행 패턴:
+- Codex main thread가 task/spec/acceptance criteria를 유지한다.
+- Claude specialist는 Claude Code MCP server 또는 `claude -p`/SDK subprocess로 호출한다.
+- Claude에게는 "large-codebase context synthesis, plugin-rich research, design-heavy planning, deep semantic review"를 맡긴다.
+- 결과는 `task.md`, `handoff.md`, PR comment, JSONL summary로 Codex에 반환한다.
+
+보존되는 Claude 자산:
+- Claude Code plugins/skills/MCP server configs.
+- Claude subagent별 skill/MCP scoping.
+- Claude Remote Control/Slack/CI integrations.
+
+리스크:
+- Codex가 Claude 내부 context를 직접 볼 수는 없다. 반드시 structured output/handoff로 압축해야 한다.
+- Claude plugin 실행은 별도 trust boundary다. Codex sandbox와 Claude permission model을 혼동하면 안 된다.
+- 비용/토큰 사용량이 쉽게 두 배가 된다.
+
+신뢰도: 중간. 공식 기능은 높지만 "Codex-first + Claude specialist" 자체는 community/GitHub architecture inference다.
+
+### (2) Claude-first planning/context hub + Codex execution/review worker
+
+판정: **현재 커뮤니티 근거가 가장 직접적이다.**
+
+근거:
+- `claude-code-settings`의 `codex-skill`은 Claude가 설계한 feature/plan을 Codex non-interactive automation으로 실행하는 구조를 명시한다.
+- 개인 블로그/Reddit은 Claude를 planning/agent orchestration hub로, Codex를 refactor/review/execution worker로 쓰는 경험담을 제시한다.
+- Claude Code의 plugin/MCP/subagent/Remote Control 생태계를 hub로 보존하기 쉽다.
+
+실행 패턴:
+- Claude가 plugin-rich planning/context gathering을 수행한다.
+- Codex는 read-only review, sandboxed implementation, isolated worktree candidate generation, code audit를 담당한다.
+- Claude가 Codex 결과를 다시 읽고 plan/acceptance criteria와 reconcile한다.
+
+리스크:
+- Codex app의 강점인 app-level command center와 multi-agent UI를 충분히 활용하지 못할 수 있다.
+- Claude context hub가 커질수록 compaction risk와 plugin context pollution이 생긴다.
+
+신뢰도: 중간-높음. 공식 기능 + 직접 GitHub skill 사례가 있다.
+
+### (3) shared artifact/task.md/spec handoff
+
+판정: **가장 견고하고 도구 독립적인 공통분모다.**
+
+근거:
+- Maestro는 self-contained markdown handoff와 repo-tracked task JSONL/mission artifacts를 사용한다.
+- Claude Code tips는 `HANDOFF.md`에 목표/진행/시도/실패/다음 단계를 저장하고 fresh agent가 이어받게 하는 방식을 권한다.
+- Reddit 사례도 "context checkpoint"나 project guidance file로 긴 context를 외부화한다.
+
+실행 패턴:
+- 최소 artifact set:
+  - `task.md`: objective, constraints, non-goals, acceptance criteria.
+  - `evidence.md`: URLs, commands run, test outputs, unresolved claims.
+  - `handoff.md`: current state, completed actions, blockers, next prompt.
+  - optional `review.md`: Claude/Codex independent verdicts and reconciliation.
+
+리스크:
+- artifact 품질이 낮으면 두 모델 모두 잘못된 상태를 재사용한다.
+- handoff가 stale해지는 순간 "공유 컨텍스트"가 아니라 "공유 오해"가 된다.
+
+신뢰도: 높음. 공식 compaction guidance와 community/GitHub patterns가 같은 방향이다.
+
+### (4) independent dual-review loop
+
+판정: **작동 사례가 있고, 고위험 변경의 검증 루프로 적합하다.**
+
+근거:
+- Mercury의 `dual-verify`는 "Parallel Claude Code deep-review + Codex code-audit"를 명시한다.
+- Luigi는 multiple reviewer/executor와 winner/approval/rejection loop를 제공한다.
+- 개인 비교 글은 Codex를 Claude-driven work의 deep review/refactor에 쓰는 패턴을 제시한다.
+
+실행 패턴:
+- 동일 diff/spec를 Claude와 Codex에 독립 입력한다.
+- 서로의 결과를 먼저 보여주지 않는다.
+- aggregation step에서 overlap findings, contradictory findings, model-specific blind spots를 분류한다.
+- 최종 판정은 tests/static checks/actual runtime evidence로 닫는다.
+
+리스크:
+- 두 모델이 같은 잘못된 assumption을 공유하면 false confidence가 생긴다.
+- 리뷰 비용과 wall-clock time이 늘어난다.
+- "두 모델 모두 OK"는 formal proof가 아니다. 테스트/타입/런타임 검증이 필요하다.
+
+신뢰도: 중간. 공개 repo 사례는 있지만 일반 성능 평가는 별도 필요하다.
+
+## 권장 아키텍처
+
+기본형:
+
+```text
+Codex app / CLI main thread
+  -> owns queue, task.md, worktrees, tests, final diff
+  -> invokes Claude Code runtime for deep-context / plugin-rich specialist tasks
+  -> invokes Codex subagents for parallel implementation/review inside Codex sandbox
+  -> reconciles all outputs into evidence.md and final PR
+```
+
+Claude 보존 레이어:
+
+```text
+Claude Code runtime
+  -> CLAUDE.md / .claude/skills / .claude/plugins / MCP servers / subagents
+  -> exposed to Codex via one of:
+     1. claude mcp serve
+     2. claude -p subprocess
+     3. Claude Agent SDK wrapper
+     4. handoff.md manual/automated artifact
+```
+
+운영 규칙:
+
+1. Claude ecosystem을 Codex plugin으로 무리하게 포팅하지 말고, 먼저 Claude Code runtime을 그대로 호출한다.
+2. 공통 컨텍스트는 `task.md`/`handoff.md`/`evidence.md`로 외부화한다.
+3. Codex와 Claude의 permission/sandbox boundary를 분리 기록한다.
+4. MCP/plugin은 "항상 켜기"가 아니라 task-local로 scope한다.
+5. dual-review는 고위험 변경, architectural migration, security-sensitive diff에만 기본값으로 둔다.
+
+## 결론
+
+"Codex를 오케스트레이터로 삼으면서 Claude의 1M context와 plugin 생태계를 보존"하는 가장 안전한 방법은 **Claude 기능을 Codex 내부로 복제하는 것**이 아니라 **Claude Code runtime을 specialist worker로 유지하는 것**이다. Codex는 worktree/queue/sandbox/review/SDK orchestration을 담당하고, Claude는 deep context synthesis, plugin-rich research, MCP-heavy enterprise context, design/planning/review를 담당한다. 두 시스템 사이의 durable contract는 shared artifact와 independent review evidence여야 한다.
+
+가장 낮은 리스크의 시작점은 다음 순서다:
+
+1. `task.md` + `handoff.md` 템플릿부터 만든다.
+2. Claude-first 또는 Codex-first 중 현재 팀의 주 UI를 하나 정한다.
+3. 다른 쪽은 `read-only review`와 `deep-context specialist`로만 붙인다.
+4. 성공하면 Claude Code MCP/SDK 또는 Codex SDK로 자동화한다.
+

--- a/docs/analysis/review-tools-comparison.html
+++ b/docs/analysis/review-tools-comparison.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>/code-review · review-pr · /frame 동작 비교 분석</title>
+<style>
+  :root{
+    --bg:#0e1116; --panel:#161b22; --panel2:#1c232d; --border:#2b3441;
+    --ink:#e6edf3; --dim:#9aa7b4; --faint:#6b7686;
+    --cr:#4493f8;   /* code-review  blue */
+    --pr:#3fb950;   /* review-pr    green */
+    --fr:#bc8cff;   /* frame        purple */
+    --warn:#f0883e; --bad:#f85149; --good:#3fb950;
+    --chip:#21262d;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Apple SD Gothic Neo","Noto Sans KR",sans-serif;
+    line-height:1.6;font-size:15px}
+  .wrap{max-width:1180px;margin:0 auto;padding:48px 24px 96px}
+  header h1{font-size:30px;margin:0 0 6px;letter-spacing:-.02em}
+  header p.sub{color:var(--dim);margin:0 0 8px;font-size:15px}
+  .meta{color:var(--faint);font-size:13px;border-top:1px solid var(--border);
+    border-bottom:1px solid var(--border);padding:10px 0;margin:18px 0 36px}
+  .meta code{color:var(--dim)}
+  h2{font-size:21px;margin:54px 0 18px;padding-bottom:8px;border-bottom:1px solid var(--border);letter-spacing:-.01em}
+  h2 .num{color:var(--faint);font-weight:600;margin-right:10px}
+  h3{font-size:16px;margin:28px 0 12px;color:var(--ink)}
+  p{color:#cdd6e0}
+
+  /* legend */
+  .legend{display:flex;gap:18px;flex-wrap:wrap;margin:0 0 8px}
+  .legend span{display:inline-flex;align-items:center;gap:7px;font-size:13px;color:var(--dim)}
+  .dot{width:11px;height:11px;border-radius:3px;display:inline-block}
+
+  /* lane cards */
+  .lanes{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:10px}
+  @media(max-width:900px){.lanes{grid-template-columns:1fr}}
+  .lane{background:var(--panel);border:1px solid var(--border);border-radius:12px;overflow:hidden;display:flex;flex-direction:column}
+  .lane .hd{padding:14px 16px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px}
+  .lane .hd b{font-size:15px}
+  .lane .hd .tag{font-size:11px;color:var(--faint);margin-left:auto;text-transform:uppercase;letter-spacing:.05em}
+  .lane.cr{border-top:3px solid var(--cr)}
+  .lane.pr{border-top:3px solid var(--pr)}
+  .lane.fr{border-top:3px solid var(--fr)}
+  .lane .bd{padding:14px 16px;flex:1}
+  .lane .role{font-size:12.5px;color:var(--dim);min-height:34px;margin-bottom:12px}
+
+  /* flow steps */
+  .flow{list-style:none;margin:0;padding:0;counter-reset:s}
+  .flow li{position:relative;padding:9px 12px 9px 12px;margin:0 0 7px;background:var(--panel2);
+    border:1px solid var(--border);border-radius:8px;font-size:13px}
+  .flow li .k{font-size:11px;color:var(--faint);text-transform:uppercase;letter-spacing:.04em;display:block;margin-bottom:2px}
+  .flow li .v{color:var(--ink)}
+  .flow li .v code{background:var(--chip);padding:1px 5px;border-radius:4px;font-size:12px;color:#a9c6ff}
+  .arrow{text-align:center;color:var(--faint);font-size:13px;line-height:1;margin:-3px 0 4px}
+  .gate{border-color:var(--fr) !important;background:rgba(188,140,255,.08) !important}
+  .gate .k{color:var(--fr)}
+  .fan{border-style:dashed}
+  .verify{border-color:var(--cr) !important;background:rgba(68,147,248,.08) !important}
+  .verify .k{color:var(--cr)}
+  .auto{border-color:var(--pr) !important;background:rgba(63,185,80,.07) !important}
+
+  /* bucket pills */
+  .buckets{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px}
+  .pill{font-size:11px;padding:2px 8px;border-radius:20px;border:1px solid var(--border);color:var(--dim)}
+  .pill.ok{border-color:var(--good);color:#7ee2a8}
+  .pill.q{border-color:var(--warn);color:#f5b27a}
+  .pill.no{border-color:var(--bad);color:#f5907f}
+
+  /* table */
+  table{width:100%;border-collapse:collapse;margin:14px 0;font-size:13.5px;background:var(--panel);border:1px solid var(--border);border-radius:10px;overflow:hidden}
+  th,td{text-align:left;padding:11px 13px;border-bottom:1px solid var(--border);vertical-align:top}
+  thead th{background:var(--panel2);font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:var(--dim);font-weight:600}
+  th.axis{width:170px;color:var(--ink)}
+  tbody tr:last-child td{border-bottom:none}
+  td.cr{color:#bcd6ff}td.pr{color:#bbe8c4}td.fr{color:#dcc8ff}
+  td code{background:var(--chip);padding:1px 5px;border-radius:4px;font-size:12px;color:#cdd6e0}
+  .col-cr{border-left:2px solid rgba(68,147,248,.35)}
+  .col-pr{border-left:2px solid rgba(63,185,80,.35)}
+  .col-fr{border-left:2px solid rgba(188,140,255,.35)}
+
+  /* pros cons */
+  .pc{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
+  @media(max-width:900px){.pc{grid-template-columns:1fr}}
+  .pc .card{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:0 0 6px;overflow:hidden}
+  .pc .card .ch{padding:12px 16px;font-weight:700;border-bottom:1px solid var(--border);font-size:14.5px}
+  .pc.cr .ch{border-top:3px solid var(--cr)} .pc .crh{border-top:3px solid var(--cr)}
+  .pcrow{padding:13px 16px}
+  .pcrow .lbl{font-size:11px;letter-spacing:.05em;text-transform:uppercase;margin-bottom:7px}
+  .lbl.up{color:var(--good)} .lbl.dn{color:var(--bad)}
+  .pcrow ul{margin:0;padding-left:17px}
+  .pcrow li{margin:4px 0;font-size:13px;color:#cdd6e0}
+  .crh{border-top:3px solid var(--cr)} .prh{border-top:3px solid var(--pr)} .frh{border-top:3px solid var(--fr)}
+
+  /* verdict / when-to-use */
+  .when{display:grid;grid-template-columns:1fr 1fr 1fr;gap:14px;margin-top:8px}
+  @media(max-width:900px){.when{grid-template-columns:1fr}}
+  .when .w{background:var(--panel);border:1px solid var(--border);border-left-width:4px;border-radius:10px;padding:14px 16px}
+  .when .w.cr{border-left-color:var(--cr)} .when .w.pr{border-left-color:var(--pr)} .when .w.fr{border-left-color:var(--fr)}
+  .when .w b{display:block;margin-bottom:6px;font-size:14px}
+  .when .w span{font-size:13px;color:var(--dim)}
+
+  .callout{background:rgba(188,140,255,.07);border:1px solid var(--fr);border-radius:10px;padding:14px 18px;margin:20px 0;font-size:14px}
+  .callout b{color:#dcc8ff}
+  .note{color:var(--faint);font-size:12.5px;margin-top:8px}
+  .kbd{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:var(--chip);padding:1px 6px;border-radius:5px;font-size:12.5px;color:#a9c6ff}
+  footer{margin-top:64px;border-top:1px solid var(--border);padding-top:18px;color:var(--faint);font-size:12.5px}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <h1>코드 리뷰 &amp; 인식론 프로토콜 동작 비교</h1>
+  <p class="sub"><b style="color:var(--cr)">/code-review</b> (빌트인) · <b style="color:var(--pr)">pr-review-toolkit:review-pr</b> (플러그인) · <b style="color:var(--fr)">/prothesis:frame</b> (인식론 프로토콜)</p>
+  <div class="meta">
+    근거: Claude Code v2.1.148 바이너리 임베디드 스킬 소스 · marketplace 플러그인 markdown · 로컬 <code>prothesis/skills/frame/SKILL.md</code> &nbsp;|&nbsp; 확신도: Confirmed (verbatim 문자열 / 직접 읽기)
+  </div>
+</header>
+
+<div class="legend">
+  <span><i class="dot" style="background:var(--cr)"></i>code-review</span>
+  <span><i class="dot" style="background:var(--pr)"></i>review-pr</span>
+  <span><i class="dot" style="background:var(--fr)"></i>frame</span>
+  <span><i class="dot" style="background:rgba(188,140,255,.5);border:1px solid var(--fr)"></i>사용자 게이트 (turn yield)</span>
+  <span><i class="dot" style="background:rgba(68,147,248,.5);border:1px solid var(--cr)"></i>적대적 검증</span>
+</div>
+
+<!-- ============ FLOW ============ -->
+<h2><span class="num">01</span>동작 흐름 (Pipeline)</h2>
+<div class="lanes">
+
+  <!-- code-review -->
+  <div class="lane cr">
+    <div class="hd"><i class="dot" style="background:var(--cr)"></i><b>/code-review</b><span class="tag">binary · review-branch</span></div>
+    <div class="bd">
+      <div class="role">git diff의 정합성 버그를 보고. 발견마다 독립 검증자가 반증에 실패해야 살아남는 <b>기각 편향</b> 엔진.</div>
+      <ul class="flow">
+        <li><span class="k">1 · Scope</span><span class="v">diff base·변경파일·컨벤션 발견 <code>git diff base...HEAD</code></span></li>
+        <div class="arrow">▼</div>
+        <li class="fan"><span class="k">2 · Review (∥ 6 dimensions)</span><span class="v">Bugs · Simplicity · Architecture · Dead Code · Best Practices · Patterns — 6개 blind 병렬 서브에이전트</span></li>
+        <div class="arrow">▼ 발견마다</div>
+        <li class="verify"><span class="k">3 · Verify (적대적, 발견당 1)</span><span class="v">fresh <code>agent()</code>가 git diff 재실행 → 5경로 반증 체크 → 기본값 <code>unclear</code>, "do NOT default to confirmed"</span>
+          <div class="buckets">
+            <span class="pill ok">confirmed</span><span class="pill q">unclear</span><span class="pill no">rejected</span><span class="pill">budgetDropped</span>
+          </div>
+        </li>
+        <div class="arrow">▼</div>
+        <li class="auto"><span class="k">4 · Report (자율)</span><span class="v">dedup + (severity → confidence) 정렬. <code>--comment</code> 시 인라인 PR 코멘트</span></li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- review-pr -->
+  <div class="lane pr">
+    <div class="hd"><i class="dot" style="background:var(--pr)"></i><b>review-pr</b><span class="tag">plugin · command</span></div>
+    <div class="bd">
+      <div class="role">변경 내용에 따라 <b>전문가 에이전트를 조건부 선택</b>. 각 에이전트가 스스로 신뢰도를 채점해 자가 검열.</div>
+      <ul class="flow">
+        <li><span class="k">1–3 · Scope</span><span class="v"><code>git status</code> + <code>git diff --name-only</code>, <code>gh pr view</code>로 PR 존재만 확인</span></li>
+        <div class="arrow">▼</div>
+        <li><span class="k">4 · Route (조건부)</span><span class="v">파일 타입 → 에이전트 매핑 선택</span></li>
+        <div class="arrow">▼ 기본 순차 (병렬 opt-in)</div>
+        <li class="fan"><span class="k">5 · Specialists</span><span class="v">
+          <b>code-reviewer</b> (항상·opus) · pr-test-analyzer · comment-analyzer · silent-failure-hunter · type-design-analyzer
+          <br><span style="color:var(--faint)">→ 통과 후 <b>code-simplifier</b> 가 코드 재작성</span></span></li>
+        <div class="arrow">▼ 검증자 없음</div>
+        <li class="auto"><span class="k">자가 신뢰도 필터</span><span class="v">code-reviewer: "<code>confidence ≥ 80</code>만 보고". 2차 재검증 없음</span></li>
+        <div class="arrow">▼</div>
+        <li class="auto"><span class="k">6–7 · Aggregate (자율)</span><span class="v">Critical/Important/Suggestions/Strengths 수동 집계 markdown. dedup 키·인라인 코멘트 없음</span></li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- frame -->
+  <div class="lane fr">
+    <div class="hd"><i class="dot" style="background:var(--fr)"></i><b>/prothesis:frame</b><span class="tag">protocol · SKILL.md</span></div>
+    <div class="bd">
+      <div class="role">코드가 아닌 <b>탐구의 분석틀 부재</b>를 해소. 어떤 렌즈로 볼지를 <b>사용자가 구성</b>하는 게이트형 프로토콜.</div>
+      <ul class="flow">
+        <li class="gate"><span class="k">Phase 0 · 게이트 ⏹</span><span class="v">Mission Brief 확인 + 모드 선택(recommend / inquire) → <b>턴 양보</b></span></li>
+        <div class="arrow">▼</div>
+        <li><span class="k">Phase 1 · Context</span><span class="v">맥락 수집, 후보 관점(lens) 배치(Placement)</span></li>
+        <div class="arrow">▼</div>
+        <li class="gate"><span class="k">Phase 2 · 게이트 ⏹</span><span class="v">분석 렌즈 <b>다중 선택</b> — 핵심 인식 행위는 사용자 몫 → <b>턴 양보</b></span></li>
+        <div class="arrow">▼ ∥ 격리 inquiry</div>
+        <li class="fan"><span class="k">Phase 3 · Spawn</span><span class="v">선택된 N개 관점을 격리 병렬 teammate로 spawn + await</span></li>
+        <div class="arrow">▼</div>
+        <li class="gate"><span class="k">Phase 4 · 게이트 ⏹</span><span class="v">교차 종합 + 라우팅(extend / add_input / wrap_up / withdraw) → <b>턴 양보</b></span>
+          <div class="buckets"><span class="pill">→ FramedInquiry</span></div></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div class="callout">
+  <b>한눈에 보는 분기점</b> — 세 도구 모두 "분석가를 병렬로 펼친 뒤 종합한다"는 <em>구현 기법</em>은 공유한다.
+  갈리는 지점은 ① <b>사용자 게이트 유무</b>(frame만 3회 턴 양보, 둘은 완전 자율)와
+  ② <b>거짓 양성 통제 방식</b>(code-review = 생산자/판정자 분리한 독립 적대 검증 · review-pr = 생산자 자가 채점).
+</div>
+
+<!-- ============ COMPARISON ============ -->
+<h2><span class="num">02</span>축별 비교</h2>
+<table>
+  <thead>
+    <tr><th class="axis">축</th>
+      <th class="col-cr">/code-review</th>
+      <th class="col-pr">review-pr</th>
+      <th class="col-fr">/frame</th></tr>
+  </thead>
+  <tbody>
+    <tr><th class="axis">결손 / 목적</th>
+      <td class="cr col-cr">git diff의 코드 정합성 버그</td>
+      <td class="pr col-pr">PR/diff의 다차원 품질 (테스트·타입·주석·에러)</td>
+      <td class="fr col-fr">탐구의 분석틀 부재 → FramedInquiry</td></tr>
+    <tr><th class="axis">차원 분해</th>
+      <td class="cr col-cr">6개 <b>고정</b> 차원, 항상 전부 병렬</td>
+      <td class="pr col-pr">6개 전문가, diff에 따라 <b>조건부</b> 선택 (기본 순차)</td>
+      <td class="fr col-fr">사용자가 <b>선택</b>한 N개 관점 렌즈, 격리 병렬</td></tr>
+    <tr><th class="axis">검증 모델</th>
+      <td class="cr col-cr"><b>발견당 적대적 단일 검증자</b> (독립 agent, 기본 unclear, 5경로 반증)</td>
+      <td class="pr col-pr"><b>없음</b> — 에이전트 자가 신뢰도 채점 (<code>≥80</code>)</td>
+      <td class="fr col-fr">검증이 아닌 <b>교차 종합</b> + 변환 트레이스 입증</td></tr>
+    <tr><th class="axis">거짓 양성 통제</th>
+      <td class="cr col-cr">구조적: 2차 에이전트 + <code>rejected</code> 버킷 + slot 예산(25, high 항상 통과)</td>
+      <td class="pr col-pr">자가보고: 생산자가 곧 판정자 ("minimize FP" 만다트)</td>
+      <td class="fr col-fr">해당 없음 (정답형 검증이 아님)</td></tr>
+    <tr><th class="axis">상호작용 모델</th>
+      <td class="cr col-cr">자율 · 게이트 없음</td>
+      <td class="pr col-pr">자율 · 게이트 없음</td>
+      <td class="fr col-fr"><b>3회 게이트 (turn yield)</b> · 사용자 판단이 결과를 구성</td></tr>
+    <tr><th class="axis">산출물</th>
+      <td class="cr col-cr">랭킹·dedup 리포트 + <code>--comment</code> 인라인 PR 코멘트</td>
+      <td class="pr col-pr">수동 집계 markdown 요약 (인라인 없음)</td>
+      <td class="fr col-fr">FramedInquiry 객체 (렌즈 핸드오프 / 합성 Lens)</td></tr>
+    <tr><th class="axis">수렴 / 종료</th>
+      <td class="cr col-cr">검증·예산 버킷 처리 후 Report에서 종료</td>
+      <td class="pr col-pr">전 에이전트 보고 집계 후 종료</td>
+      <td class="fr col-fr">사용자 만족 / withdraw / Esc + 변환 트레이스 입증</td></tr>
+    <tr><th class="axis">코드 수정</th>
+      <td class="cr col-cr">보고만 (mutating 없음)</td>
+      <td class="pr col-pr"><b>code-simplifier가 재작성</b> (통과 후)</td>
+      <td class="fr col-fr">해당 없음</td></tr>
+    <tr><th class="axis">확장성</th>
+      <td class="cr col-cr">바이너리 컴파일 — <b>편집 불가</b></td>
+      <td class="pr col-pr">markdown 명령 + 에이전트 파일 — <b>완전 포크 가능</b></td>
+      <td class="fr col-fr">SKILL.md 포크 가능</td></tr>
+    <tr><th class="axis">Initiator</th>
+      <td class="cr col-cr">사용자 호출 → AI 완주</td>
+      <td class="pr col-pr">사용자 호출 → AI 완주</td>
+      <td class="fr col-fr">AI 배치 / 사용자 선택 (Detection with Authority)</td></tr>
+  </tbody>
+</table>
+
+<!-- ============ PROS / CONS ============ -->
+<h2><span class="num">03</span>장단점</h2>
+<div class="pc">
+  <div class="card">
+    <div class="ch crh" style="color:var(--cr)">/code-review</div>
+    <div class="pcrow"><div class="lbl up">장점</div><ul>
+      <li>생산자/판정자 분리한 <b>독립 적대 검증</b> — 거짓 양성에 구조적으로 강함</li>
+      <li>정형 dedup + severity/confidence 랭킹</li>
+      <li>high/critical은 예산 무시하고 항상 검증</li>
+      <li>원격 PR 모드 + <code>--comment</code> 인라인 게시</li>
+    </ul></div>
+    <div class="pcrow"><div class="lbl dn">단점</div><ul>
+      <li>6차원 <b>고정</b> — 끌 수도 늘릴 수도 없음</li>
+      <li>바이너리 컴파일 — 프롬프트 편집 불가</li>
+      <li>코드를 고치지 않고 보고만</li>
+      <li>effort→예산 매핑이 불투명 (휴리스틱+상수)</li>
+    </ul></div>
+  </div>
+
+  <div class="card">
+    <div class="ch prh" style="color:var(--pr)">review-pr</div>
+    <div class="pcrow"><div class="lbl up">장점</div><ul>
+      <li><b>전문가 폭</b>: 에러 핸들링·타입 설계(1-10점)·주석·테스트 전용 에이전트</li>
+      <li>diff에 따라 <b>조건부 선택</b> — 불필요한 패스 생략</li>
+      <li>리뷰 후 <b>code-simplifier가 코드 재작성</b></li>
+      <li>전부 편집/포크 가능한 markdown</li>
+    </ul></div>
+    <div class="pcrow"><div class="lbl dn">단점</div><ul>
+      <li><b>독립 검증자 없음</b> — 생산자가 곧 판정자(자가 채점)라 FP에 약함</li>
+      <li>dedup 키 없음 (수동 집계)</li>
+      <li>이름과 달리 인라인 PR 코멘트 미게시</li>
+      <li>기본 순차라 느릴 수 있음 (병렬 opt-in)</li>
+    </ul></div>
+  </div>
+
+  <div class="card">
+    <div class="ch frh" style="color:var(--fr)">/prothesis:frame</div>
+    <div class="pcrow"><div class="lbl up">장점</div><ul>
+      <li>코드가 아닌 <b>사고의 틀</b>을 다룸 — 적용 영역이 다름</li>
+      <li>핵심 판단을 <b>사용자가 구성</b> (인간 주체성 보존)</li>
+      <li>변환 트레이스로 수렴을 <b>입증</b>(주장 아님)</li>
+      <li>다른 프로토콜과 조합 가능</li>
+    </ul></div>
+    <div class="pcrow"><div class="lbl dn">단점</div><ul>
+      <li>3회 게이트 — 자동화/무인 실행엔 부적합</li>
+      <li>코드 결함 탐지가 목적이 아님 (리뷰 도구 대체 불가)</li>
+      <li>사용자 참여 없이는 진행 불가</li>
+      <li>러닝 커브 (형식 블록·게이트 의미론)</li>
+    </ul></div>
+  </div>
+</div>
+
+<!-- ============ WHEN TO USE ============ -->
+<h2><span class="num">04</span>언제 무엇을 — 판정</h2>
+<p>세 도구는 <b>중복이 아니라 서로 다른 니치</b>다. code-review와 review-pr은 "같은 아이디어의 두 세대"(엄격한 검증 엔진 vs 확장 가능한 전문가 셋), frame은 아예 다른 층위(코드 결함 vs 사고틀 부재)다.</p>
+<div class="when">
+  <div class="w cr"><b style="color:var(--cr)">/code-review</b><span>거짓 양성이 비싼 <b>머지 전 정합성 게이트</b>. 적대 검증자가 값을 함. 인라인 PR 코멘트가 필요할 때.</span></div>
+  <div class="w pr"><b style="color:var(--pr)">review-pr</b><span><b>차원 특화 심층 감사</b>(에러 핸들링·타입 불변식·테스트 갭·comment rot), 리뷰어 셋 커스터마이즈, 리뷰 후 단순화 패스가 필요할 때.</span></div>
+  <div class="w fr"><b style="color:var(--fr)">/frame</b><span>코드가 아니라 <b>문제를 어떤 틀로 볼지</b>가 막혔을 때. 분석 렌즈를 사용자가 골라 다관점으로 탐구하고 싶을 때.</span></div>
+</div>
+
+<div class="callout" style="border-color:var(--cr);background:rgba(68,147,248,.06)">
+  <b>부하지지 차이 한 줄</b> — code-review의 <span class="kbd">agent('Adversarially verify: …') · "do NOT default to confirmed"</span> (독립 검증)
+  vs review-pr의 <span class="kbd">code-reviewer.md · "Only report issues with confidence ≥ 80"</span> (자가 임계).
+  <b>독립 검증 vs 자가 임계</b>가 두 리뷰 도구를 가르는 핵심이고, <b>게이트 유무</b>가 리뷰 도구 전체와 frame을 가른다.
+</div>
+
+<footer>
+  생성 근거: Claude Code v2.1.148 바이너리 임베디드 스킬 소스(verbatim 문자열) · <code>~/.claude/plugins/marketplaces/claude-plugins-official/plugins/pr-review-toolkit/</code> · <code>prothesis/skills/frame/SKILL.md</code>.
+  검증 캐비엇: 런타임 <code>--effort</code> 값이 code-review의 <code>MAX_VERIFY</code>/투표 수를 실제 변형하는지는 문자열만으로 미증명(minified 제어흐름). 그 외 전부 직접 증거.
+</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 배경

merged worktree 정리 중 `bound-kindbinding` worktree 에서 커밋되지 않은 분석 문서 두 개를 발견했다. 브랜치에 고유 커밋이 없어 브랜치 보존만으로는 구제되지 않았고, `docs/analysis/` 의 다른 문서들이 모두 추적되는 것과 달리 이 둘만 untracked 상태였다 — 해당 디렉토리가 유일한 사본이었다.

## 내용

| 파일 | 크기 | 성격 |
|---|---|---|
| `docs/analysis/codex-claude-orchestration-2026-05.md` | 20KB | 2026-05 기준 Claude Code / Codex 플랫폼 수렴 지점과 역할 분리 패턴 조사 |
| `docs/analysis/review-tools-comparison.html` | 21KB | 리뷰 도구 비교 리포트 |

내용 변경 없이 그대로 회수했다. 브랜치는 `origin/main` 최신 위에서 새로 잘라냈다.

## 검토 포인트

- `docs/analysis/` 가 이 두 문서의 적절한 거처인지 (파일명 규약은 기존 문서들과 일치)
- `.html` 산출물을 저장소에 두는 것이 맞는지 — 아니라면 이 PR 에서 빼고 md 만 병합

---
🤖 [Claude Code](https://claude.com/claude-code) 로 생성
