### PR TITLE
feat(epistemic-cooperative): review-loop 완결성 스윕을 적용 패스의 필수 단계로 (4.17.0)

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -128,11 +128,15 @@ landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
    the loop adversarially scans each planned edit site before delegating — does the fix
    interact with adjacent code, break an invariant the finding did not mention, or recur
    at unswept sites? The scan compiles the self-contained fix brief: each fix
-   file:line-anchored with its verified basis and fix direction, plus any licensed
-   completeness-sweep predicate with its candidate sites enumerated at scan time — each
-   site semantically verified and risk-screened per site (Rule 6) before it enters the
-   brief; a site the writer discovers beyond the brief is returned for screening, never
-   written unbriefed.
+   file:line-anchored with its verified basis and fix direction, and — for every fix —
+   the predicate that fix instantiates, named explicitly, with that predicate's sites
+   enumerated across the artifact at scan time. Naming it is what makes the sweep below
+   runnable, so the slot is answered rather than left open: a fix whose predicate holds
+   at exactly one site records that as its answer, which is a different statement from
+   never having looked. Each enumerated site is semantically verified and risk-screened
+   per site (Rule 6) before it enters the brief; a site the writer discovers beyond the
+   brief is returned for screening, never written unbriefed. A brief carrying a fix whose
+   predicate is unnamed is incomplete and does not hand off.
 2. **Write on the low-cost tier**: hand the brief to a fresh subagent on the low-cost
    executor tier — a role, not a model name: the running harness's configuration (its
    tier registry or agent config) resolves the concrete model — the normal case, since
@@ -154,7 +158,7 @@ landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
    surface — the loop's own convergence check remains the final reviewer of the delegated
    writing.
 
-**Completeness sweep on apply.** When an applied fix instantiates a predicate or pattern that plausibly recurs across multiple sites in the artifact — a vocabulary rename, a guard that must hold at every mention of a symbol, a stale predicate repeated in several blocks — scan the artifact for all sites of that predicate and apply the fix consistently in the **same apply pass**, rather than waiting for later rounds to re-surface them piecemeal. **Over-reach guard**: verify each candidate site actually instantiates the same predicate (a semantic match, not a superficial string match) before applying, and risk-screen each swept site the same way — a swept edit is still an apply that lands, so Rule 6's risk screen applies per site, not only to the originally-flagged edit; sites swept beyond the originally-flagged one ride as relay annotations on the trace entry. The Phase 5 full re-review still catches any miss, so the sweep is an efficiency move, not a correctness dependency.
+**Completeness sweep on apply.** The predicate the scan named for each fix (Apply executor, step 1) is what this sweep ranges over. Where that predicate recurs across multiple sites in the artifact — a vocabulary rename, a guard that must hold at every mention of a symbol, a stale predicate repeated in several blocks — apply the fix consistently at every one of its sites in the **same apply pass**, rather than waiting for later rounds to re-surface them piecemeal. **Over-reach guard**: verify each candidate site actually instantiates the same predicate (a semantic match, not a superficial string match) before applying, and risk-screen each swept site the same way — a swept edit is still an apply that lands, so Rule 6's risk screen applies per site, not only to the originally-flagged edit; sites swept beyond the originally-flagged one ride as relay annotations on the trace entry. The sweep is a required step of the apply pass: an apply that closes the flagged site while leaving its predicate's remaining sites open has not completed, and the Phase 5 full re-review is the backstop for what a sweep missed rather than the reason to defer it. Closing the site the finding named while its predicate stays open is what returns the same defect at a sibling site next round, one round at a time.
 
 ## Phase 5: Re-review + Convergence
 
@@ -262,8 +266,15 @@ At exit — converged or free — surface each ledger entry with the durable hom
 5. **Verify before apply** — a finding that fails support-integrity or context-fit is dropped with its cited basis; only support-integrity-passing findings proceed to apply.
 6. **Risk screening gates risky applies regardless of class** — a Mechanical edit is still risk-screened before it lands; risk is orthogonal to the Mechanical/Judgment axis. The venue splits by substrate: destructive operations, external communication, and production mutation route to the harness permission layer; epistemic risk judgments surface as direct Constitution decisions in the loop.
 7. **Pass design intent upstream** — alongside the diff pointer, harvest the design intent already captured for the changed surface (the relevant `.claude/rules/*.md` + design-rationale sections of the project guide (`CLAUDE.md` or `AGENTS.md`), plus the design comments adjacent to the changed hunks) and pass it to the source as context, bounded to the changed files, as pointers not copied content. The source then pre-filters findings that an intentional documented choice already explains, so that refutation happens upstream in the review request rather than being re-derived in Phase 2 each round; Phase 2 verify remains the safety net for any intent-explained finding the source still surfaces. Documented intent pre-filters only findings whose objection is the choice itself — it never licenses suppressing a real defect the documented choice actually causes, which the source still flags. Because Phase 4 can grow the changed surface (completeness sweep or licensed scope expansion), the bundle is re-harvested for the current changed surface before each full re-review rather than frozen at the Phase 0 harvest. The bundle additionally folds in decisions constituted at this loop's own gates (the design-decision ledger) as its one copied element — session-constituted decisions have no repository location to point at, so each is conveyed as content with its constitutive basis — and conveys the project's mission anchor with an explicit severity-calibration steer (conventions are what the source checks against; the mission anchor is how it weighs severity). Conveyance boundary: design intent only — never fix-status records, do-not-reflag lists, or verdict-conditioning instructions; the source re-verifies fixed code fresh, and its verdict is its own.
-8. **Tiered apply with recurrence escalation** — the inherit-tier session adversarially
-   scans the change points and compiles the fix brief; a low-cost subagent writes the
+8. **Tiered apply with a required completeness sweep, and recurrence escalation** — the
+   inherit-tier session adversarially scans the change points and compiles the fix brief,
+   naming for every fix the predicate that fix instantiates and enumerating that
+   predicate's sites across the artifact; a brief whose fix carries an unnamed predicate
+   is incomplete and does not hand off, and a predicate holding at exactly one site is an
+   answered slot rather than an empty one. The sweep over those sites runs in the same
+   apply pass and is required for the apply to complete — the Phase 5 re-review is its
+   backstop, not its substitute — with each swept site semantically verified and
+   risk-screened per site (Rule 6). A low-cost subagent writes the
    fixes (fork only when context-bound; inline only for trivial batches or parent-held
    risky edits); the side-effect is verified before the Phase 5 re-review closes the
    loop. When fix-induced follow-up findings recur across consecutive rounds, the write

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -130,13 +130,10 @@ landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
    at unswept sites? The scan compiles the self-contained fix brief: each fix
    file:line-anchored with its verified basis and fix direction, and — for every fix —
    the predicate that fix instantiates, named explicitly, with that predicate's sites
-   enumerated across the artifact at scan time. Naming it is what makes the sweep below
-   runnable, so the slot is answered rather than left open: a fix whose predicate holds
-   at exactly one site records that as its answer, which is a different statement from
-   never having looked. Each enumerated site is semantically verified and risk-screened
-   per site (Rule 6) before it enters the brief; a site the writer discovers beyond the
-   brief is returned for screening, never written unbriefed. A brief carrying a fix whose
-   predicate is unnamed is incomplete and does not hand off.
+   enumerated across the artifact at scan time. Each enumerated site is semantically
+   verified and risk-screened per site (Rule 6) before it enters the brief; a site the
+   writer discovers beyond the brief is returned for screening, never written unbriefed.
+   A brief carrying a fix whose predicate is unnamed is incomplete and does not hand off.
 2. **Write on the low-cost tier**: hand the brief to a fresh subagent on the low-cost
    executor tier — a role, not a model name: the running harness's configuration (its
    tier registry or agent config) resolves the concrete model — the normal case, since
@@ -158,7 +155,7 @@ landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
    surface — the loop's own convergence check remains the final reviewer of the delegated
    writing.
 
-**Completeness sweep on apply.** The predicate the scan named for each fix (Apply executor, step 1) is what this sweep ranges over. Where that predicate recurs across multiple sites in the artifact — a vocabulary rename, a guard that must hold at every mention of a symbol, a stale predicate repeated in several blocks — apply the fix consistently at every one of its sites in the **same apply pass**, rather than waiting for later rounds to re-surface them piecemeal. **Over-reach guard**: verify each candidate site actually instantiates the same predicate (a semantic match, not a superficial string match) before applying, and risk-screen each swept site the same way — a swept edit is still an apply that lands, so Rule 6's risk screen applies per site, not only to the originally-flagged edit; sites swept beyond the originally-flagged one ride as relay annotations on the trace entry. The sweep is a required step of the apply pass: an apply that closes the flagged site while leaving its predicate's remaining sites open has not completed, and the Phase 5 full re-review is the backstop for what a sweep missed rather than the reason to defer it. Closing the site the finding named while its predicate stays open is what returns the same defect at a sibling site next round, one round at a time.
+**Completeness sweep on apply.** The predicate the scan named for each fix (Apply executor, step 1) is what this sweep ranges over. Where that predicate recurs across multiple sites in the artifact — a vocabulary rename, a guard that must hold at every mention of a symbol, a stale predicate repeated in several blocks — apply the fix consistently at every one of its sites in the **same apply pass**, rather than waiting for later rounds to re-surface them piecemeal. **Over-reach guard**: verify each candidate site actually instantiates the same predicate (a semantic match, not a superficial string match) before applying, and risk-screen each swept site the same way — a swept edit is still an apply that lands, so Rule 6's risk screen applies per site, not only to the originally-flagged edit; sites swept beyond the originally-flagged one ride as relay annotations on the trace entry. The sweep is a required step of the apply pass, and the Phase 5 full re-review is the backstop for what a sweep missed rather than the reason to defer it.
 
 ## Phase 5: Re-review + Convergence
 
@@ -270,11 +267,10 @@ At exit — converged or free — surface each ledger entry with the durable hom
    inherit-tier session adversarially scans the change points and compiles the fix brief,
    naming for every fix the predicate that fix instantiates and enumerating that
    predicate's sites across the artifact; a brief whose fix carries an unnamed predicate
-   is incomplete and does not hand off, and a predicate holding at exactly one site is an
-   answered slot rather than an empty one. The sweep over those sites runs in the same
-   apply pass and is required for the apply to complete — the Phase 5 re-review is its
-   backstop, not its substitute — with each swept site semantically verified and
-   risk-screened per site (Rule 6). A low-cost subagent writes the
+   is incomplete and does not hand off. The sweep over those sites runs in the same
+   apply pass — the Phase 5 re-review is its backstop, not its substitute — with each
+   swept site semantically verified and risk-screened per site (Rule 6). A low-cost
+   subagent writes the
    fixes (fork only when context-bound; inline only for trivial batches or parent-held
    risky edits); the side-effect is verified before the Phase 5 re-review closes the
    loop. When fix-induced follow-up findings recur across consecutive rounds, the write

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -124,7 +124,7 @@ The screening venue splits by substrate. When applying the edit is itself a subs
 **Apply executor (tiered).** Applying is execution, not judgment — the judgment already
 landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
 
-1. **Adversarial change-point scan (inherit tier, before handoff)**: the session driving
+1. **Adversarial change-point scan (inherit tier, before writing)**: the session driving
    the loop adversarially scans each planned edit site before delegating — does the fix
    interact with adjacent code, break an invariant the finding did not mention, or recur
    at unswept sites? The scan compiles the self-contained fix brief: each fix
@@ -133,7 +133,7 @@ landed at the Phase 3 gate and the risk screen. Split the apply by model tier:
    enumerated across the artifact at scan time. Each enumerated site is semantically
    verified and risk-screened per site (Rule 6) before it enters the brief; a site the
    writer discovers beyond the brief is returned for screening, never written unbriefed.
-   A brief carrying a fix whose predicate is unnamed is incomplete and does not hand off.
+   A fix whose predicate is unnamed is not written, on any tier.
 2. **Write on the low-cost tier**: hand the brief to a fresh subagent on the low-cost
    executor tier — a role, not a model name: the running harness's configuration (its
    tier registry or agent config) resolves the concrete model — the normal case, since
@@ -266,8 +266,8 @@ At exit — converged or free — surface each ledger entry with the durable hom
 8. **Tiered apply with a required completeness sweep, and recurrence escalation** — the
    inherit-tier session adversarially scans the change points and compiles the fix brief,
    naming for every fix the predicate that fix instantiates and enumerating that
-   predicate's sites across the artifact; a brief whose fix carries an unnamed predicate
-   is incomplete and does not hand off. The sweep over those sites runs in the same
+   predicate's sites across the artifact; a fix whose predicate is unnamed is not
+   written, on any tier. The sweep over those sites runs in the same
    apply pass — the Phase 5 re-review is its backstop, not its substitute — with each
    swept site semantically verified and risk-screened per site (Rule 6). A low-cost
    subagent writes the


### PR DESCRIPTION
## 무엇을

`review-loop`의 완결성 스윕을 "효율 조치, 정확성 의존 아님"에서 **적용 패스의 필수 단계**로 승격합니다. (4.16.0 → 4.17.0)

- **Phase 4 1단계 (적대적 변경점 스캔)** — 모든 수정에 대해 그 수정이 인스턴스화하는 **술어를 명시적으로 명명**하고 아티팩트 전체에서 그 술어의 자리를 열거합니다. 술어가 명명되지 않은 수정을 실은 브리프는 불완전하며 핸드오프하지 않습니다. 자리가 하나뿐인 술어는 빈 슬롯이 아니라 *답해진* 슬롯으로 기록됩니다 — 안 찾아본 것과 구별되어야 하기 때문입니다.
- **완결성 스윕** — 같은 적용 패스에서 그 자리 전부에 적용되며, 적용 완료 조건입니다. Phase 5 전체 재리뷰는 스윕이 놓친 것의 백스톱이지 스윕을 미룰 근거가 아닙니다. 과잉 도달 가드(의미적 일치 확인 + 자리별 위험 심사)는 그대로입니다.
- **Rule 8** — 위 두 가지를 컴파일합니다.

## 왜

PR #691 리뷰 루프 27라운드(6h44m) 실증에서 도출했습니다. 결함 7개 가족이 반복 재발했고, 각 수정 커밋은 그 라운드의 구체적 발현만 닫고 일반 불변식은 한 번도 봉합하지 않았습니다. 28개 커밋의 생 증감 합 약 +260/−230이 순증 +85/−32로 수렴합니다 — 대부분의 라운드가 앞 라운드 편집을 되돌리거나 옮겼다는 뜻입니다. 27라운드 중 커밋을 남기지 않은 유일한 라운드가 루프를 종료시켰습니다.

진단은 **「자리 봉합」**입니다: 지적은 한 자리로 도착하고 그 자리 뒤에 술어가 있는데, 수리는 자리를 닫고 술어는 닫지 않으며, 술어를 다음 라운드로 실어 나르는 통로 셋이 모두 막혀 있습니다. 그래서 라운드 수가 그 술어의 형제 자리 개수가 되고, 수렴이 봉합이 아니라 소진으로 옵니다.

전체 실측·대조군·기각한 대안은 커밋 메시지에 있습니다 (`84afc690`).

## 이 변경이 장식이 되지 않는 이유

이 조항은 **이미 존재했고 PR #691에서 8번 발화하지 않았습니다.** 선언 문장만 강화하면 산출 경로 없는 절이 됩니다. 그래서 변경을 이미 존재하는 산출 단계 — Phase 4 1단계의 스캔이 브리프를 컴파일하는 지점 — 에 얹었습니다. 명명이 브리프 완결 조건이므로, 스윕이 실행 가능해지는 지점과 실행이 요구되는 지점이 같은 곳에 있습니다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → fail 0 / warn 0
- 실제 검증 경로는 **다음 `/review-loop` 실행의 라운드 수**입니다. 줄지 않으면 보류해 둔 대안(Rule 9의 재발 동일성을 형제 자리까지 확장)으로 돌아갑니다.
