### PR TITLE
fix(probe): Phase 1 카탈로그 스캔에 substrate-implicit 신호 추가

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core 17 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "description": "Utility skills layered on top of the core 17 protocols — /catalog, /onboard, /probe, /report, /dashboard, /introspect, /sophia, /curses, /comment-review, /review-loop, /lens-review, /goal-research, /steer, /realign, /misuse, /triage, /dispatch with post-cycle improvement capture, /forge, /reduced-space-test, /image-companion, and the /white-bear and /zero-shot prose audits. See each skill's SKILL.md for details.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/probe/SKILL.md
+++ b/epistemic-cooperative/skills/probe/SKILL.md
@@ -66,6 +66,8 @@ When `Λ.coverage_constraint` is set (from a prior `Narrow(CoverageSubset)`), fi
 
 Construct the candidate set. Keep at minimum two candidates with non-overlapping reverse-evidence conditions — singleton high-confidence framing is forbidden (see Rules section, Rule 5).
 
+**Substrate-implicit disambiguation**: Before defaulting a candidate to a missing-information framing (e.g., ContextInsufficient/`/inquire`, FrameworkAbsent/`/frame`), check whether the situation's external substrate (the user's own codebase, project rules or Northstar documents, prior session record, or environment) already carries an implicit, not-yet-articulated decision signal relevant to the utterance. When it does, include AbstractAporia (`/elicit`) in the candidate set — per Euporia's own `substrate_implicit` boundary (`euporia/skills/elicit/SKILL.md` Gate predicate), an implicit-but-unarticulated decision coordinate is intent-decoding, not external-fact supply, and belongs to `/elicit` rather than `/inquire`. Utterance-only ambiguity without an external substrate signal still routes to `/inquire`, consistent with that same boundary.
+
 **Single-pass routing scope**: Phase 1 enumerates named deficits across the catalog as a one-shot fit review. Per-protocol convergence dynamics — including cycle iteration within a routed protocol such as `/elicit`'s reverse-induction loop — remain internal to that destination protocol; Probe does not surface, measure, or aggregate convergence efficiency across uses (Rule 7 reinforcement; cycle-counter visibility is the destination protocol's UX surface, not Probe's).
 
 ### Phase 2: Hypothesis Presentation


### PR DESCRIPTION
## 배경

별개 세션(hermeneutic-assistant, 2026-07-13)에서 `/probe`가 실행됐고, 세션의 substrate(프로젝트 CLAUDE.md Northstar 문장)에 이미 방향/의도가 명시돼 있었음에도, 제시된 3개 가설(`/bound`, `/frame`+`/inquire`, `/delimit`) 모두 "목표가 이미 있다는 전제 위의 하위 문제"였다. 사용자는 셋 중 어느 것도 고르지 않고 자유 응답으로 재지정("의도부터 맞춰야 될 것 같은데")했는데, 이는 `/elicit`(Euporia, AbstractAporia)에 정확히 대응하는 결핍이었으나 후보 3개 어디에도 없었다.

## 원인 분석

- `/probe` Phase 1 "Catalog Scan"은 "17개 결핍의 카탈로그를 상황에 대고 스캔하라"는 일반 지시만 갖고 있고, 근접 이웃 결핍(예: `ContextInsufficient`/`/inquire` vs `AbstractAporia`/`/elicit`)을 구분할 신호가 전혀 없다.
- 반면 `euporia/skills/elicit/SKILL.md`의 Gate predicate는 이 경계를 이미 정확히 정의하고 있다: `substrate_implicit`는 external channel(Codebase/Rules/Session/Environment)만 인정하고, utterance-only 모호성은 `/inquire`로 라우팅한다. probe Phase 1은 이 기존 경계를 전혀 참조하지 않는다.
- 선례: `aaacc49` 커밋에서 probe의 `DeficitName`/`ProtocolId` enum 자체에서 `AbstractAporia`가 누락된 적이 있다(이번 건은 enum이 아니라 휴리스틱 프로즈 층위의 별개 gap — enum에는 이미 포함돼 있으나 스캔 휴리스틱이 이를 충분히 활용하도록 유도하지 않음).

## 변경 사항

- `epistemic-cooperative/skills/probe/SKILL.md` Phase 1에 "Substrate-implicit disambiguation" 문단 추가 — substrate(코드베이스/규칙/Northstar/세션 기록)에 의도가 이미 암묵적으로 있을 때 `/elicit`을 후보에 포함하도록 명시. euporia의 기존 `substrate_implicit` 경계를 인용만 하고 재정의하지 않음.
- `epistemic-cooperative/.claude-plugin/plugin.json`, `epistemic-cooperative/.codex-plugin/plugin.json` 버전 3.13.7 → 3.13.8.

## 판단 근거 (근거 강도)

단일 관찰 사례이므로 새 타입/FLOW/COMPOSITION 변경이나 아키텍처 층위 개입은 하지 않았다(probe SKILL.md Rule 17 기준 "type-level realization"에 해당 — 신규 core protocol/graph.json edge/카테고리 승격이 아님). 대신 Phase 1 프로즈에 문단 하나만 추가하는 최소 범위로 한정했다. 단일 사례지만 결과가 아니라 메커니즘 자체(Phase 1에 근접 이웃 구분 신호가 전무하다는 점)를 직접 읽어서 확인할 수 있는 구조적 gap이라 판단해 변경을 진행했다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — `fail: []`, `warn: []`
- pre-commit hook(패키징 dry-run 포함) 통과

## 범위

머지는 보류 — 사용자 승인 필요. PR 생성까지가 이 작업의 범위.
