### PR TITLE
fix: resolve 3 marketplace submission blockers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "epistemic-protocols",
+  "description": "A domain-free metalanguage of structured types and morphisms for human-AI collaboration: it reduces cognitive load by eliciting unknowns into utterance, constraining AI attention without bias, and resolving interaction deficits at their root within bounded loops before local misalignment hardens into system-wide rework.",
   "owner": {
     "name": "jongwony"
   },

--- a/epistemic-cooperative/skills/white-bear/SKILL.md
+++ b/epistemic-cooperative/skills/white-bear/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: white-bear
-description: Use when the user asks to "check white bear", "audit prohibition phrasing", "find negative framing", or invokes /white-bear. Read-only audit of LLM-facing prose: positive rationale over prohibition.
+description: "Use when the user asks to \"check white bear\", \"audit prohibition phrasing\", \"find negative framing\", or invokes /white-bear. Read-only audit of LLM-facing prose: positive rationale over prohibition."
 user_invocable: true
 allowed-tools: Read, Grep, Glob
 ---

--- a/epistemic-cooperative/skills/zero-shot/SKILL.md
+++ b/epistemic-cooperative/skills/zero-shot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zero-shot
-description: Use when the user asks to "check zero-shot", "audit few-shot anchoring", "find example anchoring", or invokes /zero-shot. Read-only audit of LLM-facing prose: principle over anchoring examples.
+description: "Use when the user asks to \"check zero-shot\", \"audit few-shot anchoring\", \"find example anchoring\", or invokes /zero-shot. Read-only audit of LLM-facing prose: principle over anchoring examples."
 user_invocable: true
 allowed-tools: Read, Grep, Glob
 ---


### PR DESCRIPTION
## Purpose

Prepares this repo for submission to Anthropic's official `claude-plugins-community`
marketplace by fixing 3 mechanical blockers found in a prior read-only audit.

## Fixes

1. `epistemic-cooperative/skills/zero-shot/SKILL.md` — the frontmatter `description:`
   value contained an unquoted internal `: ` (in "...LLM-facing prose: principle over
   anchoring examples."), which breaks plain-scalar YAML parsing. Wrapped the value in
   a double-quoted YAML scalar, escaping the pre-existing embedded `"..."` phrases
   (`\"...\"`) per this repo's own established convention for this exact pattern (see
   `.claude/skills/encapsulation/SKILL.md` and `.claude/skills/formal-review/SKILL.md`).
   Text content is unchanged — only YAML quoting/escaping was added.
2. `epistemic-cooperative/skills/white-bear/SKILL.md` — identical issue, identical fix.
3. `.claude-plugin/marketplace.json` — added the missing top-level `description` field
   (only `name`/`owner`/`plugins` existed before). This is a hard failure under
   `claude plugin validate . --strict` (plain warning under non-strict). Wording is
   adapted from AGENTS.md's Northstar one-line project summary (not new marketing copy).

## Verification

`claude plugin validate .` (root marketplace manifest):

Before:
```
⚠ Found 1 warning:
  ❯ description: No marketplace description provided. ...
✔ Validation passed with warnings   (non-strict)
✘ Validation failed (--strict treats warnings as errors)
```
After:
```
✔ Validation passed        (both non-strict and --strict)
```

`claude plugin validate ./epistemic-cooperative`:

Before:
```
✘ Found 1 error: frontmatter: YAML frontmatter failed to parse ... (zero-shot/SKILL.md)
✘ Found 1 error: frontmatter: YAML frontmatter failed to parse ... (white-bear/SKILL.md)
✘ Validation failed
```
After:
```
✔ Validation passed
```

## Scope

Only the 3 files above were touched — no refactors, no unrelated cleanup.

Personal-scope repo — lighter self-record PR, no reviewer assignment needed. **Not
merged** — merge remains the user's decision.
