### PR TITLE
refactor(epistemic-cooperative): 리뷰 스킬 `/conduct` 부정 표현을 긍정형으로 전환

### DIFF
--- a/.claude/skills/formal-review/SKILL.md
+++ b/.claude/skills/formal-review/SKILL.md
@@ -75,7 +75,7 @@ The diff headers are the authoritative source for file fate and the hunks carry 
 
 ## Phase 2: Fixed-Lens Review (isolated analysis → adversarial cross-verification)
 
-`/frame` forms the parallel perspectives; this skill then describes the substrate that analyzes and adversarially verifies them **directly** — the isolated-then-adversarial arrangement is recorded here, in the skill, not routed to `/conduct`. Review **only the changed files**.
+`/frame` forms the parallel perspectives; this skill then describes the substrate that analyzes and adversarially verifies them **directly** — the isolated-then-adversarial arrangement is recorded here in the skill itself. Review **only the changed files**.
 
 **Lens framing.** Call `/frame` (prothesis) to frame the perspectives and `/gap` (syneidesis) for the gap audit. Unlike the general `/lens-review`, this skill **pins** the panel: `/frame` is framed onto the fixed formal triple every run, never a diff-derived selection. The fixed lenses and gap dimensions are:
 
@@ -124,7 +124,7 @@ If the scope is a working tree (no PR), there is no PR to post to — present th
 
 1. **Fixed formal panel** — the lenses are pinned to Category Theory, Type Theory, and Operational Semantics every run; `/frame` is framed onto this triple, not a diff-derived selection. A diff-derived panel is the general `/lens-review`, not this skill.
 2. **Changed files only** — review the files in the Phase 1 diff and nothing else; the diff headers are authoritative for file fate, the hunks for line-level evidence.
-3. **Isolated lenses, then adversarial cross-verification** — each lens forms its findings in isolation (independence-before-contamination); the aggregated findings then pass a single adversarial refutation pass before posting. Surviving findings proceed; defeated findings are recorded in the consolidated comment as refuted with cited basis. The isolated-then-adversarial substrate is described in this skill directly, not routed to `/conduct`.
+3. **Isolated lenses, then adversarial cross-verification** — each lens forms its findings in isolation (independence-before-contamination); the aggregated findings then pass a single adversarial refutation pass before posting. Surviving findings proceed; defeated findings are recorded in the consolidated comment as refuted with cited basis. The isolated-then-adversarial substrate is described in this skill directly.
 4. **Confidence ≥ 80%** — only report findings at or above the confidence threshold; trivial changes (e.g. version bumps) are stated briefly and skipped rather than padded with low-value findings.
 5. **Verify before post** — run the Phase 3 direction-error guard against the diff-header fate before any comment is posted; an Added-but-described-as-deleted file augments the review with a direction-misread warning.
 6. **Substrate writes route to harness permission** — posting the consolidated PR comment is an external, human-visible GitHub mutation; surface what will be posted and let the harness gate the execution. The skill does not absorb that substrate decision.

--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. Browse available skills via /catalog; each skill's SKILL.md carries its own contract.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Utility skills layered on top of the core protocols. Browse available skills via /catalog; each skill's SKILL.md carries its own contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/lens-review/SKILL.md
+++ b/epistemic-cooperative/skills/lens-review/SKILL.md
@@ -71,7 +71,7 @@ The diff headers are the authoritative source for file fate and the hunks carry 
 
 ## Phase 2: Framed-Lens Review (isolated analysis → adversarial cross-verification)
 
-`/frame` forms the parallel perspectives; this skill then describes the substrate that analyzes and adversarially verifies them **directly** — the isolated-then-adversarial arrangement is recorded here, in the skill, not routed to `/conduct`. Review **only the changed files**.
+`/frame` forms the parallel perspectives; this skill then describes the substrate that analyzes and adversarially verifies them **directly** — the isolated-then-adversarial arrangement is recorded here in the skill itself. Review **only the changed files**.
 
 **Lens framing.** Call `/frame` (prothesis) to derive the review perspectives that fit the changed files, and `/gap` (syneidesis) for the gap audit. `/frame` selects the lenses appropriate to the diff — for a formally-structured change these are often morphism-coherence, type-soundness, and evaluation-order lenses, but the panel is `/frame`'s to determine, not a fixed list baked into this skill. Each derived lens is one isolated perspective; the gap dimensions audited by `/gap` are:
 
@@ -116,7 +116,7 @@ If the scope is a working tree (no PR), there is no PR to post to — present th
 
 1. **Changed files only** — review the files in the Phase 1 diff and nothing else; the diff headers are authoritative for file fate, the hunks for line-level evidence.
 2. **Frame-derived lenses** — the review panel is not fixed at definition time; `/frame` selects the lenses fitting the diff. A project needing a fixed panel pins it in a project-skill specialization, not by hard-coding lenses here.
-3. **Isolated lenses, then adversarial cross-verification** — each lens forms its findings in isolation (independence-before-contamination); the aggregated findings then pass a single adversarial refutation pass before posting. Surviving findings proceed; defeated findings are recorded in the consolidated comment as refuted with cited basis. The isolated-then-adversarial substrate is described in this skill directly, not routed to `/conduct`.
+3. **Isolated lenses, then adversarial cross-verification** — each lens forms its findings in isolation (independence-before-contamination); the aggregated findings then pass a single adversarial refutation pass before posting. Surviving findings proceed; defeated findings are recorded in the consolidated comment as refuted with cited basis. The isolated-then-adversarial substrate is described in this skill directly.
 4. **Confidence ≥ 80%** — only report findings at or above the confidence threshold; trivial changes (e.g. version bumps) are stated briefly and skipped rather than padded with low-value findings.
 5. **Verify before post** — run the Phase 3 direction-error guard against the diff-header fate before any comment is posted; an Added-but-described-as-deleted file augments the review with a direction-misread warning.
 6. **Substrate writes route to harness permission** — posting the consolidated PR comment is an external, human-visible GitHub mutation; surface what will be posted and let the harness gate the execution. The skill does not absorb that substrate decision.


### PR DESCRIPTION
## 배경

PR #671(`ce583aa`)에서 리뷰 스킬 본문을 축약할 때, `/lens-review`와 `/formal-review`에 남아 있던 `/conduct` 비-표적 부정 표현 4곳은 명시적으로 범위 밖으로 두었다. 이번 PR이 그 후속이다.

## 변경

`"… not routed to `/conduct`"` 4곳을 제거하고 **의도한 경로만 진술**하도록 재작성했다. 경쟁 스킬을 "여기로 가지 않는다"고 명명하는 것은 negated anchoring — 일어나지 않는 라우팅을 주의에 붙이는 White Bear 신호다.

| 파일 | 위치 | 변경 |
|---|---|---|
| `epistemic-cooperative/skills/lens-review/SKILL.md` | Phase 2 산문 | → `recorded here in the skill itself` |
| `epistemic-cooperative/skills/lens-review/SKILL.md` | Rule 3 | → `described in this skill directly.` |
| `.claude/skills/formal-review/SKILL.md` | Phase 2 산문 | (동일) |
| `.claude/skills/formal-review/SKILL.md` | Rule 3 | (동일) |

근거: `CLAUDE.md` Editing Conventions — "prefer positive predicates over negated anchoring". 방향이 이미 결정되어 있어 relay로 처리했다.

## 범위 경계 (over-sweep 금지)

harness 권한 경계를 규정하는 부정 표현은 `/white-bear`의 **load-bearing boundary mention** carve-out에 해당하므로 그대로 보존했다 — 양쪽 파일 각 3곳:

- `does not gate` (relay verify step이 게이트가 아님)
- `does not absorb that decision` / `that substrate decision` (substrate write가 harness permission layer로 라우팅됨)
- `not one inline comment per diff line` (단일 통합 코멘트 규정)

편집 후 grep으로 6곳 전부 잔존 확인.

## 버전 범프 (비대칭)

- `epistemic-cooperative` 4.2.1 → 4.2.2 (`.claude-plugin` + `.codex-plugin` 미러 동일)
- `formal-review`는 `.claude/skills/` 프로젝트 로컬 스킬 — 자체 plugin.json 없음, 범프 대상 아님

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → exit 0, `fail: []`, `warn: []`
- pre-commit hook 테스트 통과
- over-sweep grep: `/conduct` 부정 0곳, load-bearing 부정 6곳 잔존
