### PR TITLE
refactor(epistemic-cooperative): 리뷰 스킬 설명 영역 축약

### DIFF
--- a/.claude/skills/formal-review/SKILL.md
+++ b/.claude/skills/formal-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: formal-review
-description: "This skill should be used when the user asks to \"formal review\", \"formal lens review\", \"review this PR with the formal triple\", or invokes /formal-review. A fixed-lens multi-perspective PR review specialized for this repository's formally-structured protocol changes: it pins a Category Theory / Type Theory / Operational Semantics lens panel plus a gap scan over only the files changed in a PR, analyzes each lens in isolation, adversarially cross-verifies the findings, and posts the survivors as a single consolidated PR comment. Self-contained project specialization of the frame-driven /lens-review (epistemic-cooperative): it composes /frame for lens framing and /gap for the gap audit, but pins the panel here rather than letting /frame derive it. Project-local contributor tooling."
+description: "This skill should be used when the user asks to \"formal review\", \"formal lens review\", or invokes /formal-review. A fixed-lens PR review for this repository's formally-structured protocol changes: it pins a Category Theory / Type Theory / Operational Semantics lens panel plus a gap scan over only the files changed in a PR, analyzes each lens in isolation, adversarially cross-verifies the findings, and posts the survivors as a single consolidated PR comment. Project-local contributor tooling."
 allowed-tools: Bash, Read, Grep, Glob, Task, Skill
 skills:
   - prothesis:frame
@@ -47,13 +47,6 @@ The skill's identity is the **fixed formal lens panel** applied once over a PR d
 - One-pass review of a formally-structured protocol change on this repository's standing formal axes — morphism/type/evaluation-order coherence — plus a gap audit, every run on the same three lenses
 - You want the findings posted back to the PR as a single consolidated comment for human reviewers to consume
 - The change touches protocol formal blocks (`TYPES`, `PHASE TRANSITIONS`, `MORPHISM`, `LOOP`, `CONVERGENCE`) where the formal triple is the load-bearing review axis
-
-## When NOT to Use
-
-- You want the review lenses derived from the diff rather than the fixed formal triple — that is the general `/lens-review` (epistemic-cooperative)
-- Driving review findings all the way to fixed (apply-and-converge) — that is `/review-loop` (this skill posts a comment, it does not apply fixes)
-- Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets a PR code diff and posts a GitHub comment)
-- A general correctness-bug review with no formal-lens framing — call `/review-loop` with the built-in `code-review` source directly
 
 ## Phase 0: Scope Detection + Free-Exit
 
@@ -138,14 +131,3 @@ If the scope is a working tree (no PR), there is no PR to post to — present th
 7. **Context-question separation at gates** — present all analysis and evidence as text before any gate; a gate carries only the question and the options with their differential implications.
 8. **Plain everyday language** in all user-facing emit — no internal protocol jargon at the user-facing surface.
 9. **One consolidated comment** — all surviving findings go in a single PR comment, each referencing its `path:line` in text; preserve lens tags and severity on every finding; skip duplicates.
-
-## Composition Lineage
-
-Project-local specialization of the general `/lens-review` plugin skill (epistemic-cooperative). Both run the same one-pass isolated→adversarial→consolidated-comment pipeline; they differ only in lens selection:
-
-- `/formal-review` (this skill) **pins** the formal triple (category theory ∥ type theory ∥ operational semantics) plus a gap scan — the fixed panel this repository's protocol work always wants. Self-contained in the project skill layer — it composes `/frame` and `/gap`, but takes no dependency on the `/lens-review` plugin.
-- `/lens-review` (plugin) leaves the panel **frame-derived** — `/frame` selects the lenses that fit the diff. The general capability; this skill is its project-specific fixed-panel specialization.
-- `/review-loop` (plugin) is **convergence-paced** — it drives a review source and applies fixes to verdict-convergence, gating the judgment calls.
-- `/comment-review` (plugin) targets **markdown artifacts before fixation** and surfaces findings through a browser sidepanel, user-paced.
-
-This skill composes `/frame` (prothesis) to frame the fixed lenses and `/gap` (syneidesis) for the gap audit. The posting step is a substrate write routed to the harness permission layer, not an in-skill gate.

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. Browse available skills via /catalog; each skill's SKILL.md carries its own contract.",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Utility skills layered on top of the core protocols. Browse available skills via /catalog; each skill's SKILL.md carries its own contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/comment-review/SKILL.md
+++ b/epistemic-cooperative/skills/comment-review/SKILL.md
@@ -40,7 +40,7 @@ Phase L  : loop iteration k
 free-exit : user may end the review at any time by saying so (Phase 0 prose declares this once)
 ```
 
-4 protocols composed inside each `apply + scan` round's scan step (only when the user picks that option; `apply`-only sessions run 0 sub-protocol audits). `/sublate` joins the scan as a *range expansion* — it does NOT add a new round-mode option, the Phase L gate stays 2-option (`apply + scan` / `apply`). The loop is outer; sub-protocol Constitution semantics persist but their judgment venue moves from in-round chat to next-round sidepanel disposition (see "Why No Gate Reduction" below). Each iteration boundary surfaces exactly one branch gate. Findings surfaced by the scan are materialized into the harness-managed TaskList file with the source protocol's disposition coproduct attached, rendered in a browser sidepanel for the next round so the user can recognize per-finding state without leaving the rendered preview; resolution flows through the response popup (click finding → type response → submit; comment auto-tagged with `[task: <id>]`) or chat (TaskUpdate). Round-mode decisions stay in chat — modality cleanliness preserved.
+4 protocols composed inside each `apply + scan` round's scan step (only when the user picks that option; `apply`-only sessions run 0 sub-protocol audits). `/sublate` joins the scan as a *range expansion* — it does NOT add a new round-mode option, the Phase L gate stays 2-option (`apply + scan` / `apply`). The loop is outer; sub-protocol Constitution semantics persist but their judgment venue moves from in-round chat to next-round sidepanel disposition (see Channel Modality). Each iteration boundary surfaces exactly one branch gate. Findings surfaced by the scan are materialized into the harness-managed TaskList file with the source protocol's disposition coproduct attached, rendered in a browser sidepanel for the next round so the user can recognize per-finding state without leaving the rendered preview; resolution flows through the response popup (click finding → type response → submit; comment auto-tagged with `[task: <id>]`) or chat (TaskUpdate). Round-mode decisions stay in chat — modality cleanliness preserved.
 
 ## When to Use
 
@@ -53,7 +53,6 @@ free-exit : user may end the review at any time by saying so (Phase 0 prose decl
 ## When NOT to Use
 
 - Trivial artifacts (single sentence, typo, comment fix) — direct Edit suffices
-- Code-centric changesets where `/review` is the right tool
 - One-shot artifacts the user does not intend to revise
 
 ## Phase 0: Channel Open
@@ -220,6 +219,8 @@ The disposition tag convention `[disposition: <variant>] [task: <task-id>]` rema
 
 Modality cleanliness preserved: the response popup is the existing comment-collection surface (extended with finding context + auto-tag); round-mode decisions and explicit closes still flow through chat.
 
+Sub-protocol Constitution gates are relocated to this channel: each sub-protocol's Phase 2 coproduct materializes as the disposition affordance on the corresponding TaskList entry, and the user judges it in the next round's sidepanel. Every audit finding is therefore judged by the user before it becomes an edit; the venue is the sidepanel and the timing is the next round, leaving one round-mode decision per iteration in chat.
+
 ### Anchor Assignment (UUID-based, ambiguity-free)
 
 When a scan finding has a text-anchored target in the source markdown, the AI references the rendered HTML preview to identify the unique span (rendered DOM position is unambiguous; markdown substring may not be — e.g., repeated phrases like "Phase 1" or "the user"), generates a UUID, and wraps the target span in source markdown:
@@ -278,21 +279,6 @@ An `apply`-only round skips the scan step entirely. It runs the apply step exact
 
 Apply step tools are restricted to Edit / Write + `TaskUpdate` — sub-protocol invocation belongs to the `apply + scan` mode's scan step only. The "wait without consuming" affordance is implicit in not yet answering the gate — the user may keep drag-commenting and disposing in the browser; consumption happens only when the user responds.
 
-## Why No Gate Reduction
-
-Sub-protocol Constitution gates are **not elided** — they are **relocated**. All four protocols require Constitution user judgment on answers not entailed by upstream protocol outputs:
-- `InformedExecution` (Aitesis output) does not entail the per-source disposition judgment Elenchus asks
-- `VettedContext` (Elenchus output) does not entail the `{Address, Dismiss, Probe}` judgment Syneidesis asks
-- `AuditedDecision` (Syneidesis output) does not entail the `{Confirm, Adapt, Dismiss}` judgment Epharmoge asks
-
-In a standalone invocation, each sub-protocol's Phase 2 fires as an in-round chat gate, the user judges, and edits follow. In this pipeline, the Phase 2 coproduct is **materialized into the corresponding TaskList entry's disposition affordance** in the next round's sidepanel; the user's per-finding judgment expresses through sidepanel clicks (and tagged comments), and the next apply step translates that judgment into edits + `TaskUpdate` calls. Constitution semantics — every audit finding is judged by the user before becoming an edit — are preserved without loss; only the venue (chat → sidepanel) and timing (in-round → next-round) shift.
-
-The composition's value is therefore structural, not interaction-reducing:
-1. **Signature unification** — caller supplies `(artifact, D, context)` once; the composition distributes
-2. **Scope differentiation inscribed** — Named 4-scope + Emergent clause bypasses two suppression edges at pipeline level
-3. **Channel-first modality with cross-round sidepanel disposition** — rendered preview is opened in Phase 0 and persists across iterations; the sidepanel surfaces per-finding state with disposition affordances from the TaskList file across rounds; sub-protocol scans materialize findings whenever the user picks `apply + scan`, and the user judges them through the sidepanel rather than through in-round chat gates
-4. **Loop branch gate at the iteration boundary, in-round chat gate count = 1** — single 2-option Constitution gate (`apply + scan` / `apply`) controls AI processing depth; per-finding sub-protocol Constitution judgments are deferred to next-round sidepanel rather than firing as additional in-round chat gates, compressing in-round chat traffic to one decision per round while preserving the per-finding judgment cardinality across rounds. `/sublate` joins as a scan range expansion, NOT a peer round-mode option (it shares the audit-depth axis with the other scan steps, not a distinct downstream trajectory at the round-mode level). Termination is a free-response pathway declared once in Phase 0; "wait and add more comments / dispose findings" is implicit in not yet answering the gate.
-
 ## Materialized View
 
 On user-explicit termination (free-response exit), present the transformation trace as aggregated totals — not a per-round breakdown. Round-level visibility belongs to the in-loop pre-gate prose (Phase L); the materialized view is the audit summary.
@@ -350,7 +336,3 @@ Suffix-replay rules (apply within a single `apply + scan` round's scan step — 
 - `scripts/serve.ts` — Bun-based live server; `bun scripts/serve.ts <artifact.md|artifact.html> [more...]`. Picks the render mode from the file extension and injects it into the preview; handles GET/POST/WebSocket; `node:fs.watch` triggers reload broadcasts.
 - `templates/preview.html` — interactive preview with anchored comment popup, WebSocket hot-reload client, dark-mode support. Renders markdown via marked into the light DOM (drag-select text anchoring) or raw HTML through a Shadow DOM (right-click element → CSS-selector anchoring, with hover outline + live selector chip).
 - `templates/marked.min.js` — bundled marked.js markdown renderer (markdown mode only; not used in HTML mode).
-
-## Composition Lineage
-
-Authored via `/compose`. Supersedes the legacy `/write-review` skill by generalizing the domain scope from blog-specific ("publish") to artifact-agnostic (caller-supplied fixation event + application context). Sub-protocol scope differentiation and channel-loop mechanism carry forward unchanged; changes are at the orchestration and signature layers. `/sublate` (Elenchus) was added later as a scan range expansion per a 2-cycle `/elicit` design session: the loop branch gate stays 2-option, the scan grows from 3 sub-protocols to 4, and finding visibility extends through a TaskList-backed sidepanel — preserving the modality split (browser collects, chat decides) while making per-finding state recognizable across rounds. A subsequent `/inquire` cycle then revealed that the original `scan + apply` framing conflated the apply step (this round's queued comments → edits) with the in-round firing of sub-protocol Constitution gates, which empirically required multiple chat turns per round-mode commitment. The corrected design renames `scan + apply` → `apply + scan` to make the cross-round nature visible and relocates sub-protocol Phase 2 judgment from in-round chat to next-round sidepanel disposition affordances, preserving Constitution semantics while compressing in-round chat traffic to a single round-mode decision per iteration.

--- a/epistemic-cooperative/skills/lens-review/SKILL.md
+++ b/epistemic-cooperative/skills/lens-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lens-review
-description: "A frame-driven multi-perspective PR review that posts findings as a single consolidated PR comment. /frame derives the review perspectives that fit the diff — for a formally-structured change, often morphism, type, or evaluation-order lenses — plus a gap scan, over only the files changed in a PR. Each lens analyzes in isolation (independence-before-contamination), then the findings are adversarially cross-verified before surviving ones are posted as a single consolidated comment. Composes prothesis:frame for lens framing and syneidesis:gap for the gap audit; the isolated-then-adversarial substrate is described in the skill, not routed to /conduct. The lens panel is not fixed at definition time — a project that needs a fixed panel specializes this skill in a project skill. User-invoked via /lens-review. Sibling of /review-loop (applies fixes to convergence) and /comment-review (markdown artifacts)."
+description: "One-pass multi-perspective PR review that posts findings as a single consolidated PR comment. /frame derives the review lenses that fit the diff, plus a gap scan, over only the files changed in a PR; each lens analyzes in isolation, then the findings are adversarially cross-verified before the survivors are posted. Composes prothesis:frame and syneidesis:gap. User-invoked via /lens-review."
 skills:
   - prothesis:frame
   - syneidesis:gap
@@ -42,13 +42,7 @@ The skill's identity is a frame-derived lens panel applied once over a PR diff a
 - One-pass multi-perspective review of a PR from the epistemic lenses `/frame` derives for the diff, plus a gap audit
 - You want the findings posted back to the PR as a single consolidated comment for human reviewers to consume
 - The change benefits from several structural perspectives held in isolation and then adversarially cross-checked
-- Need the *same* fixed lens panel every run (e.g. a formal triple)? Specialize this skill in a project skill that pins the lenses — see Composition Lineage
-
-## When NOT to Use
-
-- Driving review findings all the way to fixed (apply-and-converge) — that is `/review-loop` (this skill posts comments, it does not apply fixes)
-- Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets a PR code diff and posts GitHub comments)
-- A general correctness-bug review with no lens framing — call `/review-loop` with the built-in `code-review` source directly
+- Need the *same* fixed lens panel every run (e.g. a formal triple)? A project pins those lenses in its own project skill and reuses this isolated→adversarial→consolidated-comment pipeline; the fixed panel lives in the project layer while this plugin skill stays general
 
 ## Phase 0: Scope Detection + Free-Exit
 
@@ -129,15 +123,3 @@ If the scope is a working tree (no PR), there is no PR to post to — present th
 7. **Context-question separation at gates** — present all analysis and evidence as text before any gate; a gate carries only the question and the options with their differential implications.
 8. **Plain everyday language** in all user-facing emit — no internal protocol jargon at the user-facing surface.
 9. **One consolidated comment** — all surviving findings go in a single PR comment, each referencing its `path:line` in text; preserve lens tags and severity on every finding; skip duplicates.
-
-## Composition Lineage
-
-Sibling of `review-loop` and `comment-review`. All three surface review findings, but they differ in what they target and what they do with the findings:
-
-- `/lens-review` is a **one-pass frame-driven review that POSTS a single PR comment** for human reviewers — `/frame` derives the lenses that fit a PR diff, plus a gap scan, and the findings are written back as a single consolidated GitHub comment. It does not apply fixes and does not loop.
-- `/review-loop` is **convergence-paced** — it drives a pluggable review source (`codex` | `code-review`) and applies fixes to verdict-convergence (ends when the source verdict reaches approve), gating the judgment calls.
-- `/comment-review` targets **markdown artifacts before fixation** and surfaces findings through a browser sidepanel, user-paced.
-
-**Project specialization.** Because the lens panel is `/frame`-derived, a project that always wants the *same* fixed panel — for example a formal category-theory ∥ type-theory ∥ operational-semantics triple for protocol review — specializes this skill in its own project skill that pins those lenses and otherwise reuses the same isolated→adversarial→consolidated-comment pipeline. The fixed panel lives in the project layer; this plugin skill stays general.
-
-`/lens-review` composes `/frame` (prothesis) to derive the lenses and `/gap` (syneidesis) for the gap audit. The posting step is a substrate write routed to the harness permission layer, not an in-skill gate.

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-loop
-description: "Convergence-paced code/PR review-resolve loop via /review-loop. Drives a pluggable review source (codex | code-review), passing it the design intent already captured for the changed surface (relevant project rules + adjacent design comments + decisions constituted at the loop's own gates, with a mission-anchored severity steer) so intentional documented choices are pre-filtered upstream, verifies each finding against the codebase (/inquire) and work-flow (/contextualize), auto-applies Mechanical fixes (Extension) and gates Judgment fixes by shared disposition (Constitution), risk-screens applies (substrate risk → harness permission; epistemic risk → direct Constitution), then re-reviews until the source verdict converges to approve — recurring signals escalate to constituted design decisions rather than suppression, keeping the reviewer independent. At exit, converged or free, a decision constituted at its gates is offered for durable record on the home its reach implies (for a PR scope, the issues the PR closes), never as a condition of exiting. User-invoked via /review-loop."
+description: "Convergence-paced review-resolve loop over code/PR diffs. Drives a pluggable review source (codex | code-review), verifies each finding against the codebase and the work-flow, auto-applies mechanical fixes and gates judgment fixes with the user, then re-reviews until the source verdict reaches approve. User-invoked via /review-loop."
 skills:
   - aitesis:inquire
   - epharmoge:contextualize
@@ -51,9 +51,6 @@ The loop is the skill's identity; the review source is a parameter behind it. Lo
 
 ## When NOT to Use
 
-- Reviewing a markdown artifact before fixation — that is `/comment-review` (this skill targets code/PR diffs)
-- Wanting a one-shot review with no apply phase — call a source directly (the codex CLI or `/code-review`); for a cross-model composition, assemble it with `/conduct` (frame supplies the lenses, conduct arranges the review topology) — `/review-loop` is the loop that drives findings to approve
-- Wanting to resolve ONLY findings your PR's own changes introduced (not pre-existing issues surfaced in the touched files) — `/review-loop` drives the whole changed surface to convergence; for a PR-introduced-only pass, use a one-shot reviewer (the codex CLI or `/code-review`) and triage manually
 - Trivial single-line edits where a direct Edit is faster than a review loop
 
 ## Phase 0: Source Designation + Scope Detection
@@ -311,18 +308,3 @@ At exit — converged or free — surface each ledger entry with the durable hom
     boundary and the Phase 0 design-intent harvest, not to invent a new scope restriction
     on the reviewer: a restriction manufactured to force convergence is the suppression
     regime under a different name, and courts the same manufactured approve Rule 9 forbids.
-
-## Deferred (v1.x stretch)
-
-Out of v1 scope, recorded so the source interface stays forward-compatible:
-
-- **Live-teammate driving** — driving an already-active teammate via SendMessage rather than spawning a fresh source per round. No codebase precedent yet; spawn-and-wait (background launch + collect on notification) is the current pattern.
-- **`/frame` as a direct single source** — using `/frame` standalone as a source behind the same interface.
-- **Cross-model composite via `/conduct`** — a user-assembled arrangement (frame-supplied lenses + codex, arranged by `/conduct`) as a source behind the same interface.
-- **`/sublate` + `/gap` in the verify step** — adding `/sublate` (evidence-currency stress test) and `/gap` (decision-quality audit) alongside `/inquire` and `/contextualize` in Phase 2.
-
-## Composition Lineage
-
-Sibling of `comment-review`: both are review-resolve loops, but `/review-loop` targets code/PR diffs where `/comment-review` targets markdown artifacts before fixation. Termination differs — `/review-loop` is convergence-paced (it ends when the source verdict reaches approve), where `/comment-review` is user-paced (rounds end when the user answers the branch gate). The judgment venue differs too — `/review-loop` gates Judgment findings through a disposition-cluster chat scope-gate, where `/comment-review` surfaces findings through a browser sidepanel.
-
-`/review-loop` drives pluggable review sources (`codex` directly, or the built-in `code-review`). It composes `/inquire` (codebase verification) and `/contextualize` (work-flow fit), and screens applies for risk directly — substrate risk routes to the harness permission layer, epistemic risk to an in-loop Constitution decision.


### PR DESCRIPTION
## 요약

White Bear 감사에 따라 네 개 리뷰 스킬의 **설명 영역**을 축약. 형제 스킬을 경쟁 대상으로 지목하는 문장을 제거하고, 상시 로딩되는 `description`을 줄였다.

## 변경

- **When NOT to Use의 형제 라우팅 항목 제거** (`review-loop`, `comment-review`, `lens-review`, `formal-review`) — "that is `/X`" 형태. 각 스킬은 형제 이름 없이 자기 대상을 긍정형으로 진술하므로 구분은 유지.
- **Composition Lineage 섹션 전문 삭제** (4파일) — 내력 서술은 "그때" 기록, Ledger binding에 따라 git 이력이 보존 채널.
- **`description` 축약** (합계 2,855 → 약 1,240자):
  - `review-loop` 1,114 → 340자
  - `lens-review` 931 → 393자
  - `formal-review` 810 → 512자
  - `comment-review` 444자는 이미 충분해 유지
  - `hasRoutingCue`가 요구하는 `/스킬명` 라우팅 큐는 모두 유지.
- **comment-review**: "Why No Gate Reduction" 섹션 삭제, 운영 사실(sub-protocol 게이트 재배치)은 Channel Modality로 긍정형 이관.
- **review-loop**: `Deferred (v1.x stretch)` 로드맵 4개 항목 제거 — 커밋 본문에 verbatim 보존.

## 근거

- 형제 라우팅은 frontmatter `description`이 이미 담아 본문 중복.
- `description`은 스킬 인덱스로 매 세션 항상 로드 → 축약이 상시 비용 절감.
- 사용자 직접 호출이 주 경로(Unix Philosophy Homomorphism)이므로 본문 라우팅 산문 불필요.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → exit 0, fail/warn 없음.
- `epistemic-cooperative` 4.2.0 → 4.2.1 (claude/codex plugin.json). `formal-review`는 프로젝트 스킬로 자체 plugin.json 없음.
