### PR TITLE
refactor(anamnesis): /recollect SKILL.md 갈래 조건부 블록을 references로 분리

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anamnesis",
-  "version": "0.8.10",
+  "version": "0.9.0",
   "description": "Resolve vague recall into recognized context — /recollect",
   "author": {
     "name": "Jongwon Choi",

--- a/anamnesis/skills/recollect/SKILL.md
+++ b/anamnesis/skills/recollect/SKILL.md
@@ -149,8 +149,7 @@ progress(Σ) = attempts: N/max, enrichments: N, candidates_presented: N
 --   memory           ↦ {config_dir}/projects/{slug}/memory/                              (user-curated insights)
 --   slug-partitioned: prevents cwd-scattered INDEX; cross-cwd /recollect reaches one canonical location
 -- Candidate source binding: `Candidate.session_id` ← INDEX entry frontmatter `session_id`; `Candidate.cwd` ← INDEX entry frontmatter `cwd` (Optional — absent for entries written before cwd capture was implemented); Candidate.cross_refs ← INDEX entry frontmatter cross_refs — inline-mapping items {kind, ref, channel} since v0.7.0 (StructuredAnchor); bare-string items in older entries are LegacyAnchor and remain valid (degraded read: kind unknown); Candidate.evidence_mode ← max tier over matched artifacts' frontmatter evidence_mode/evidence_modes (Optional — absent for pre-v0.7 entries)
--- Fork/sidechain binding (SidechainNoSSOT): `Candidate.fork_marker = true` ⇐ the recalled id appears as an `agent_id` in INDEX_substitute ({config_dir}/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl, appended by the SubagentStop hook) AND has no sibling top-level SSOT {config_dir}/projects/{slug}/{agent_id}.jsonl of its own — the fork's turns live only in the parent record + this capture, so `claude --resume <agent_id>` has no transcript to resume
--- Parent back-trace (`backtrace_parent` ↦ `Candidate.parent_pointer`, `Candidate.parent_cwd`): deterministic, not heuristic — the substitute capture entry records `session_id` = the orchestrating parent's session id (the SubagentStop payload field), so `parent_pointer ← capture.session_id` is a direct read. The capture lives under the parent's slug by construction ({slug} = dirname of the parent transcript), so the parent is always same-slug — look only there. Resumability: if the parent's top-level SSOT {config_dir}/projects/{slug}/{parent_pointer}.jsonl still exists, `parent_pointer` is set and `parent_cwd ← that transcript's `cwd` field` when present (`parent_cwd = Null` if the parent transcript predates cwd capture — parent identified but cwd unknown); the full handle `cd <parent_cwd> && claude --resume <parent_pointer>` requires both components. If the parent SSOT has aged out, `parent_pointer = parent_cwd = Null` (non-resumable → surface the capture's recoverable artifacts). The native subagent transcript (captured verbatim as the `agent_transcript_path` field) is not relied on as a resume handle; the durable parent link is the capture's `session_id`.
+-- Fork/sidechain binding + parent back-trace: to set `Candidate.fork_marker`, `Candidate.parent_pointer`, and `Candidate.parent_cwd`, read references/fork-resume.md — it carries the detection precondition (substitute-channel hit with no sibling top-level SSOT) and the deterministic read that recovers the orchestrating parent. Without it these three fields have no substrate binding and `backtrace_parent` cannot execute.
 Phase 0 Detect      (sense)    → Internal analysis
 Phase 0 relay_not_empty (extension) → TextPresent+Proceed (¬empty_intention(V): present finding, proceed without activation)
 Phase 0 Classify    (sense)    → Internal analysis (InputType detection from V + Σ)
@@ -180,52 +179,21 @@ seam                (extension)    → TextPresent+Proceed (fires at deactivatio
 *: /recollect ∘ /inquire — RecalledContext → ClueVector_prose seeds Aitesis as input substrate; on NullMatch, the accumulated recall trace seeds Aitesis to search SSOT directly (INDEX may lack entries while SSOT retains the information).
 
 ── ENTROPY EXTRACTION ──
-extract : Session → Set(IdentifierTuple)
-laws:
-  identity:          extract(∅) = ∅
-  locality:          extract(s₁ ⊔ s₂) = extract(s₁) ⊔ extract(s₂)          -- disjoint sessions
-  compositionality:  extract(s) = ⋃ᵢ extractor_i(s)                         -- plugin-summable
-
-precision(t, corpus) = 1 / (1 + |occ(t, corpus \ {t.source})|)
-reject(t, θ) ≡ precision(t, corpus) < θ                                    -- derivable, not enumerated
-claim_kind(trace) = expected identifier category implied by the recall trace
-compatible_anchor(t, trace) ≡ claim_kind(trace) ∈ AuthorizedClaimKinds(source_namespace(t))
-  where AuthorizedClaimKinds(ns) = { ck : (ns, ck) ∈ AuthorizedPairs }   -- a namespace determines the claim kinds it can anchor
-        AuthorizedPairs = ⋃ᵢ extractor_i.authorized_pairs                -- each extractor declares the (source_namespace, claim_kind) pairs it grounds; the registry is the explicit witness
-  -- the witness is defined LOCALLY (extractor registry), independent of Aitesis's reflexive authorizes: analogous structure, different concern (namespace → claim-kind authorization, not evidence-channel authorization)
-  -- the tuple carries source_namespace only; claim_kind(t) is not stored, removing the unused-field inconsistency and matching what the regex writer can materialize
-
-extractor registry:
-  core (bootstrap) = { URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, SessionID_literal }
-                     -- semantic categories: URL_path group {URL_literal, PathRef_literal},
-                     --                      ExplicitRef group {PR_literal, Issue_literal, Commit_literal},
-                     --                      Citation group {SessionID_literal}  -- UUIDs as session citations
-                     -- each extractor declares the (source_namespace, claim_kind) it authorizes for entropy anchoring (Anamnesis-local canonical values, self-contained — NOT a shared cross-protocol vocabulary):
-                     --   URL_literal → (url, url_reference);      PathRef_literal → (fs_path, path_reference)
-                     --   PR_literal → (github_pr, pull_request); Issue_literal → (github_issue, issue);  Commit_literal → (git_commit, commit)
-                     --   SessionID_literal → (session, session_citation)
-  plugin           = { domain-specific extractors conforming to laws }
-
+extract : Session → Set(IdentifierTuple)                                   -- laws, precision threshold, compatible_anchor, extractor registry: read references/entropy-track.md
 dispatch binding: InputType = StructuredIdentifier → Track = entropy
+-- Before running scan_entropy, read references/entropy-track.md: it types extract's laws, the
+-- precision threshold, and the compatible_anchor authorization that decides whether a literal
+-- match may anchor ranking at all. Anchoring a literal without that predicate is unbounded.
 
 ── SALIENCE MARKERS ──
-detect : Session × DateAnchor? → MarkerProfile     -- DateAnchor? = optional ISO date for temporal normalization (e.g., session start)
+detect : Session × DateAnchor? → MarkerProfile     -- categories, semantic invariants, coinage formula: read references/salience-track.md
 categories: { coinage, actor, temporal, emotional, cognitive, singularity }   -- working hypothesis (Emergent admitted)
-
-semantic invariants:
-  traceability:    detect(s) contains only markers grounded in SSOT session content or normalized from session-anchored context
-  boundedness:     ∀c ∈ categories, |detect(s).c| ≤ category_limit
-  stability:       repeated detect(s) under the same extractor version should preserve recall-relevant category intent, but exact set equality is not required (idempotence not claimed — LLM-extracted categories are non-deterministic; stability subsumes intent-level repeatability)
-  locality*:       detect is applied per session; cross-session comparison is ranking-layer only, except corpus-statistical coinage
-  monotonicity*:   adding content may refine, normalize, merge, or reject prior candidate markers; exact set inclusion is not guaranteed
-  -- Provisional invariant relaxation (exact laws → starred semantic invariants) justified by 88.5% noise rate in MarkerProfile.temporal corpus-wide audit (2026-05-04); the coinage formula below remains deterministic and is unaffected.
-
-coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
-  where salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
-  -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
-
 dispatch binding: InputType = NaturalRecall → Track = salience
                   InputType = Mixed → Track = hybrid    -- union scan: entropy ∪ salience
+-- Before running scan_salience, read references/salience-track.md: it bounds what detect may
+-- return (the semantic invariants) and supplies the coinage formula that decides which tokens
+-- count as salient. On Track = hybrid, read references/entropy-track.md as well — the union scan
+-- runs both, so both track contracts bind.
 
 ── STORE TOPOLOGY ──
 Store = SSOT ⊕ INDEX ; memory/ = realization-layer adjunct (non-scanned, user-curated)
@@ -241,9 +209,9 @@ scan_{Track} : (Store, Trace) → List(Candidate)
   scan_hybrid(Store, trace)     = scan_entropy ∪ scan_salience
   evidence_mode(c) = max tier over matched signals' frontmatter evidence_mode(s); frontmatter absent ⇒ Null (legacy entry, neutral — partial-INDEX normal mode, no fallback trigger)
 
-degraded_scan: INDEX_semantic = ∅ ⟹ scan'(SSOT, Track, trace) ∪ literal-id match over INDEX_substitute origin ids   -- SSOT guarantees semantic recall; cold start falls back to SSOT directly. INDEX_substitute is a separate primary channel (not derived from INDEX_semantic), so the sidechain/derived-id match persists under degraded mode — SidechainNoSSOT stays reachable when INDEX_semantic is empty
+degraded_scan: INDEX_semantic = ∅ ⟹ scan'(SSOT, Track, trace) ∪ literal-id match over INDEX_substitute origin ids
   -- partial INDEX (e.g., MarkerProfile? = ∅ while IdentifierTuples / Coinage / narrative present) is a normal mode and does NOT trigger total fallback; scan_salience returns empty for the missing component and ranking degrades gracefully
-  -- INDEX_substitute loss non-recoverable (SSOT lacks subagent-channel messages); precondition for Cold-Start invariant (see Verification)
+  -- once the fallback has fired, read references/failure-modes.md §Degraded scan before relying on the result: it states why the substitute channel survives the fallback (so SidechainNoSSOT stays reachable) and which loss is non-recoverable
 
 ── SUBSTRATE AGNOSTICISM ──
 The protocol essence (form) consists of FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, and the
@@ -265,34 +233,19 @@ externalizing the realization-boundary explanation would split the user-visible 
 from its semantic grounding, breaking the hermeneutic circle that local inscription preserves.
 
 ── KNOWN FAILURE MODES ──
+-- The taxonomy (names + triggering predicate) is here so a mode is recognizable without a read.
+-- Once a mode is suspected, read references/failure-modes.md before acting: it carries each mode's
+-- cause, detection, and recovery, and the recovery is what the protocol executes. Emergent admitted
+-- — the named modes are working hypotheses, not an exhaustive partition.
 FalseAnchor       : extract(s) contains t with high precision but t ≠ recall_target
-                    -- cause: precision threshold locally calibrated but semantically wrong, or source_namespace does not authorize this recall claim's kind
-                    -- detection: Qc Recognize=false despite scan_entropy match
-
 ExtractorLacking  : recall_target ∈ s ∧ ∄ extractor_i : recall_target ∈ extractor_i(s)
-                    -- cause: domain-specific extractor absent from registry
-                    -- detection: NullMatch on scan_entropy ∧ user can cite literal
-
 PartialExtract    : extract/detect produces well-formed but semantically partial INDEX from corrupted/truncated source
-                    -- cause: continue-on-error parser tolerates malformed lines; anomalous shape logged but not write-gated
-                    -- detection: invisible to reader without schema version field or observability log surface
-
 SidechainNoSSOT   : scan_entropy(Store, trace) ≠ ∅ via INDEX_substitute ∧ no top-level SSOT for the recalled id (the id is a sidechain/derived record)
-                    -- cause: the recalled id is a sidechain/derived record whose turns live in the originating record + the substitute channel; no top-level SSOT for the id ever existed — distinct from NullMatch₁ (pre-store/lifecycle gap): here the scan SUCCEEDS on the substitute channel, only the top-level SSOT is absent by design
-                    -- detection: the recalled id matches a substitute-channel record with no sibling top-level SSOT of its own (substrate mechanism in TOOL GROUNDING)
-                    -- recovery: the id is not independently resumable (no top-level record of its own); read the orchestrating parent from the substitute record (backtrace_parent → parent_pointer, parent_cwd) and offer the parent as the resumable candidate; when the parent's record has aged out, mark non-resumable and surface the recoverable artifacts (substitute record + memory)
-
+                    -- distinct from NullMatch₁: here the scan SUCCEEDS on the substitute channel, only the top-level SSOT is absent by design
 NullMatch₁        : scan_entropy(Store, trace) = ∅ ∧ InputType = StructuredIdentifier
-                    -- cause: literal absent from SSOT/INDEX (pre-store, lifecycle gap)
-                    -- recovery: offer Aitesis handoff with accumulated trace
-
 NullMatch₂        : scan_salience(Store, trace) = ∅ ∧ InputType = NaturalRecall
-                    -- cause: profile too vague or target session lacks distinctive markers
-                    -- recovery: Socratic probe enrichment → Phase 1 re-scan
-
 MutualNull        : scan_entropy = ∅ ∧ scan_salience = ∅ on Track = hybrid
-                    -- structural risk: recall target genuinely absent from Store
-                    -- action: NullMatch pathway with full scope disclosure (principal failure mode)
+                    -- structural risk: recall target genuinely absent from Store (principal failure mode)
 ```
 
 ## Core Principle
@@ -378,7 +331,7 @@ Detect empty intention and extract contextual trace. This phase is **silent** �
 
 Dispatch the scan on the classified `Track`, execute track-appropriate lookup over `Store = SSOT ⊕ INDEX`, then rank candidates.
 
-1. **Track-dispatched scan strategy**:
+1. **Track-dispatched scan strategy**. The dispatched track decides which contract binds: read `references/entropy-track.md` before running `scan_entropy`, `references/salience-track.md` before running `scan_salience`, and both on the hybrid track. Each carries the laws and thresholds its scan executes; the untaken track's reference does not bind and is not read.
    - **entropy track** (`InputType = StructuredIdentifier`): execute `scan_entropy` over `SSOT ∪ INDEX` — literal match on `IdentifierTuple.literal`, then apply `compatible_anchor(t, trace)` before the match can anchor ranking; precision-thresholded compatible identifiers win. URL path literals, explicit references, citation tokens dominate only within their authorized source_namespace × claim_kind. A structured id with no IdentifierTuple is additionally matched literally against `INDEX_substitute` origin ids (sidechain/derived records) — a hit whose id has no sibling top-level SSOT is the SidechainNoSSOT precondition (parent back-trace; see Phase 3 emission).
    - **salience track** (`InputType = NaturalRecall`): execute `scan_salience` over `INDEX` (SSOT fallback on degraded_scan) — match against `MarkerProfile` (coinage / actor / temporal / emotional / cognitive / singularity); session context (Σ) supplies ranking signal within this track.
    - **hybrid track** (`InputType = Mixed`): union of entropy and salience results.
@@ -395,7 +348,7 @@ Dispatch the scan on the classified `Track`, execute track-appropriate lookup ov
    - Adjacent topics from the same session or time period
    - Confidence level based on trace alignment, modulated by evidence mode when present (absence neutral)
 
-4. If `|C[]| = 0`: NullMatch pathway. Inform user what was searched and not found. Before declaring NullMatch, attempt at least one Socratic probe enrichment. After enrichment attempts exhausted: surface the search scope summary and the accumulated recall trace (keywords, temporal signals, user hints from probing), then offer Aitesis handoff — the recall INDEX (hypomnesis/) may lack the entry (lifecycle gap: SessionEnd did not fire; or pre-store: session predates hypomnesis implementation), but the SSOT (session JSONL) may still contain the information. The accumulated trace from Anamnesis probing becomes context seed for Aitesis to search SSOT directly.
+4. If `|C[]| = 0`: NullMatch pathway. **Read `references/failure-modes.md` first and identify which mode fired** — the recovery differs per mode (probe enrichment, Aitesis handoff, or a missing-extractor report), and the taxonomy in the Definition block carries only the triggering predicates, not the recoveries. A scan that succeeded but yielded no resumable record is not a NullMatch at all; that mode routes to parent back-trace instead. Inform user what was searched and not found. Before declaring NullMatch, attempt at least one Socratic probe enrichment. After enrichment attempts exhausted: surface the search scope summary and the accumulated recall trace (keywords, temporal signals, user hints from probing), then offer Aitesis handoff — the recall INDEX (hypomnesis/) may lack the entry (lifecycle gap: SessionEnd did not fire; or pre-store: session predates hypomnesis implementation), but the SSOT (session JSONL) may still contain the information. The accumulated trace from Anamnesis probing becomes context seed for Aitesis to search SSOT directly.
 
 **Scope restriction**: Investigation uses Read, Grep, Glob exclusively.
 
@@ -414,7 +367,7 @@ Present the candidate as narrative text — the discussion's story, not just its
 - **Direction**: How the discussion developed — what path was taken, what was explored
 - **Outcome**: What was decided, produced, or concluded
 - **Session**: Full session ID for identification and `claude --resume` verification (e.g., `session: abc12345-def6-7890-ghij-klmnopqrstuv`). Narrative uses short reference. For a non-fork candidate this id is the resumable identifier; for a fork candidate (`fork_marker = true`) it identifies the recognized session but is not itself resumable — the resumable handle is the back-traced parent (see Resume).
-- **Resume**: Copy-paste-ready invocation pairing the originating cwd with the session ID — `cd <cwd> && claude --resume <session_id>`. Claude Code resolves the project slug from invocation cwd, so both components are required; emit only the literal command, no narrative wrapper. Omit this field only when `Candidate.cwd` is absent or empty, and surface the omission to the user. **Fork candidate** (`fork_marker = true`): the fork id is not a valid resume handle (a fork has no top-level transcript, so `--resume <fork_id>` fails). When the parent was back-traced and both components are present (`parent_pointer` and `parent_cwd` non-empty), emit the parent's command instead — `cd <parent_cwd> && claude --resume <parent_pointer>` — and note it resumes the orchestrating parent, not the fork. When `parent_pointer` is present but `parent_cwd` is absent (parent identified but its cwd is unknown), omit the copy-paste command and surface the parent session id with a note to resume from the parent's own project directory. When the parent was not recovered (`parent_pointer = Null`), mark the candidate non-resumable and surface the recoverable artifacts (the substitute log path + any memory) rather than a broken command.
+- **Resume**: Copy-paste-ready invocation pairing the originating cwd with the session ID — `cd <cwd> && claude --resume <session_id>`. Claude Code resolves the project slug from invocation cwd, so both components are required; emit only the literal command, no narrative wrapper. **When the candidate carries `fork_marker = true`, or when `Candidate.cwd` is absent or empty, read `references/fork-resume.md` and build this field by the four-branch rule there before emitting anything.** A fork id is never a valid resume handle, so emitting one produces a command that fails; the four branches cover which handle to emit, when to omit it, and what to surface instead.
 - **Adjacent**: Other topics discussed nearby in the same time period — for Refine orientation
 - **Framing**: how many recall tries remain before the cap, and the size of the candidate space still in scope — stated as the budget you reason with, not a numeric attempt fraction
 
@@ -434,7 +387,7 @@ Other is always available — maps to `Reorient`: user describes a fundamentally
 
 After user response:
 
-1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), and a resume handle built per the fork-aware rule: when the candidate is **not** a fork and `Candidate.cwd` is present and non-empty, emit a literal `cd <cwd> && claude --resume <session_id>` line (the project slug derives from invocation cwd, so the command is the resumable handle); when the candidate **is** a fork (`fork_marker = true`) with both `parent_pointer` and `parent_cwd` present, emit the back-traced parent's `cd <parent_cwd> && claude --resume <parent_pointer>` line (resuming the orchestrating parent, since the fork id itself is non-resumable); when `parent_pointer` is present but `parent_cwd` is absent, omit the copy-paste command and note the parent session id with the cwd-unknown caveat; when the parent was not recovered (`parent_pointer = Null`), omit the command, mark the context non-resumable, and surface the recoverable artifacts (substitute log path + memory); when `Candidate.cwd` is absent or empty for a non-fork candidate, omit the line and note the omission in the prose. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition. ClueVector_prose carries a currency≠fidelity caveat: it states that the context was recognized as a past discussion or decision, not that the recalled content is verified against current reality — downstream consumers (e.g., Aitesis composition) treat it as recalled-and-requiring-re-verification, not as confirmed current context.
+1. **Recognize(c)**: Mark candidate as recognized. Emit ClueVector_prose — natural language rendering of the recognized context to session text. ClueVector_prose includes: session reference (short form in narrative, full session ID for `--resume` verification), topic summary with narrative, key cross-references (memory paths, issue numbers, document pointers), and a resume handle: for a non-fork candidate with `Candidate.cwd` present and non-empty, emit a literal `cd <cwd> && claude --resume <session_id>` line (the project slug derives from invocation cwd, so the command is the resumable handle). **Otherwise — `fork_marker = true`, or `Candidate.cwd` absent or empty — read `references/fork-resume.md` and build the handle by the four-branch rule there**, which is the same rule the Phase 2 `Resume` field uses. This prose enters the session text and is naturally readable by any downstream protocol via Session Text Composition. ClueVector_prose carries a currency≠fidelity caveat: it states that the context was recognized as a past discussion or decision, not that the recalled content is verified against current reality — downstream consumers (e.g., Aitesis composition) treat it as recalled-and-requiring-re-verification, not as confirmed current context.
 
 2. **Refine**: Candidate not recognized but recall direction acknowledged. Initiate Socratic probing for recall deepening:
 

--- a/anamnesis/skills/recollect/references/entropy-track.md
+++ b/anamnesis/skills/recollect/references/entropy-track.md
@@ -1,0 +1,32 @@
+# Entropy track — extraction laws and anchor authorization
+
+Read when `Track = entropy` or `Track = hybrid` — whenever `scan_entropy` is about to run. This is the `── ENTROPY EXTRACTION ──` formal block: runtime-normative contract, not commentary.
+
+```
+── ENTROPY EXTRACTION ──
+extract : Session → Set(IdentifierTuple)
+laws:
+  identity:          extract(∅) = ∅
+  locality:          extract(s₁ ⊔ s₂) = extract(s₁) ⊔ extract(s₂)          -- disjoint sessions
+  compositionality:  extract(s) = ⋃ᵢ extractor_i(s)                         -- plugin-summable
+
+precision(t, corpus) = 1 / (1 + |occ(t, corpus \ {t.source})|)
+reject(t, θ) ≡ precision(t, corpus) < θ                                    -- derivable, not enumerated
+claim_kind(trace) = expected identifier category implied by the recall trace
+compatible_anchor(t, trace) ≡ claim_kind(trace) ∈ AuthorizedClaimKinds(source_namespace(t))
+  where AuthorizedClaimKinds(ns) = { ck : (ns, ck) ∈ AuthorizedPairs }   -- a namespace determines the claim kinds it can anchor
+        AuthorizedPairs = ⋃ᵢ extractor_i.authorized_pairs                -- each extractor declares the (source_namespace, claim_kind) pairs it grounds; the registry is the explicit witness
+  -- the witness is defined LOCALLY (extractor registry), independent of Aitesis's reflexive authorizes: analogous structure, different concern (namespace → claim-kind authorization, not evidence-channel authorization)
+  -- the tuple carries source_namespace only; claim_kind(t) is not stored, removing the unused-field inconsistency and matching what the regex writer can materialize
+
+extractor registry:
+  core (bootstrap) = { URL_literal, PathRef_literal, PR_literal, Issue_literal, Commit_literal, SessionID_literal }
+                     -- semantic categories: URL_path group {URL_literal, PathRef_literal},
+                     --                      ExplicitRef group {PR_literal, Issue_literal, Commit_literal},
+                     --                      Citation group {SessionID_literal}  -- UUIDs as session citations
+                     -- each extractor declares the (source_namespace, claim_kind) it authorizes for entropy anchoring (Anamnesis-local canonical values, self-contained — NOT a shared cross-protocol vocabulary):
+                     --   URL_literal → (url, url_reference);      PathRef_literal → (fs_path, path_reference)
+                     --   PR_literal → (github_pr, pull_request); Issue_literal → (github_issue, issue);  Commit_literal → (git_commit, commit)
+                     --   SessionID_literal → (session, session_citation)
+  plugin           = { domain-specific extractors conforming to laws }
+```

--- a/anamnesis/skills/recollect/references/failure-modes.md
+++ b/anamnesis/skills/recollect/references/failure-modes.md
@@ -1,0 +1,48 @@
+# Failure modes — cause, detection, recovery
+
+Read when a scan returns zero candidates, when a recognized candidate is rejected despite a scan match, or when `INDEX_semantic` is empty. This is the operative body of the `── KNOWN FAILURE MODES ──` formal block: runtime-normative contract, not commentary. The mode names stay in `SKILL.md` so a mode is recognizable without a read; cause, detection, and recovery live here.
+
+```
+── KNOWN FAILURE MODES ──
+FalseAnchor       : extract(s) contains t with high precision but t ≠ recall_target
+                    -- cause: precision threshold locally calibrated but semantically wrong, or source_namespace does not authorize this recall claim's kind
+                    -- detection: Qc Recognize=false despite scan_entropy match
+
+ExtractorLacking  : recall_target ∈ s ∧ ∄ extractor_i : recall_target ∈ extractor_i(s)
+                    -- cause: domain-specific extractor absent from registry
+                    -- detection: NullMatch on scan_entropy ∧ user can cite literal
+
+PartialExtract    : extract/detect produces well-formed but semantically partial INDEX from corrupted/truncated source
+                    -- cause: continue-on-error parser tolerates malformed lines; anomalous shape logged but not write-gated
+                    -- detection: invisible to reader without schema version field or observability log surface
+
+SidechainNoSSOT   : scan_entropy(Store, trace) ≠ ∅ via INDEX_substitute ∧ no top-level SSOT for the recalled id (the id is a sidechain/derived record)
+                    -- cause: the recalled id is a sidechain/derived record whose turns live in the originating record + the substitute channel; no top-level SSOT for the id ever existed — distinct from NullMatch₁ (pre-store/lifecycle gap): here the scan SUCCEEDS on the substitute channel, only the top-level SSOT is absent by design
+                    -- detection: the recalled id matches a substitute-channel record with no sibling top-level SSOT of its own (substrate mechanism in TOOL GROUNDING)
+                    -- recovery: the id is not independently resumable (no top-level record of its own); read the orchestrating parent from the substitute record (backtrace_parent → parent_pointer, parent_cwd) and offer the parent as the resumable candidate; when the parent's record has aged out, mark non-resumable and surface the recoverable artifacts (substitute record + memory)
+
+NullMatch₁        : scan_entropy(Store, trace) = ∅ ∧ InputType = StructuredIdentifier
+                    -- cause: literal absent from SSOT/INDEX (pre-store, lifecycle gap)
+                    -- recovery: offer Aitesis handoff with accumulated trace
+
+NullMatch₂        : scan_salience(Store, trace) = ∅ ∧ InputType = NaturalRecall
+                    -- cause: profile too vague or target session lacks distinctive markers
+                    -- recovery: Socratic probe enrichment → Phase 1 re-scan
+
+MutualNull        : scan_entropy = ∅ ∧ scan_salience = ∅ on Track = hybrid
+                    -- structural risk: recall target genuinely absent from Store
+                    -- action: NullMatch pathway with full scope disclosure (principal failure mode)
+```
+
+## Degraded scan
+
+Read when `INDEX_semantic = ∅`. The `degraded_scan` equation and the partial-INDEX guard stay in `── STORE TOPOLOGY ──`, because the guard binds on every scan; what follows binds only once the fallback has fired.
+
+```
+degraded_scan rationale:
+  -- SSOT guarantees semantic recall; cold start falls back to SSOT directly. INDEX_substitute is a
+     separate primary channel (not derived from INDEX_semantic), so the sidechain/derived-id match
+     persists under degraded mode — SidechainNoSSOT stays reachable when INDEX_semantic is empty
+  -- INDEX_substitute loss non-recoverable (SSOT lacks subagent-channel messages); precondition for
+     the Cold-Start invariant
+```

--- a/anamnesis/skills/recollect/references/fork-resume.md
+++ b/anamnesis/skills/recollect/references/fork-resume.md
@@ -1,0 +1,23 @@
+# Fork/sidechain resume — detection, back-trace, and handle construction
+
+Read when a candidate carries `fork_marker = true`, or when `Candidate.cwd` is absent — the two cases where the plain `cd <cwd> && claude --resume <session_id>` handle does not apply. Carries the `── TOOL GROUNDING ──` substrate binding that sets `fork_marker` / `parent_pointer` / `parent_cwd`, and the four-branch handle rule both emission sites (Phase 2 `Resume`, Phase 3 `Recognize`) reach.
+
+## Substrate binding (Claude Code realization)
+
+```
+-- Fork/sidechain binding (SidechainNoSSOT): `Candidate.fork_marker = true` ⇐ the recalled id appears as an `agent_id` in INDEX_substitute ({config_dir}/projects/{slug}/hypomnesis/subagent/{agent_id}.jsonl, appended by the SubagentStop hook) AND has no sibling top-level SSOT {config_dir}/projects/{slug}/{agent_id}.jsonl of its own — the fork's turns live only in the parent record + this capture, so `claude --resume <agent_id>` has no transcript to resume
+-- Parent back-trace (`backtrace_parent` ↦ `Candidate.parent_pointer`, `Candidate.parent_cwd`): deterministic, not heuristic — the substitute capture entry records `session_id` = the orchestrating parent's session id (the SubagentStop payload field), so `parent_pointer ← capture.session_id` is a direct read. The capture lives under the parent's slug by construction ({slug} = dirname of the parent transcript), so the parent is always same-slug — look only there. Resumability: if the parent's top-level SSOT {config_dir}/projects/{slug}/{parent_pointer}.jsonl still exists, `parent_pointer` is set and `parent_cwd ← that transcript's `cwd` field` when present (`parent_cwd = Null` if the parent transcript predates cwd capture — parent identified but cwd unknown); the full handle `cd <parent_cwd> && claude --resume <parent_pointer>` requires both components. If the parent SSOT has aged out, `parent_pointer = parent_cwd = Null` (non-resumable → surface the capture's recoverable artifacts). The native subagent transcript (captured verbatim as the `agent_transcript_path` field) is not relied on as a resume handle; the durable parent link is the capture's `session_id`.
+```
+
+Being a realization binding, this section is non-normative with respect to the protocol essence — any substrate that can identify a fork's orchestrating parent from the fork's own record satisfies it.
+
+## Handle construction — the four branches
+
+The fork id is never a valid resume handle: a fork has no top-level transcript, so `--resume <fork_id>` fails. Build the handle from `parent_pointer` and `parent_cwd` instead:
+
+1. **`parent_pointer` and `parent_cwd` both present** — emit the parent's command, `cd <parent_cwd> && claude --resume <parent_pointer>`, and note that it resumes the orchestrating parent, not the fork.
+2. **`parent_pointer` present, `parent_cwd` absent** (parent identified, its cwd unknown) — omit the copy-paste command and surface the parent session id with a note to resume from the parent's own project directory.
+3. **`parent_pointer = Null`** (parent record aged out) — mark the candidate non-resumable and surface the recoverable artifacts (the substitute log path plus any memory) rather than a broken command.
+4. **Non-fork candidate with `Candidate.cwd` absent or empty** — omit the resume line and note the omission in the prose. This branch is reached from the same emission sites and is recorded here so the four cases read as one rule.
+
+Emit only the literal command, with no narrative wrapper; Claude Code resolves the project slug from the invocation cwd, so both components are required whenever a command is emitted at all.

--- a/anamnesis/skills/recollect/references/salience-track.md
+++ b/anamnesis/skills/recollect/references/salience-track.md
@@ -1,0 +1,21 @@
+# Salience track — marker detection and coinage
+
+Read when `Track = salience` or `Track = hybrid` — whenever `scan_salience` is about to run. This is the `── SALIENCE MARKERS ──` formal block: runtime-normative contract, not commentary.
+
+```
+── SALIENCE MARKERS ──
+detect : Session × DateAnchor? → MarkerProfile     -- DateAnchor? = optional ISO date for temporal normalization (e.g., session start)
+categories: { coinage, actor, temporal, emotional, cognitive, singularity }   -- working hypothesis (Emergent admitted)
+
+semantic invariants:
+  traceability:    detect(s) contains only markers grounded in SSOT session content or normalized from session-anchored context
+  boundedness:     ∀c ∈ categories, |detect(s).c| ≤ category_limit
+  stability:       repeated detect(s) under the same extractor version should preserve recall-relevant category intent, but exact set equality is not required (idempotence not claimed — LLM-extracted categories are non-deterministic; stability subsumes intent-level repeatability)
+  locality*:       detect is applied per session; cross-session comparison is ranking-layer only, except corpus-statistical coinage
+  monotonicity*:   adding content may refine, normalize, merge, or reject prior candidate markers; exact set inclusion is not guaranteed
+  -- Provisional invariant relaxation (exact laws → starred semantic invariants) justified by 88.5% noise rate in MarkerProfile.temporal corpus-wide audit (2026-05-04); the coinage formula below remains deterministic and is unaffected.
+
+coinage(s, corpus, θ) = { t ∈ s : salience_precision(t, s, corpus) ≥ θ }
+  where salience_precision(t, s, corpus) = |occ(t, s)| / (1 + |occ(t, corpus \ {s})|)
+  -- Zipf deviation: rare in corpus, repeated within session (low-frequency high-entropy)
+```


### PR DESCRIPTION
이슈 #693이 확정한 절단 기준 — **"이번 호출에서 이 갈래를 타는가"** — 의 첫 적용입니다. 대상은 `/recollect` 하나이고, 갈래 조건부 블록만 `references/`로 옮깁니다.

## 왜 이것부터인가 (Northstar)

> …**constraining AI attention without bias**, and resolving interaction deficits at their root within bounded loops **before local misalignment hardens into system-wide rework**.

자연어 회상으로 부른 호출에 `ENTROPY EXTRACTION`을 얹는 것은 타지 않을 갈래에 주의를 쓰는 것이다. 실제로 타는 갈래만 로드하는 것이 첫 절의 직접적 실현이다.

대안이었던 "중복 근거 제거 먼저"는 둘째 절이 막으라는 상태를 만든다. 같은 22개 규칙 위에서 서로 다른 세 방법이 미머지로 병렬 진행되는 상황 — #682(포인터화, Rule 8·22) / #683(산문 압축, Rule 9·16·17·20) / 근거→ledger — 이 "local misalignment hardens into system-wide rework"다. 그래서 이 PR은 **Rules 섹션을 한 줄도 건드리지 않는다.**

## Rule 20과의 관계 — 이 PR의 핵심 판단

`Rule 20`은 형식 블록이 "constitutive of protocol identity"이며 축약 실현도 "carries every one of them through as runtime contract"라고 한다. `── SUBSTRATE AGNOSTICISM ──`은 `ENTROPY EXTRACTION` / `SALIENCE MARKERS` / `STORE TOPOLOGY` / `KNOWN FAILURE MODES`를 프로토콜 essence로 열거한다. **essence 블록을 지연 로드로 옮기는 것이 Rule 20을 깨는가?**

깨지 않는다는 판단이고, 근거는 이렇다:

- `Track ∈ {entropy, salience, hybrid}`와 dispatch 바인딩(`InputType = … → Track = …`)은 본문에 남는다. 옮긴 것은 갈래별 법칙이고, 그 법칙은 해당 갈래를 타지 않는 호출에서는 애초에 구속하지 않는다.
- 법칙이 **구속력을 갖는 시점에 결정적으로 도달**하면 런타임 계약은 유지된다. 도달을 보장하는 것이 분기점의 지시문 포인터다.
- 세 블록의 헤더(`── ENTROPY EXTRACTION ──` 등)는 본문에 남겼다 — `SUBSTRATE AGNOSTICISM`이 그 이름들로 essence를 열거하므로, 헤더를 지우면 그 열거가 허공을 가리킨다.

따라서 **포인터 규율은 편의가 아니라 분할 하에서 프로토콜 동일성을 보존하는 장치**다. #693이 트리거 규율을 "선택 항목이 아니라 기준의 일부"로 기록한 이유가 여기서 드러난다. 포인터 없이 옮기면 로드 최적화가 아니라 동일성 위반이 된다.

`Rule 20` 자체는 건드리지 않았다. #683이 이미 다시 쓰고 있다.

## 옮긴 것

| 블록 | 발화 조건 | 목적지 |
|---|---|---|
| `ENTROPY EXTRACTION` 본체 | `InputType = StructuredIdentifier` | `references/entropy-track.md` |
| `SALIENCE MARKERS` 본체 | `InputType = NaturalRecall` | `references/salience-track.md` |
| `KNOWN FAILURE MODES` 원인·탐지·복구 | 해당 모드가 의심될 때 | `references/failure-modes.md` |
| fork/sidechain 실현부 + 4분기 핸들 규칙 | `fork_marker = true` 또는 `cwd` 부재 | `references/fork-resume.md` |
| `degraded_scan` 근거 | `INDEX_semantic = ∅` | `references/failure-modes.md` |

**남긴 것**: `SUBSTRATE AGNOSTICISM`(#693 예외), TYPES·FLOW·MORPHISM·PHASE TRANSITIONS·LOOP·CONVERGENCE·MODE STATE·COMPOSITION, 모든 dispatch 바인딩, 실패 모드 이름 + 발화 술어(읽지 않고도 모드를 알아보게), `degraded_scan` 등식과 partial-INDEX 가드, **Rules 22개 전부**.

## 포인터 — 9곳, 고아 0

각 포인터는 "see also"가 아니라 실행 모델이 행동에 옮기는 지시문이다. 예:

> Before running `scan_entropy`, read `references/entropy-track.md`: it types extract's laws, the precision threshold, and the compatible_anchor authorization that decides whether a literal match may anchor ranking at all. Anchoring a literal without that predicate is unbounded.

> When the candidate carries `fork_marker = true`, or when `Candidate.cwd` is absent or empty, **read `references/fork-resume.md` and build this field by the four-branch rule there before emitting anything.**

배치: TOOL GROUNDING(fork) / ENTROPY EXTRACTION / SALIENCE MARKERS(hybrid에서 양쪽 지목) / STORE TOPOLOGY(degraded) / KNOWN FAILURE MODES / Phase 1 step 1 / Phase 1 step 4 / Phase 2 `Resume` / Phase 3 `Recognize`.

Phase 2 `Resume`와 Phase 3 `Recognize`가 각각 통째로 쓰던 **4분기 fork 케이스 분석(185 + 258단어)이 한 벌로 합쳐졌다.** 두 자리 모두 같은 규칙에 도달한다.

## 실측 — 이득은 상용 경로 5%대다

| 경로 | 로드 단어 | 기준 대비 |
|---|---|---|
| salience, 실패·fork 없음 | 7,641 | **−5.8%** |
| entropy, 실패·fork 없음 | 7,698 | −5.1% |
| salience + 실패 모드 1건 | 8,147 | +0.4% |
| hybrid + fork + 실패 | 8,951 | **+10.3%** |

`SKILL.md` 508줄 / 8,115단어 → **461줄 / 7,408단어**.

블록 원본 크기가 시사한 것보다 이득이 작다. 포인터 지시문이 본문에서 약 180단어를 되찾아가고, 참조 파일마다 읽기 조건 줄이 붙기 때문이다. **실패 모드가 하나만 껴도 기준선으로 돌아오고, 최악 경로는 기준선보다 비싸다.** 그것이 이 기준이 하는 거래이고, 여기 그대로 적는다.

이 수치가 확정하는 것: recollect 무게의 63%(Protocol 산문 25% + Rules 17% + TYPES 11% + TOOL GROUNDING 10%)는 이 축이 닿지 않는다. 무거운 것은 한 설계 결정이 여러 블록에 되풀이 정당화되는 쪽이다 — `SingleObvious` 23줄, currency≠fidelity 9줄. 그 축은 `references/`가 아니라 ledger로 가고, #682·#683이 머지된 뒤 별도 패스로 다룬다.

## 검증

부모 세션에서 재현한 결과다 (실행기 보고를 그대로 채택하지 않음):

```
node .claude/skills/verify/scripts/static-checks.js .   → 147 pass / 0 fail / 0 warn
node --test scripts/package.test.js …                   → 81 pass / 0 fail
node scripts/package.js --dry-run                       → recollect.zip 1 → 5 files, 25,081 bytes
```

의미 폐쇄는 손으로 확인했다 — `AGENTS.md`가 정적 검사로 증명되지 않는다고 선언한 지점이라 자동 통과를 근거로 쓰지 않는다.

## 판단이 들어간 곳

- **`degraded_scan`은 지정 범위보다 덜 옮겼다.** "partial INDEX는 총 폴백을 트리거하지 않는다"는 줄은 *모든* 스캔에 구속하는 음의 가드다. 옮기면 정상 partial INDEX에서 총 폴백을 발동시킬 위험이 있어 본문에 뒀다. 여기 회수량이 다섯 항목 중 가장 작다(~55단어).
- **실패 모드 분할 기준은 역할이다** — 이름 + 발화 술어는 본문(읽지 않고 알아보기 위해), 원인·탐지·복구는 참조(모드가 의심된 뒤에만 구속).
- **`failure-modes.md`는 이름·술어를 본문과 중복해서 싣는다**(약 120단어). 참조를 단독으로 읽을 때 `-- cause:`가 붙을 대상이 필요해서다. 실패 경로에서만 발생하는 중복이고, 최악 경로 비용의 일부다.
- **hybrid 포인터는 두 파일을 지목한다.** 합집합 스캔이 두 계약을 다 구속하므로. "포인터 하나가 한 파일" 제약의 목적은 고아 방지와 모호성 제거이고, 명시적 이중 지목은 둘 다 만족한다.
- **한 줄은 이동이 아니라 추가다** — 실패 모드 헤더에 "Emergent admitted — the named modes are working hypotheses, not an exhaustive partition"을 넣었다. `.claude/rules/derived-principles.md` §Full Taxonomy Confirmation이 요구하는데 원본 블록에 없던 문장이다.

## 잔여 — 다음 패스 후보

`Rule 3`(line 427)이 `source_namespace × claim_kind` 호환성을 부르는데, 그 술어의 정의는 이제 `entropy-track.md`에 있다. Rules는 매 호출 로드되므로 salience 트랙에서는 정의 없이 용어만 보인다. 거기서 **구속하지는 않으므로**(entropy 트랙 랭킹만 지배) 폐쇄는 유지되지만, 옮긴 용어가 참조를 읽지 않는 경로에 남은 유일한 자리다. Rules가 범위 밖이라 손대지 않았다.

## 참조

- 기준: 이슈 #693
- 충돌 회피 대상: #682(Rule 8·22), #683(Rule 9·16·17·20) — 둘 다 미머지
- 허용 근거: `.claude/skills/verify/scripts/artifact-self-containment.js:76-94`(`references/`는 금지 목록에 없음), `scripts/package.js:176`(`CODEX_SUPPORT_DIRS`가 아카이브에 동봉)
- 옵션 집합 검토: 외부 자문(`gpt-5.6-sol`, reasoning high) 판정 — "GENUINE CHOICE, 단 제시된 옵션 집합이 잘못 세워짐". 자문이 붕괴시킨 것: 중복 제거 선행은 순서상 열등(fork가 두 축에 동시에 걸려 있어, 갈래 분리가 정본 자리를 먼저 정한다). 자문이 확인한 것: 의미 폐쇄 규약은 구조적 정렬을 요구하지 근거 산문 반복을 요구하지 않는다. 자문이 교정한 것: `SUBSTRATE AGNOSTICISM`을 포함한 12%는 과대 계상 — #693이 그 블록을 예외로 두므로 820단어 / 10.2%가 맞다.
