### PR TITLE
package: add description overrides for 7 epistemic-cooperative utility skills

### DIFF
--- a/scripts/package.js
+++ b/scripts/package.js
@@ -49,6 +49,13 @@ const DESCRIPTION_OVERRIDES = {
   catalog: 'Instant protocol handbook — browse all protocols, compare by concern, view detailed scenarios',
   triage: 'Work-unit triage — group GitHub issues, fuse with AGENTS.md northstar, and emit dispatchable initial prompts.',
   dispatch: 'Focused work-unit execution — consume /triage initial prompts, verify premises, fan out PRs, and inscribe rejection traces.',
+  'comment-review': "Reviews markdown/HTML artifacts before fixation (publish/commit/merge) via a channel-first browser preview loop.",
+  forge: "Reference-grounded prompt-artifact formation — surfaces under-determined contract coordinates from a reference doc and projects a ready-to-use prompt or skill recipe.",
+  'lens-review': "Frame-driven multi-perspective PR review — derives fitting lenses per diff, cross-verifies findings, posts one consolidated PR comment.",
+  misuse: "Retrospective protocol contract-violation detector — scans past sessions and surfaces violation records for review.",
+  'reduced-space-test': "Scoped empirical validation — decomposes a target↔surrogate equivalence claim, bounds a test space, captures evidence, carries the untested complement forward.",
+  'review-loop': "Convergence-paced review-resolve loop — verifies findings, auto-applies mechanical fixes, gates judgment fixes, re-reviews to approval.",
+  steer: "Project-profile recalibration — audits calibration drift, presents evidence for verdict, writes an updated profile rule and Settled Directions clause.",
 };
 
 const EXCLUDE_NAMES = new Set([


### PR DESCRIPTION
## What

Adds 7 packaged-description overrides to `DESCRIPTION_OVERRIDES` in `scripts/package.js`, covering the `epistemic-cooperative` utility skills whose source `SKILL.md` `description:` exceeds `DESCRIPTION_LIMIT` (200 chars) and was shipping unabridged (400-900+ chars) to every downstream installer's session.

| Skill | Source description length |
|---|---|
| comment-review | 426 chars |
| forge | 544 chars |
| lens-review | 910 chars |
| misuse | 476 chars |
| reduced-space-test | 458 chars |
| review-loop | 892 chars |
| steer | 797 chars |

Source `SKILL.md` files are untouched -- the full description still serves this maintainer's own local routing. Only the packaged copy (what installers load) gets the compact override.

Per design choice: the override text is purpose-only and does not enumerate composed protocols/plugins by name or slash-command (e.g. no "/inquire x /sublate x /gap" or "Composes prothesis:frame..."). That composition info already lives structurally in each skill's own `skills:` frontmatter field, so repeating it in prose would be redundant token waste.

## Verification

`node scripts/package.js --dry-run` warnings, measured on this branch's base (`origin/main` at merge-base, i.e. this diff's only variable is the `DESCRIPTION_OVERRIDES` edit):

**Before** (10 warnings):
```
WARN: aitesis: Skill.md is 539 lines (29 over 510-line guideline)
WARN: epistemic-cooperative: description is 426 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 544 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 910 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 476 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 458 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 892 chars (over 200-char limit, no override defined)
WARN: epistemic-cooperative: description is 797 chars (over 200-char limit, no override defined)
WARN: horismos: Skill.md is 633 lines (123 over 510-line guideline)
WARN: katalepsis: Skill.md is 524 lines (14 over 510-line guideline)
```

**After** (3 warnings, all pre-existing/unrelated to this change):
```
WARN: aitesis: Skill.md is 539 lines (29 over 510-line guideline)
WARN: horismos: Skill.md is 633 lines (123 over 510-line guideline)
WARN: katalepsis: Skill.md is 524 lines (14 over 510-line guideline)
```

All 7 `epistemic-cooperative: description is N chars (over 200-char limit, no override defined)` warnings are gone. The 3 line-count guideline warnings (`aitesis`/`horismos`/`katalepsis`) are identical before and after -- this diff touches only `DESCRIPTION_OVERRIDES`, not `LINE_GUIDELINE` or any `SKILL.md`, so those warnings are unaffected and out of scope for this change.

`claude plugin validate .` (root): passes with 1 pre-existing unrelated warning (marketplace description).
`claude plugin validate ./epistemic-cooperative`: 2 pre-existing errors (`zero-shot`, `white-bear` frontmatter YAML parse) confirmed present on pristine `origin/main` before this change -- zero new errors introduced by this PR.

## Scope

Only `scripts/package.js` changed (7 new map entries). No `SKILL.md` files touched. No changes to the unrelated `aitesis`/`horismos`/`katalepsis` line-count warnings.

Personal repo -- self-record PR, no reviewer needed. Merge held per project convention.
