### PR TITLE
fix(aitesis): 소진 구별만 최소 복원 — 승격 아크 가드와 처분 권한

### DIFF
--- a/aitesis/.claude-plugin/plugin.json
+++ b/aitesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aitesis",
   "description": "Infer context insufficiency before execution \u2014 /inquire (\u03b1\u1f34\u03c4\u03b7\u03c3\u03b9\u03c2: a requesting)",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/aitesis/.codex-plugin/plugin.json
+++ b/aitesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aitesis",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Infer context insufficiency before execution — /inquire (αἴτησις: a requesting)",
   "author": {
     "name": "Jongwon Choi",

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -53,9 +53,7 @@ Uᵣ       = Context-resolved uncertainties (resolved during collection)
 Q        = Inquiry (Constitution interaction), ordered by information gain
 A        = User answer ∈ {Provide(context), Point(location), Dismiss, Unknown(Partial)}
              -- Unknown(Partial) = user declines certainty; Phase 3 auto-promotes via Cite-or-observe tiebreaker (UserTacit → next-preferred
-             -- untried EvidenceSource in ValidSources(v)) and re-enters Phase 1 for reclassification. When no untried valid source remains,
-             -- automatic promotion has no warranted move: the item stays in remaining and its disposition returns to the user at the next
-             -- Phase 2 — an item the evidence channels could not reach is not thereby dismissible on the user's behalf; arcs in PHASE TRANSITIONS
+             -- untried EvidenceSource in ValidSources(v)) and re-enters Phase 1 for reclassification; both arcs formalized in PHASE TRANSITIONS
 Ac         = User coherence classification ∈ CoherenceType     -- Phase 1 Qc gate answer type
 X'       = Updated prospect (context-enriched)
 InformedExecution = X' where remaining = ∅
@@ -166,8 +164,8 @@ Phase 1: Uᵢ → Step₁ Ctx(Uᵢ) → (Uᵢ', Uᵣ) →                    -- 
          [if Uₑ_candidates ≠ ∅] Step₄ EmpiricalObservation(Uₑ_candidates) → Uₑ  -- Step 4: dynamic evidence gathering [Tool]
 Phase 2: Qs(classify_result + Uₑ + Uᵢ''[cluster], framing) → Stop → A          -- uncertainty surfacing [Tool]; cluster = one coherent cluster (size ≤ 4)
 Phase 3: A → integrate(A, X) → X'                               -- prospect update (track: mutates Λ.X)
-         [if A = Unknown(Partial) ∧ some valid source for u is untried] auto_promote(u, next-preferred untried source in ValidSources(v)) → goto Phase 1  -- backward arc (T2): user declines certainty → re-enter classification with that source. The guard is what bounds the arc: a source already tried is not re-selected, so the automatic path runs out rather than cycling
-         [if A = Unknown(Partial) ∧ no valid source for u is untried] u stays in Λ.remaining → Phase 2  -- the arc has no target; automatic resolution is spent for u and Phase 2 discloses that, leaving the disposition to the user rather than resolving or dismissing it on their behalf
+         [if A = Unknown(Partial) ∧ some valid source for u is untried] auto_promote(u, next-preferred untried source in ValidSources(v)) → goto Phase 1  -- backward arc (T2): a tried source is not re-selected
+         [if A = Unknown(Partial) ∧ no valid source for u is untried] u stays in Λ.remaining → Phase 2  -- promotion has no target; disposition is the user's, not an AI dismissal
 
 ── LOOP ──
 After Phase 3: re-scan X' for remaining or newly emerged uncertainties.
@@ -175,7 +173,6 @@ New uncertainties accumulate into uncertainties (cumulative, never replace).
 If Uᵢ' remains: return to Phase 1 (collect context for new uncertainties).
 If remaining = ∅: proceed with execution.
 User can declare the context sufficient at Phase 2 (sufficiency_declared): the remaining uncertainties are dismissed with the declaration recorded and the loop converges, rather than exiting. User can exit at Phase 2 (early_exit).
-When automatic promotion is spent for an uncertainty, the loop does not terminate on that account: the item is surfaced as spent at Phase 2 and waits for the user's disposition — supplying or pointing to context re-enters Phase 1, Dismiss records the stated default, a sufficiency declaration converges, and Esc exits. Spent automatic reach is a disclosure, not a terminal.
 Continue until: informed(X') OR user ESC.
 Convergence evidence: At remaining = ∅, present transformation trace — for each u ∈ (Λ.context_resolved ∪ Λ.read_only_resolved ∪ Λ.empirically_observed ∪ Λ.user_responded), show (ContextInsufficient(u) → resolution(u)). Convergence is demonstrated, not asserted.
 On user ESC (EarlyExit, not InformedExecution): present the same partial transformation trace restricted to uncertainties already resolved, then declare `remaining` as explicit unresolved residual.
@@ -198,7 +195,7 @@ Phase 1 Qc      (constitution)        → present (conditional: Coherence 2D off
 Phase 2 Qs_emergent_channel (constitution) → present (specialization of Phase 2 Qs: channel unvalidated by definition; regardless of parent Verifiability, the classify summary records the observed channel description and awaits user confirmation before proceeding; confirmation rides the parent A coproduct — Point(location) designates/validates the authoritative channel, Provide(context) supersedes it, Dismiss declines it (proceed-with-assumption), Unknown(Partial) leaves the item unresolved — no answer auto-resolves the item through the unconfirmed channel; the answer is recorded in Λ.channel_validations — a channel already Point-validated this session skips this gate only (prior in-session user decision); each later item on that channel still takes the claim-specific Phase 1 evidence pass against the validated channel, per the Point(location) semantics (record location, resolve via next Phase 1 iteration) — never blanket-resolved as user-responded)
 Phase 2 Qs_staleness (constitution) → present (specialization of Phase 2 Qs: when staleness cannot be verified; require BOTH `staleness:unverified` tag — the temporal sub-case of the general `support_integrity:unverified` tag — AND classify summary surfacing — no silent escalation path; publishing authority claim warrants user awareness)
 Phase 1 Observe (transform)   → Write, Bash, Read (dynamic evidence gathering, Factual only); cleanup via Bash
-Phase 2 Qs      (constitution)        → present (mandatory: classify result + uncertainty surfacing; user provides context judgment on insufficiency; when automatic promotion is spent for an uncertainty, the classify summary states that — which channels the automatic path reached and that it holds no further move — so the user recognizes its reach instead of recalling it; the answer rides the A coproduct unchanged, no separate gate; Esc key → loop termination at LOOP level, not an Answer)
+Phase 2 Qs      (constitution)        → present (mandatory: classify result + uncertainty surfacing; user provides context judgment on insufficiency; an item whose promotion is spent is marked as such in the classify summary, so its reach is recognized rather than recalled; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3         (track)       → Internal state update
 converge     (extension)       → TextPresent+Proceed (convergence evidence trace; proceed with informed execution)
 sufficiency  (extension)       → TextPresent+Proceed (fires on sufficiency_declared: the user declares the context sufficient as a free response at any Phase 2. Every uncertainty still in Λ.remaining moves to Λ.dismissed carrying the declaration as its recorded reason, so remaining = ∅ and informed(X') holds — the run converges as InformedExecution, not as an exit. It is a free-response pathway rather than a peer option in the Phase 2 set because declaring the WHOLE inquiry sufficient produces no trajectory on the per-item axis those options occupy: it disposes of the axis instead of taking a position on it. Present the dismissed set with the declaration recorded against each, so the convergence trace shows what was accepted unresolved rather than asserting resolution)
@@ -451,7 +448,7 @@ After user response:
 1. **Provide(context)**: Integrate user-provided context into prospect `X'`
 2. **Point(location)**: Record location, resolve via next Phase 1 iteration
 3. **Dismiss**: Mark uncertainty as dismissed, note default assumption used
-4. **Unknown(Partial)**: Promote the uncertainty to the next-preferred untried EvidenceSource in `ValidSources(v)` and re-enter Phase 1 classification via the backward arc. When every valid source has been tried, promotion has no target: keep the uncertainty in `remaining` and state at the next Phase 2 that automatic resolution is spent for it, so the user disposes of it — do not dismiss it on their behalf
+4. **Unknown(Partial)**: Promote the uncertainty to the next-preferred untried EvidenceSource in `ValidSources(v)` and re-enter Phase 1 classification via the backward arc; when none is untried, keep it in `remaining` and mark it spent for the user to dispose of
 
 After integration:
 - Re-scan `X'` for remaining or newly emerged uncertainties

--- a/aitesis/skills/inquire/SKILL.md
+++ b/aitesis/skills/inquire/SKILL.md
@@ -53,7 +53,9 @@ Uᵣ       = Context-resolved uncertainties (resolved during collection)
 Q        = Inquiry (Constitution interaction), ordered by information gain
 A        = User answer ∈ {Provide(context), Point(location), Dismiss, Unknown(Partial)}
              -- Unknown(Partial) = user declines certainty; Phase 3 auto-promotes via Cite-or-observe tiebreaker (UserTacit → next-preferred
-             -- EvidenceSource in ValidSources(v)) and re-enters Phase 1 for reclassification; routing arc formalized in PHASE TRANSITIONS
+             -- untried EvidenceSource in ValidSources(v)) and re-enters Phase 1 for reclassification. When no untried valid source remains,
+             -- automatic promotion has no warranted move: the item stays in remaining and its disposition returns to the user at the next
+             -- Phase 2 — an item the evidence channels could not reach is not thereby dismissible on the user's behalf; arcs in PHASE TRANSITIONS
 Ac         = User coherence classification ∈ CoherenceType     -- Phase 1 Qc gate answer type
 X'       = Updated prospect (context-enriched)
 InformedExecution = X' where remaining = ∅
@@ -164,7 +166,8 @@ Phase 1: Uᵢ → Step₁ Ctx(Uᵢ) → (Uᵢ', Uᵣ) →                    -- 
          [if Uₑ_candidates ≠ ∅] Step₄ EmpiricalObservation(Uₑ_candidates) → Uₑ  -- Step 4: dynamic evidence gathering [Tool]
 Phase 2: Qs(classify_result + Uₑ + Uᵢ''[cluster], framing) → Stop → A          -- uncertainty surfacing [Tool]; cluster = one coherent cluster (size ≤ 4)
 Phase 3: A → integrate(A, X) → X'                               -- prospect update (track: mutates Λ.X)
-         [if A = Unknown(Partial)] auto_promote(uncertainty, next_source(ValidSources(v))) → goto Phase 1  -- backward arc (T2): user declines certainty → re-enter classification with next-preferred EvidenceSource
+         [if A = Unknown(Partial) ∧ some valid source for u is untried] auto_promote(u, next-preferred untried source in ValidSources(v)) → goto Phase 1  -- backward arc (T2): user declines certainty → re-enter classification with that source. The guard is what bounds the arc: a source already tried is not re-selected, so the automatic path runs out rather than cycling
+         [if A = Unknown(Partial) ∧ no valid source for u is untried] u stays in Λ.remaining → Phase 2  -- the arc has no target; automatic resolution is spent for u and Phase 2 discloses that, leaving the disposition to the user rather than resolving or dismissing it on their behalf
 
 ── LOOP ──
 After Phase 3: re-scan X' for remaining or newly emerged uncertainties.
@@ -172,6 +175,7 @@ New uncertainties accumulate into uncertainties (cumulative, never replace).
 If Uᵢ' remains: return to Phase 1 (collect context for new uncertainties).
 If remaining = ∅: proceed with execution.
 User can declare the context sufficient at Phase 2 (sufficiency_declared): the remaining uncertainties are dismissed with the declaration recorded and the loop converges, rather than exiting. User can exit at Phase 2 (early_exit).
+When automatic promotion is spent for an uncertainty, the loop does not terminate on that account: the item is surfaced as spent at Phase 2 and waits for the user's disposition — supplying or pointing to context re-enters Phase 1, Dismiss records the stated default, a sufficiency declaration converges, and Esc exits. Spent automatic reach is a disclosure, not a terminal.
 Continue until: informed(X') OR user ESC.
 Convergence evidence: At remaining = ∅, present transformation trace — for each u ∈ (Λ.context_resolved ∪ Λ.read_only_resolved ∪ Λ.empirically_observed ∪ Λ.user_responded), show (ContextInsufficient(u) → resolution(u)). Convergence is demonstrated, not asserted.
 On user ESC (EarlyExit, not InformedExecution): present the same partial transformation trace restricted to uncertainties already resolved, then declare `remaining` as explicit unresolved residual.
@@ -194,7 +198,7 @@ Phase 1 Qc      (constitution)        → present (conditional: Coherence 2D off
 Phase 2 Qs_emergent_channel (constitution) → present (specialization of Phase 2 Qs: channel unvalidated by definition; regardless of parent Verifiability, the classify summary records the observed channel description and awaits user confirmation before proceeding; confirmation rides the parent A coproduct — Point(location) designates/validates the authoritative channel, Provide(context) supersedes it, Dismiss declines it (proceed-with-assumption), Unknown(Partial) leaves the item unresolved — no answer auto-resolves the item through the unconfirmed channel; the answer is recorded in Λ.channel_validations — a channel already Point-validated this session skips this gate only (prior in-session user decision); each later item on that channel still takes the claim-specific Phase 1 evidence pass against the validated channel, per the Point(location) semantics (record location, resolve via next Phase 1 iteration) — never blanket-resolved as user-responded)
 Phase 2 Qs_staleness (constitution) → present (specialization of Phase 2 Qs: when staleness cannot be verified; require BOTH `staleness:unverified` tag — the temporal sub-case of the general `support_integrity:unverified` tag — AND classify summary surfacing — no silent escalation path; publishing authority claim warrants user awareness)
 Phase 1 Observe (transform)   → Write, Bash, Read (dynamic evidence gathering, Factual only); cleanup via Bash
-Phase 2 Qs      (constitution)        → present (mandatory: classify result + uncertainty surfacing; user provides context judgment on insufficiency; Esc key → loop termination at LOOP level, not an Answer)
+Phase 2 Qs      (constitution)        → present (mandatory: classify result + uncertainty surfacing; user provides context judgment on insufficiency; when automatic promotion is spent for an uncertainty, the classify summary states that — which channels the automatic path reached and that it holds no further move — so the user recognizes its reach instead of recalling it; the answer rides the A coproduct unchanged, no separate gate; Esc key → loop termination at LOOP level, not an Answer)
 Phase 3         (track)       → Internal state update
 converge     (extension)       → TextPresent+Proceed (convergence evidence trace; proceed with informed execution)
 sufficiency  (extension)       → TextPresent+Proceed (fires on sufficiency_declared: the user declares the context sufficient as a free response at any Phase 2. Every uncertainty still in Λ.remaining moves to Λ.dismissed carrying the declaration as its recorded reason, so remaining = ∅ and informed(X') holds — the run converges as InformedExecution, not as an exit. It is a free-response pathway rather than a peer option in the Phase 2 set because declaring the WHOLE inquiry sufficient produces no trajectory on the per-item axis those options occupy: it disposes of the axis instead of taking a position on it. Present the dismissed set with the declaration recorded against each, so the convergence trace shows what was accepted unresolved rather than asserting resolution)
@@ -447,7 +451,7 @@ After user response:
 1. **Provide(context)**: Integrate user-provided context into prospect `X'`
 2. **Point(location)**: Record location, resolve via next Phase 1 iteration
 3. **Dismiss**: Mark uncertainty as dismissed, note default assumption used
-4. **Unknown(Partial)**: Promote the uncertainty to the next-preferred EvidenceSource in `ValidSources(v)` and re-enter Phase 1 classification via the backward arc
+4. **Unknown(Partial)**: Promote the uncertainty to the next-preferred untried EvidenceSource in `ValidSources(v)` and re-enter Phase 1 classification via the backward arc. When every valid source has been tried, promotion has no target: keep the uncertainty in `remaining` and state at the next Phase 2 that automatic resolution is spent for it, so the user disposes of it — do not dismiss it on their behalf
 
 After integration:
 - Re-scan `X'` for remaining or newly emerged uncertainties


### PR DESCRIPTION
## 배경

PR #703(`d755f854`)이 aitesis의 승격 사다리 스캐폴딩을 철회했다. 그 철회 자체는 옳았다 — `base()`, `next_source()`, 하향 측도 µ, per-item 원장 `Λ.attempted_sources`, 전용 게이트 `Qs_ladder_spent`는 이미 구별된 미래에 알고리즘과 증명 증인을 공급하던 기계장치였다.

문제는 삭제 단위였다. 그 헝크 안에 증명 장치와 함께 **A2 권한 경계**가 동거하고 있었고, 문단 단위로 지우면서 구별도 같이 나갔다.

## 남아 있던 결함

- `PHASE TRANSITIONS`가 정의 없는 `next_source(ValidSources(v))`를 호출했다 — 정의는 `d755f854`에서 삭제되어 SKILL.md 어디에도 없었다.
- 자동 승격이 소진된 국면에서 프로토콜이 아무 규정도 갖지 않았다. 런타임이 재시도할지, 같은 게이트를 반복할지, 조용히 기각할지, 종료할지를 스스로 발명해야 하는 상태였다.

## 변경 범위

복원한 것은 **구별과 권한 경계뿐**이다. 기계장치는 되돌리지 않았다.

- **아크 가드** — 아직 시도하지 않은 유효 소스가 있을 때만 자동 승격.
- **소진 시 착지** — 항목은 `remaining`에 머물고 처분은 사용자 몫. 새 게이트 없이 기존 `A` 코프로덕트를 그대로 탄다.
- **종단 술어 불변** — `early_exit = user_esc` 유지. 소진은 종단이 아니라 표시다.

새 구성자·게이트·상태 필드·함수를 하나도 추가하지 않았고, `MODE STATE` 불변식도 그대로다. 구별의 정본 자리는 `PHASE TRANSITIONS`의 두 갈래이며, 다른 블록은 각자 층위에서 필요한 만큼만 둔다 — TYPES는 구성자 의미와 아크 참조, TOOL GROUNDING은 표시 의무(A1), Rules는 런타임 규범 컴파일.

## 두 번째 커밋: 자기 적용

첫 커밋(`e4297168`)은 하나의 구별을 다섯 블록에 서술했다. "remaining에 머문다"가 네 곳, "Phase 2가 표시한다"가 다섯 곳, "사용자 대신 기각하지 않는다"가 세 곳. 같은 엣지 케이스가 여러 형식 블록을 통해 반복되는 것은 이 스윕이 스캐폴딩 탐지 기준으로 쓰는 신호 그 자체다.

`98e66573`에서 정리했다.

- 블록 간 중복 서술 제거 — 정본 한 자리만 남김
- 증명 주석 제거 — "이미 시도한 소스는 재선택되지 않으므로 순환하지 않고 소진된다"는 가드가 왜 유계인지 설명하는 문장으로, 철회한 측도 µ와 같은 종류다
- LOOP의 네 처분 열거 제거 — 넷 모두 `A` 코프로덕트와 TOOL GROUNDING의 `sufficiency`·`esc`가 이미 정의하며, 소진이 종단이 아니라는 것은 종료 조건 목록에 소진이 없다는 사실로 이미 말해진다

줄 수: 508(복원 전) → 512(첫 커밋) → **509**. 510줄 가이드라인 경고 해소.

## 판단 기준

코덱스 자문(gpt-5.6-sol, xhigh)의 **반사실적 구별 테스트**를 따랐다.

> 절 하나를 지웠을 때, 서로 다른 허용 미래를 갖는 두 런타임 상태가 LLM에게 구별 불가능해지는가. 그렇다면 느린 계층. 그렇지 않고 이미 구별된 미래에 알고리즘·증명 증인·카운터·원장·재시도 예산만 공급한다면 스캐폴딩.

시맨틱 클로저 요구(`CLAUDE.md`)는 TYPES에 종료 증명을 새길 것을 함의하지 않는다. 형식 블록 전반에 걸쳐 충족되면 되고, 이번 변경은 타입·가드·상태 갱신·종료 경로·결과 방정식을 모두 기존 구조 안에서 닫는다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → 149 pass / 0 fail / 0 warn
- 미정의 심볼 잔존 확인: `next_source` / `sources_exhausted` / `attempted_sources` / `Qs_ladder_spent` 모두 0건
- 시맨틱 클로저 수동 점검: 새 조건이 기존 `Λ.remaining`으로 흡수되고 종단 술어가 불변임을 확인

## 범위 밖

이 PR은 aitesis 한 건만 담는다. 페이스 레이어링 스윕의 다음 대상(구조 신호 스캔 결과 proplasma가 60건으로 최다, 줄 수도 532줄로 22줄 초과)은 main에서 다시 컷해 별도 PR로 진행한다.
