### PR TITLE
feat(agents): Settled Directions에 원장 바인딩 선언 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Citable registry of conventions whose resolution direction is already constitute
 - Mechanism pointer: the consuming mechanism (the option-set relay test) is defined in `.claude/rules/axioms.md` §A5 — not restated here.
 - **Count-free protocol cardinality**: do not hardcode the protocol count in prose, comments, test names, or metadata descriptions — use count-free phrasing ("all core protocols", "every protocol plugin"). Completeness-sensitive code and tests compare exact protocol identities against the canonical registry (`scripts/load-protocols.js` `CANONICAL_PRECEDENCE`) or derive displayed counts from it; a deliberate subset (e.g. the Codex submission set) states its inclusion policy explicitly.
 - **Multi-skill plugin description scope**: a plugin bundling more than one skill (currently: `epistemic-cooperative` only) is not required to enumerate every skill's `/command` in its top-level plugin description to satisfy `artifact-self-containment.js`'s `hasRoutingCue` check; single-skill plugin descriptions must still name their one skill's `/command`, enforced unchanged.
+- **Ledger binding**: this project's canonical ledger is the git record — commit messages plus issue/PR bodies. "Then"-records (narrative, provenance, trade-offs, rejected alternatives) route there at write time; state surfaces carry only now-asserting operative content, strictest in always-loaded instruction files.
 
 ## Protocol Index
 


### PR DESCRIPTION
## 요약
Settled Directions에 이 프로젝트의 원장 바인딩 선언을 추가한다: 정본 원장 = git 기록(커밋 메시지·이슈·PR 본문). 조항은 운영 규칙만 담고, 구성 경위와 기각된 대안은 이 PR의 커밋 메시지에 보존했다(원장/상태 분리 원칙의 자기 적용).

## 검증
- `node .claude/skills/verify/scripts/static-checks.js .` → 0 fail / 0 warn 확인
