### PR TITLE
refactor(proplasma): 페이스 레이어링 — 구별의 층별 자리만 남기고 스캐폴딩 제거

### DIFF
--- a/proplasma/.claude-plugin/plugin.json
+++ b/proplasma/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "proplasma",
   "description": "Expose direction unknowns through divergent-discard instantiation before commitment — /preview (πρόπλασμα: a preliminary clay model)",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/proplasma/.codex-plugin/plugin.json
+++ b/proplasma/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "proplasma",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Expose direction unknowns through divergent-discard instantiation before commitment — /preview (πρόπλασμα: a preliminary clay model)",
   "author": {
     "name": "Jongwon Choi",

--- a/proplasma/skills/preview/SKILL.md
+++ b/proplasma/skills/preview/SKILL.md
@@ -14,20 +14,14 @@ Expose direction unknowns through divergent-discard instantiation before commitm
 ```
 ── FLOW ──
 Proplasma(X) → detect(X, route) →
-  [¬pre_commit(X) ∨ |direction_candidates(X)| < 2] requires_fail_relay → exit (checkpoint failed: state which
-    requirement; fewer than two candidates (one or none) is row ③ territory — /ideate (heuresis) diverges the thin field as the primary target; /frame · /elicit remain correct only for their own narrower cases (frame absent; substrate-implicit coordinates); not activated)
-  [futures recognizable from text] no_deficit_relay → exit (regular gate suffices; not activated)
-  [route ∈ {①, ②, ③}] route_away_relay(matched row) → exit (routed; not activated)
-  [a type guard fails (¬fake_data_sufficient ∨ ¬placeholder_fidelity) ∧ no routing row matches] unfit_relay → exit
-    (the deficit may be real but Proplasma cannot legitimately serve it: state the failed guard; the decision stays at a regular gate; not activated)
+  [¬pre_commit(X) ∨ |direction_candidates(X)| < 2] requires_fail_relay → exit (not activated)
+  [futures recognizable from text] no_deficit_relay → exit (not activated)
+  [route ∈ {①, ②, ③}] route_away_relay(matched row) → exit (not activated)
+  [a type guard fails (¬fake_data_sufficient ∨ ¬placeholder_fidelity) ∧ no routing row matches] unfit_relay → exit (not activated)
   derive_axes(X) → Axs → draft_policy → Qspec(Axs, policy, Tgt, tier) → S →
   [S = Adjust(revision)] revise → Qspec (re-present; still pre-generation)
   [at any Qspec circulation, either party: sharpened description makes the futures recognizable ∨ activation premise collapses]
-    dissolution: [Λ.probes ≠ ∅ (refan re-entry) → cleanup_verify first] → dissolution_relay → exit (DissolutionExit: deficit dissolved;
-      pre-generation circulation has Λ.probes = ∅ — the relay fires directly, nothing to clean;
-      enriched axes handed to a regular gate; any probe already generated is discarded with its disposition declared;
-      on a refan re-entry the pending re-fan target set — the user-authored composition, or the revised candidates —
-      is relayed as live candidates, never silently dropped)
+    dissolution: [Λ.probes ≠ ∅ (refan re-entry) → cleanup_verify first] → dissolution_relay → exit (DissolutionExit)
   [S = Approve] instantiate(∥ probes over Tgt, temp-isolated, cleanup-registered) →
   contrast(P, Axs) → (CM, EU, CC) → present(probe-first: probes → contrast map → unknowns) →
   Qdir → D →
@@ -36,22 +30,11 @@ Proplasma(X) → detect(X, route) →
     [Gs = Confirm] harvest(synthesized direction) → cleanup_verify → assemble → DirectionalContrast
     [Gs = Materialize] spec_gate_if_spec_revision → refan(composition) → contrast → present → Qdir
   [contrast_insufficient ∧ refan_budget > 0] spec_gate_if_spec_revision → refan(gap) → contrast → present → Qdir
-  [contrast_insufficient ∧ refan_budget = 0 ∧ refan_kind = Materialization ∧ ¬insufficiency_relayed] insufficiency_after_materialization_relay → Qdir (re-present over the accumulated probes; one-shot relay)
-  [contrast_insufficient ∧ refan_budget = 0 ∧ refan_kind = Materialization ∧ insufficiency_relayed] insufficiency_standdown_relay → cleanup_verify → exit (EarlyExit via insufficiency_standdown: an unchanged gate re-presented cannot progress — the contrast harvest is relayed as context to a regular gate)
+  [contrast_insufficient ∧ refan_budget = 0 ∧ refan_kind = Materialization ∧ ¬insufficiency_relayed] insufficiency_after_materialization_relay → Qdir (re-present over the accumulated probes)
+  [contrast_insufficient ∧ refan_budget = 0 ∧ refan_kind = Materialization ∧ insufficiency_relayed] insufficiency_standdown_relay → cleanup_verify → exit (EarlyExit via insufficiency_standdown)
   [contrast_insufficient ∧ refan_budget = 0 ∧ refan_kind = Gap] misdiagnosis_exit → cleanup_verify → route_away(MisdiagnosisRoute)
--- Materialize is a BUDGET-GUARDED constructor: it belongs to Qmicro's option set only while refan_budget > 0. With the budget spent,
---   Qmicro's defined option set IS {Confirm} and materialize_unavailable_relay states the exhaustion with its basis — a guarded
---   constructor absent from the option set is not option deletion, and no path can re-enter Materialize (termination guaranteed)
--- interrogation is a FREE-RESPONSE pathway at Qdir, not a D constructor: it commits no downstream action on the decision axis
--- refan_budget = 1 (shared): contrast-insufficiency re-fan and synthesis materialization draw from the SAME single budget
 -- spec_gate_if_spec_revision: a refan whose implication carries a spec revision — a NEW divergence axis, a realization-tier
---   escalation, or a revised probe target set — routes through Qspec BEFORE generation (breach condition 1; axes, tier,
---   and target set are spec-gate settings: none is revised past the gate)
--- dissolution is a SUCCESS stand-down (axis derivation itself sharpened the description until probes became unnecessary),
---   distinct from EarlyExit (user withdraws; residual) and MisdiagnosisExit (wrong deficit; rerouted)
--- cleanup_verify runs on EVERY protocol-controlled exit path: DirectionalContrast, EarlyExit (withdrawal),
---   MisdiagnosisExit, and a DissolutionExit reached on a refan re-entry (probes exist there); on the pre-generation
---   circulation nothing was generated, so the discard obligation is trivially declared
+--   escalation, or a revised probe target set — routes through Qspec BEFORE generation
 
 ── MORPHISM ──
 DirectionProspect
@@ -81,18 +64,12 @@ X   = DirectionProspect: a direction decision immediately before commitment (inp
         -- Input type: morphism processes X uniformly; enumeration scopes the definition, not behavioral dispatch
 DirectionAxis = a declared divergence axis — a direction unknown on which the probes must commit different values
 Axs = Set(DirectionAxis) settled at the spec gate (AI derives candidates; user settles — no axis is AI-selected past the gate)
-      -- extended ONLY via the inherited spec-gate duty: a refan carrying a new axis settles it at Qspec before generating
 Tgt = List(direction) — the probe target set settled at the spec gate: which directions get probes on this fan
       -- contrast fan (initial, or gap refan): Tgt ⊆ X.direction_candidates with |Tgt| ∈ 2..4. When |candidates| > 4,
-      --   Qspec settles WHICH candidates are probed (the cap is a presentation bound, not a silent truncation);
-      --   candidates left unprobed are declared at present so none is silently dropped, and they stay reachable at the
-      --   direction gate via free response: within the remaining re-fan budget, naming one triggers a gap refan over it
-      --   (target-set revision through the spec gate); with the budget spent, settling an unprobed candidate happens at a
-      --   regular gate — the protocol stands down as a withdrawal with the contrast harvest relayed as context (its future
-      --   was never materialized, so the morphism cannot claim it)
+      --   Qspec settles WHICH candidates are probed (the cap is a presentation bound, not a silent truncation)
       -- materialization refan: Tgt = [composition] — the user's own synthesis, materialized so they can see it;
-      --   |Tgt| ≥ 1 here, because a materialization is a recognition step, not a contrast (the composition is
-      --   contrasted against the ACCUMULATED probes, which already carry the differentiated axis values)
+      --   |Tgt| ≥ 1 here: the composition is contrasted against the ACCUMULATED probes, which already carry the
+      --   differentiated axis values
 DetectGuards (type guards, both required for activation):
   fake_data_sufficient : the direction contrast holds with placeholder concreta alone — no real evidence required
   placeholder_fidelity : placeholder concretization carries the differential futures on the divergence axes without distortion
@@ -114,141 +91,97 @@ CleanupAction = the concrete destruction step for artifact_ref (no-op for None; 
 ContrastMap = per-axis juxtaposition: for each axis ∈ Axs, the futures each probe exposes on that axis
 ExposedUnknown = a direction unknown newly exposed by the contrast (or recorded at an interrogation), tagged with its
                            DownstreamRoute at recording — the harvest inherits the tag, it does not attach it
-DownstreamRoute = Gap      -- a pre-commit check. It applies once the settled direction MATERIALIZES INTO A COMMITTED
-                           --   ACTION: /gap's activation predicate captures execution commitment, not direction
-                           --   commitment, so the handoff is stated at that boundary, not at the direction decision
+DownstreamRoute = Gap      -- a pre-commit check, handed off once the settled direction MATERIALIZES INTO A COMMITTED
+                           --   ACTION — not at the direction decision
                 | Inquire  -- a factual unknown needing real evidence (placeholders can never ground it)
 GroundTag = optional annotation ON THE CONSTITUTED DIRECTION (not an ExposedUnknown route): when the surviving
                            --   direction maps onto a familiar domain, it is tagged at harvest for /ground
                            --   structural-mapping validation; the tag rides Harvest.direction into
-                           --   DirectionalContrast.direction, so the proplasma→analogia handoff survives assembly
+                           --   DirectionalContrast.direction
 CommonCommitment = a design decision forced uniformly across ALL probes during instantiation (not on a divergence axis);
                    must be reported at present so the user does not mistake a shared premise for a divergence axis
 S  = Spec gate answer ∈ {Approve, Adjust(revision)}       -- Adjust revises axes/policy/target set/tier and re-presents; pre-generation
        -- on a MATERIALIZATION re-entry, Adjust revises the new axis, policy, or tier only: Tgt = [composition] is fixed
-       --   by the refan kind — a different target set is a different fan, which the spent budget does not cover
-       --   (the user can instead Confirm the standing synthesis or withdraw at the direction gate)
+       --   by the refan kind
 D  = Direction gate answer ∈ {Select(direction), Synthesize(composition)}
        -- Select: settle one probe-exposed direction — CONSTRAINED constructor: direction ∈ directions(Λ.probes);
        --   a response naming an UNPROBED candidate is never parsed as Select — it enters the unprobed-candidate
-       --   free-response pathway (probed first within budget, or stand-down), so no unmaterialized future can
-       --   converge as a DirectionalContrast
+       --   free-response pathway (probed first within budget, or stand-down)
        -- Synthesize: user composes/recombines the presented probes → opens micro-gate Gs
-       -- INTERROGATION IS NOT A PEER OPTION: questioning a probe commits no downstream action on the decision axis
-       --   (it answers or records, then returns to the same gate), so it carries no differential future and surfaces as a
-       --   free-response pathway declared in the pre-gate text — design-intent questions answered within placeholder
-       --   discipline, factual unknowns harvested as ExposedUnknown (route Inquire); the gate is re-presented unchanged
+       -- interrogation is NOT a D constructor: it settles no direction, and surfaces as a free-response pathway (Rule 8)
 Gs = Synthesis micro-gate answer ∈ {Confirm} ∪ {Materialize | refan_budget > 0}
        -- Confirm: settle the synthesized direction as-is, now
        -- Materialize: re-fan the synthesis into new probes (consumes the shared re-fan budget)
-       -- BUDGET-GUARDED CONSTRUCTOR: Materialize belongs to the option set only while refan_budget > 0. With the budget
-       --   spent, Qmicro's defined option set IS {Confirm} and materialize_unavailable_relay states the exhaustion with
-       --   its basis. The guard is part of the type, so a Materialize-free presentation is not option deletion — and no
-       --   path can re-enter Materialize with a spent budget, which is what makes the synthesis loop terminate
-       -- micro-gate exists because only the user can judge whether their synthesis is already recognized well enough
 UserDecision = the constituted direction: Select's direction, or the synthesis settled via Confirm (either way user-constituted)
 Disposition ∈ {FileDestroyed, NoFileArtifact, DiscardFailed(reason)}
   -- FileDestroyed: Path artifact removed and verified absent (satisfying condition for Mockup tier)
   -- NoFileArtifact: Vignette tier — nothing to destroy; discard = non-promotion, remnant text stays under the non-evidence stamp
   -- DiscardFailed: destruction attempted (with one retry) and still present; declared, never silent
 ProbeRef = minimal identity carrier { index: ℕ (ordinal in Λ.probes — uniqueness key), direction: String, artifact_ref: ArtifactRef }
-            -- what was destroyed and where it lived — axis values, probe content, and cleanup actions stay
-            --   session-local (Rule 10): the trace records the discard, not what the probe contained
+            -- what was destroyed and where it lived; axis values, probe content, and cleanup actions stay
+            --   session-local (Rule 10)
 DiscardTrace = List<(ProbeRef, Disposition)>  -- one entry per instantiated probe (re-fanned probes included)
 RefanKind ∈ {Gap, Materialization}   -- what the single shared budget was spent on; decides the still-insufficient branch
 Harvest = { direction: UserDecision (⊕ optional GroundTag), deciding_rows: ContrastMap, unknowns: Set(ExposedUnknown) }
-            -- recorded BEFORE discard; carries no discard_trace (the trace does not exist yet — cleanup produces it)
+            -- recorded BEFORE discard; carries no discard_trace — cleanup produces it
 DirectionalContrast = single record {                          -- terminal; single-record codomain (no bare plural)
                         contrast_map:     ContrastMap,         --   restricted to the DECIDING rows at harvest (Rule 10)
                         exposed_unknowns: Set(ExposedUnknown), --   each tagged with its DownstreamRoute
                         direction:        UserDecision (⊕ optional GroundTag),
                         discard_trace:    DiscardTrace }
-            -- ASSEMBLED after cleanup_verify: assemble(Harvest, DiscardTrace) → DirectionalContrast. Harvest precedes
-            --   discard; the record that carries both is built once the discard trace exists (no circular ordering)
+            -- ASSEMBLED after cleanup_verify: assemble(Harvest, DiscardTrace) → DirectionalContrast
 EarlyExit = user WITHDRAWAL at any gate — an explicit exit declared as a free response, a typed withdrawal the protocol
             acts on (side effects require explicit answer types, not tool-level escape): partial transformation trace
             over completed steps + cleanup_verify enforced + residual declared (direction NOT constituted)
-            -- a hard esc (tool-level escape that yields the protocol no turn) is ungraceful by nature: cleanup cannot
-            --   run there. Temp isolation's bounded scratch lifecycle is the backstop — part of why probes never live
-            --   outside it (breach condition 2 is what makes an uncaught esc safe)
 DissolutionExit = deficit dissolved during the Phase 1 circulation: deriving or settling the axes sharpened the description
             until the candidate futures became recognizable without probes, or the circulation collapsed the activation
-            premise itself (the fork proves false). Declared by either party; relayed with cited basis — the sharpened
-            axes ARE the evidence. The direction decision returns to a regular gate carrying the enriched axes. On the
-            pre-generation circulation no probe exists (phase < 2 guard) and discard is trivially declared; on a refan
-            re-entry probes already exist — cleanup_verify runs before the stand-down and their dispositions enter the
-            trace, and any exposed unknowns already recorded are relayed with their DownstreamRoutes (never silently
-            dropped), and the pending re-fan target set — the user-authored composition on a materialization re-entry,
-            the revised candidate set on a gap re-fan — is relayed as live candidates for that gate (a user-constituted
-            candidate never dies with the stand-down: it sits in Λ.tgt, not Λ.direction, so the relay must carry it).
-            A success stand-down: no unresolved residual remains — recorded unknowns are relayed with their routes
-            rather than lost, and the deficit itself needs no rerouting — description-sharpening resolved what
-            the protocol was invoked to materialize
+            premise itself (the fork proves false). Declared by either party. Payload: the sharpened axes as the cited
+            basis, any recorded unknowns with their DownstreamRoutes, and — on a refan re-entry — the per-probe
+            dispositions plus the pending re-fan target set (the user-authored composition on a materialization
+            re-entry, the revised candidate set on a gap re-fan) relayed as live candidates for the regular gate.
+            A success stand-down: no unresolved residual remains
 MisdiagnosisRoute = Row(① | ② | ③)   -- a sibling deficit matches: hand off to the cited protocol
                   | NoRow             -- NO row matches (the candidates may simply not genuinely diverge): declare the
                                       --   misdiagnosis with no downstream protocol and return the decision to a regular
                                       --   gate, residual declared. The exit is defined even when nothing downstream fits
 MisdiagnosisExit = refan_budget = 0 ∧ refan_kind = Gap ∧ contrast still insufficient: deficit misdiagnosis report
             + cleanup_verify enforced + route_away(MisdiagnosisRoute); no DirectionalContrast is emitted
-            -- scoped to a spent GAP refan. A budget spent on the user's own Materialization does NOT reach this exit:
-            --   the user already recognized the contrast well enough to synthesize from it, so the deficit was not
-            --   misdiagnosed — that branch relays back to Qdir over the accumulated probes instead
 contrast_insufficient = the presented contrast does not make the candidate futures recognizable on the settled axes
             -- declared by the user (free response at the direction gate — not a D constructor) or detected at contrast
             --   (an axis with no differentiated values across probes); either way surfaced, never silently self-repaired
-            -- an insufficiency rooted in realization fidelity (the tier could not carry the contrast — not a missing axis)
-            --   signals a tier escalation through the spec gate, not more probes at the same tier
-            -- the Materialization-exhaustion relay is ONE-SHOT (Λ.insufficiency_relayed): a repeated insufficiency at the
-            --   re-presented gate stands down as EarlyExit via insufficiency_standdown — re-presenting an unchanged gate
-            --   cannot progress, so the loop stays bounded; the contrast harvest is relayed as context to a regular gate
 
 ── PHASE TRANSITIONS ──
 Phase 0: X → detect(X) → route?                                -- deficit predicate + 4-step routing (silent analysis)
-       [¬pre_commit(X) ∨ |direction_candidates(X)| < 2] requires_fail_relay → exit  -- the MORPHISM requires-checkpoint,
-                                                                 --   typed: state the failed requirement; one or zero
-                                                                 --   candidates routes to row ③'s targets — /ideate
-                                                                 --   primary (diverge the thin field), /frame · /elicit
-                                                                 --   for their own narrower cases; not activated
+       [¬pre_commit(X) ∨ |direction_candidates(X)| < 2] requires_fail_relay → exit  -- the MORPHISM requires-checkpoint
        [futures recognizable from text] no_deficit_relay → exit  -- regular gate suffices; Proplasma not activated
-       [route ∈ {①, ②, ③}] route_away_relay(matched row) → exit -- cite the matched routing row; not activated
-       [a type guard fails ∧ no row matches] unfit_relay → exit  -- failed guard stated; decision stays at a regular
-                                                                 --   gate; not activated (the flow is total: no path
-                                                                 --   falls through to Phase 1 with a failed guard)
+       [route ∈ {①, ②, ③}] route_away_relay(matched row) → exit -- the matched routing row; not activated
+       [a type guard fails ∧ no row matches] unfit_relay → exit  -- decision stays at a regular gate; not activated
 Phase 1: derive_axes(X) → Axs_candidates → draft_policy → Qspec(axes + policy + probe target set + tier) → Stop → S  -- spec gate [Tool]
        [S = Adjust(revision)] revise(Λ) → re-present Qspec       -- pre-generation loop; no probe exists yet
        [S = Approve] settle(Λ.axes, Λ.policy, Λ.tgt, Λ.tier) → Phase 2
        [at any circulation, either party: futures recognizable from the sharpened description ∨ activation premise collapsed]
          [Λ.probes ≠ ∅ (refan re-entry) → cleanup_verify first] → dissolution_relay → DissolutionExit
-         -- pre-generation circulation (Λ.probes = ∅): the relay fires directly — the conditional guards only the cleanup step
-         (enriched axes handed to the regular gate; any already-generated probe is discarded with its disposition declared;
-          on a refan re-entry the pending re-fan target set — composition or revised candidates — is relayed as live candidates)
        -- free-response pathways at this gate, declared in the pre-gate text — none is an S constructor: a question is
        --   answered and the gate re-presented; a premise contest feeds the dissolution arm; a withdrawal runs
        --   cleanup_verify (when probes exist) and terminates as EarlyExit
        -- |X.direction_candidates| > 4: Qspec settles WHICH candidates are probed (Λ.tgt); unprobed candidates are declared at present
        -- ENTERED FROM A REFAN carrying a SPEC REVISION (Phase 3 or Phase 4) — a new divergence axis, a realization-tier
-       --   escalation, or a revised probe target set: Qspec is re-presented SCOPED TO THAT REVISION before any generation —
-       --   the inherited spec-gate duty, typed (axes, tier, and target set are spec-gate settings; none is revised past
-       --   the gate). A refan that revises nothing in the spec skips this and enters Phase 2 directly. No probe is ever
-       --   generated on an axis the user has not settled, nor at a tier the user has not settled
-       --   On a materialization re-entry Adjust cannot replace Λ.tgt: the target stays [composition] (fixed by Λ.refan_kind);
-       --   revising the target set into a new contrast fan is not covered by the spent budget
+       --   escalation, or a revised probe target set: Qspec is re-presented SCOPED TO THAT REVISION before any
+       --   generation. A refan that revises nothing in the spec skips this and enters Phase 2 directly
+       --   On a materialization re-entry Adjust cannot replace Λ.tgt: the target stays [composition] (fixed by Λ.refan_kind)
 Phase 2: instantiate(∥ over Λ.tgt, temp-isolated, cleanup-registered) → P → Λ.probes := Λ.probes ++ P  -- transform [Tool]
        [Mockup tier, conditional] instantiate_delegate(∥ one probe per agent, temp-isolated) [Tool]
        -- contrast fan (initial | gap refan): |P| ∈ 2..4 — one probe per target direction
        -- materialization refan: |P| ≥ 1 — the composition itself; it is contrasted against Λ.probes (cumulative), which
-       --   already carry the differentiated values on the PREVIOUSLY SETTLED axes, so a materialization needs no second
-       --   probe of its own. A NEW axis settled on this refan predates the prior probes: contrast re-derives their
-       --   positions on it analytically where their artifacts carry them, and declares the cell undifferentiated where
-       --   they do not — surfaced, never fabricated (a declared-undifferentiated axis can then feed the insufficiency arms)
-       -- each probe records its concretum at instantiation (Vignette: the narration text; Mockup: AtArtifact) —
-       --   the typed carrier present re-presents; presentation never regenerates a probe
+       --   already carry the differentiated values on the PREVIOUSLY SETTLED axes. A NEW axis settled on this refan
+       --   predates the prior probes: contrast re-derives their positions on it analytically where their artifacts
+       --   carry them, and declares the cell undifferentiated where they do not — surfaced, never fabricated
+       -- each probe records its concretum at instantiation (Vignette: the narration text; Mockup: AtArtifact)
        -- forced common design decisions recorded → Λ.common_commitments
 Phase 3: contrast(Λ.probes, Λ.axes) → (CM, EU, CC) → Λ.contrast_map := CM; Λ.exposed_unknowns ∪= EU;
          Λ.common_commitments := CC → present                       -- probe-first order: probes one by one → contrast map
          -- CC is RECOMPUTED over ALL accumulated probes at every contrast and REPLACES the set (:=, never ∪=):
-         --   a re-fan can break an earlier fan's shared premise, and a stale entry silently presented as shared
-         --   would corrupt the axis/premise distinction the declaration exists to protect
+         --   a re-fan can break an earlier fan's shared premise
                                                                   --   (with CommonCommitments declared) → new unknowns [Tool]
        [contrast_insufficient ∧ Λ.refan_budget > 0] refan(gap) → Λ.refan_kind := Gap → decrement budget
          → [spec revision: new axis ∨ tier escalation ∨ revised target set] Phase 1 (Qspec scoped to the revision —
@@ -257,8 +190,7 @@ Phase 3: contrast(Λ.probes, Λ.axes) → (CM, EU, CC) → Λ.contrast_map := CM
        [contrast_insufficient ∧ Λ.refan_budget = 0 ∧ Λ.refan_kind = Materialization ∧ ¬Λ.insufficiency_relayed]
          insufficiency_after_materialization_relay → Λ.insufficiency_relayed := True → Phase 4 (re-present Qdir over Λ.probes; one-shot)
        [contrast_insufficient ∧ Λ.refan_budget = 0 ∧ Λ.refan_kind = Materialization ∧ Λ.insufficiency_relayed]
-         insufficiency_standdown_relay → Phase 5 (EarlyExit arm via insufficiency_standdown — a withdrawal by consequence:
-           an unchanged gate re-presented cannot progress; the contrast harvest is relayed as context to a regular gate)
+         insufficiency_standdown_relay → Phase 5 (EarlyExit arm via insufficiency_standdown — a withdrawal by consequence)
        [contrast_insufficient ∧ Λ.refan_budget = 0 ∧ Λ.refan_kind = Gap] → Phase 5 (MisdiagnosisExit arm)
 Phase 4: Qdir(probe-exposed futures) → Stop → D                   -- direction gate [Tool]
        -- pre-gate text declares the free-response pathways: interrogate a probe, declare the contrast insufficient, or withdraw
@@ -269,8 +201,6 @@ Phase 4: Qdir(probe-exposed futures) → Stop → D                   -- directi
          [Gs = Materialize] refan(composition) → Λ.refan_kind := Materialization → Λ.tgt := [composition] → decrement budget
            → [spec revision: new axis ∨ tier escalation — a target-set revision cannot arise here: Tgt is fixed to
                [composition] by the refan kind] Phase 1 (Qspec scoped to the revision) | [no spec revision] Phase 2
-         -- Λ.refan_budget = 0: Materialize is not in Qmicro's option set (budget-guarded constructor);
-         --   materialize_unavailable_relay states the exhaustion and Qmicro presents {Confirm} → no path re-enters Materialize
        [free response: interrogation]                              -- not a D constructor; the gate is re-presented unchanged
          [design-intent] answer within placeholder discipline → re-present Qdir
          [factual unknown] record as ExposedUnknown (route: Inquire) → re-present Qdir
@@ -279,82 +209,56 @@ Phase 4: Qdir(probe-exposed futures) → Stop → D                   -- directi
          judged on ACCUMULATED probe coverage, not on Λ.tgt, which a materialization overwrites)]
          [Λ.refan_budget > 0] refan(gap over the named candidate) → Λ.refan_kind := Gap → decrement budget
            → Phase 1 (Qspec scoped to the revised target set) — the named candidate is probed before it is settled
-         [Λ.refan_budget = 0] stand_down_relay → unprobed_standdown → EarlyExit (a withdrawal by consequence: the choice
-           moved outside the materialized set; cleanup_verify runs, the decision returns to a regular gate with the
-           contrast harvest relayed as context — the morphism never claims an unmaterialized future)
+         [Λ.refan_budget = 0] stand_down_relay → cleanup_verify → unprobed_standdown → EarlyExit
+           (a withdrawal by consequence: the choice moved outside the materialized set)
 Phase 5: three entry arms; cleanup_verify runs on all of them, harvest only where a direction was constituted [Tool]
        [from Phase 4 — direction constituted] harvest → cleanup_verify → assemble → DirectionalContrast  -- harvest BEFORE discard
          harvest = (direction, deciding contrast rows, inherited unknowns with DownstreamRoutes) → Λ.harvest
          assemble(Λ.harvest, Λ.discard_trace) → the terminal record -- built after the trace exists; harvest carries no trace
-       [from Phase 3 misdiagnosis arm — no direction constituted; Harvest is unconstructible and is NOT attempted]
+       [from Phase 3 misdiagnosis arm — no direction constituted; Harvest is NOT attempted]
          misdiagnosis report (+ any exposed unknowns with their routes) → cleanup_verify → MisdiagnosisExit(route_away(MisdiagnosisRoute))
          [no row matches] route = NoRow → declare the misdiagnosis with no downstream protocol; the decision returns to a
            regular gate with the residual declared -- the exit is defined even when nothing downstream fits
        [user withdrawal at any gate, or a withdrawal by consequence (unprobed_standdown / insufficiency_standdown) —
          no direction constituted; Harvest is NOT attempted]
          partial transformation trace → cleanup_verify → EarlyExit (residual declared)
-         -- withdrawal is an explicit free-response exit the protocol acts on; a hard esc yields no turn, so cleanup
-         --   cannot run there — temp isolation's bounded scratch lifecycle is the backstop
        cleanup_verify (all arms): per probe, execute cleanup → verify absence → Disposition → Λ.discard_trace
          [DiscardFailed] retry once → still present → declare DiscardFailed(reason) in discard_trace (visible, never silent)
 
 ── LOOP ──
 Probe target set 2–4 for a contrast fan (settled at the spec gate; when candidates exceed 4, the gate settles which are probed).
 Re-fan bound: at most 1 re-fan per activation — contrast-insufficiency re-fan and synthesis materialization SHARE this
-  single budget (no separate budgets). What the budget was spent on decides the still-insufficient branch:
-  - spent on a GAP re-fan, contrast still insufficient → deficit misdiagnosis: report and hand off per the routing table
-    (MisdiagnosisExit; NoRow when nothing downstream fits), never fan again.
-  - spent on the user's own MATERIALIZATION, contrast still insufficient → NOT misdiagnosis: the user already recognized the
-    contrast well enough to synthesize from it. Relay the exhaustion and re-present the direction gate over the accumulated
-    probes — the standing synthesis is Selectable there (its probe now exists among the accumulated probes — a
-    type-preserving materialization of Select) and the original directions stay Selectable. A direction the
-    user has already recognized is never discarded by a budget rule. That re-presentation is ONE-SHOT: a repeated
-    insufficiency at the re-presented gate stands down as EarlyExit via insufficiency_standdown (cleanup runs; the
-    contrast harvest is relayed as context to a regular gate) — the loop never re-presents an unchanged gate twice.
-Materialize is budget-guarded: with the budget spent it is not in the micro-gate's option set, so the synthesis loop terminates.
+  single budget (no separate budgets), and what it was spent on decides the still-insufficient branch (Rule 9).
 Interrogation, contrast-insufficiency declaration, and Adjust do not consume the re-fan budget (they generate no probes).
 User can withdraw at any gate (an explicit exit, free response): EarlyExit — cleanup_verify runs; partial trace
-  presented; residual declared. A hard esc (tool-level escape) gives the protocol no turn: cleanup cannot run there,
-  and temp isolation's bounded scratch lifecycle is the backstop.
+  presented; residual declared.
 Continue until: DirectionalContrast (direction constituted + harvest recorded + discard declared) OR EarlyExit OR MisdiagnosisExit
   OR DissolutionExit (deficit dissolved in the spec-gate circulation — the cheapest success).
-Convergence evidence: at terminal, present the transformation trace over the steps actually completed. At
-  DirectionalContrast: each settled axis mapped to the contrast rows that made its futures recognizable, the constituted
-  direction, each exposed unknown with its downstream route, and the per-probe discard disposition. At DissolutionExit:
-  the sharpened axes and the dissolution basis (plus dispositions, any exposed unknowns with their routes, and the
-  pending re-fan target set relayed as live candidates when a refan re-entry had generated probes). At
-  EarlyExit / MisdiagnosisExit: the partial trace with the per-probe dispositions. Demonstrated, not asserted.
+Convergence evidence: at terminal, present the transformation trace over the steps actually completed — at
+  DirectionalContrast, each settled axis mapped to the contrast rows that made its futures recognizable, the constituted
+  direction, each exposed unknown with its downstream route, and the per-probe discard disposition; each other terminal
+  presents its own relay payload (TOOL GROUNDING). Demonstrated, not asserted.
 
 ── CONVERGENCE ──
 converged(Λ) = (Λ.direction ≠ None ∧ Λ.harvest ≠ None ∧ discard_declared(Λ))  -- primary success: DirectionalContrast
                                                                    --   (harvest recorded before discard — assemble needs it)
              ∨ (Λ.phase = 1 ∧ (futures_recognizable(sharpened description) ∨ premise_collapsed) ∧ discard_declared(Λ))
-                                                                   -- success stand-down: DissolutionExit — dissolution is
-                                                                   --   convergence (the deficit resolved), not abandonment;
-                                                                   --   EarlyExit / MisdiagnosisExit are non-convergent exits.
-                                                                   --   Dissolution emits the enriched axes, not a
-                                                                   --   DirectionalContrast: the advertised codomain is the
-                                                                   --   primary path's
+                                                                   -- success stand-down: DissolutionExit is convergent;
+                                                                   --   EarlyExit / MisdiagnosisExit are not
 discard_declared(Λ) = ∀ p ∈ Λ.probes: ∃ d: (ref(p), d) ∈ Λ.discard_trace   -- every probe has a declared Disposition,
                                                                    --   keyed by ref(p) = {index(p), p.direction,
-                                                                   --   p.artifact_ref}; the ordinal makes each probe's
-                                                                   --   entry distinct even when labels repeat
+                                                                   --   p.artifact_ref}
                                                                    --   (DiscardFailed is declared, not converged-silently)
 result equations:
   DirectionalContrast ⇔ Λ.direction ≠ None ∧ Λ.harvest ≠ None ∧ discard_declared(Λ)
-                        -- harvest is a convergence requirement: assemble(Λ.harvest, Λ.discard_trace) is undefined without
-                        --   it — a direction with discard declared but nothing harvested cannot emit the terminal record
   EarlyExit           ⇔ (user_withdraw ∨ unprobed_standdown ∨ insufficiency_standdown) ∧ discard_declared(Λ)
-                        -- non-convergent exit: withdrawal is the typed exit cleanup can act on; unprobed_standdown (budget-spent naming of an
-                        --   unprobed candidate) and insufficiency_standdown (repeated insufficiency at the re-presented gate
-                        --   with the budget spent on Materialization) are withdrawals by consequence — the user exits the
-                        --   materialized decision space; a hard esc yields no turn — the bounded scratch lifecycle is the backstop
+                        -- non-convergent exit; unprobed_standdown (budget-spent naming of an unprobed candidate) and
+                        --   insufficiency_standdown (repeated insufficiency at the re-presented gate with the budget spent
+                        --   on Materialization) are withdrawals by consequence — the user exits the materialized decision space
   MisdiagnosisExit    ⇔ Λ.refan_budget = 0 ∧ Λ.refan_kind = Gap ∧ contrast_insufficient ∧ discard_declared(Λ)
-                        -- non-convergent exit; a budget spent on Materialization does NOT reach it: that branch relays back to Qdir
-                        --   over the accumulated probes, where the direction is still constitutable
+                        -- non-convergent exit
   DissolutionExit     ⇔ Λ.phase = 1 ∧ (futures_recognizable(sharpened description) ∨ premise_collapsed) ∧ discard_declared(Λ)
-                        -- convergent success stand-down (see converged); pre-generation circulation: Λ.probes = ∅ and the obligation is trivially declared;
-                        --   refan re-entry: probes exist and cleanup_verify produces their dispositions first
+                        -- convergent success stand-down (see converged)
 framing readout: the surfaced state names the work in play (axes being settled, probes under contrast, direction being
   constituted, discard being verified) — never a completion tally.
 
@@ -376,14 +280,14 @@ Phase 2 instantiate_delegate (dispatch) → Agent (conditional, Mockup tier; par
 Phase 3 contrast (sense)           → Internal analysis (per-axis juxtaposition; CommonCommitment extraction)
 Phase 3 present (extension)        → TextPresent+Proceed (probe-first order: probes one by one, each from its typed concretum — the Vignette narration re-presented as instantiated, the Mockup artifact walked through, never regenerated at presentation → per-axis contrast map with common commitments declared → newly exposed unknowns; table-first re-abstracts and reproduces the deficit)
 Phase 4 Qdir (constitution)        → present (mandatory direction gate: each option points at the probe-exposed future it settles — recognition, not label simulation; presented as one concrete Select per probe-exposed direction (type-preserving materialization of the Select constructor) plus Synthesize. The free-response pathways — interrogate a probe, declare the contrast insufficient, withdraw — are declared in the pre-gate text, never as peer options: they commit no downstream action on the decision axis)
-Phase 4 Qmicro (constitution)      → present (conditional: fires on Synthesize; Confirm settles the synthesis now, Materialize re-fans it into new probes consuming the shared budget; only the user can judge whether the synthesis is already recognized. Materialize is budget-guarded: with the budget spent the defined option set is {Confirm} — the guard is in the type, so this is not option deletion)
+Phase 4 Qmicro (constitution)      → present (conditional: fires on Synthesize; Confirm settles the synthesis now, Materialize re-fans it into new probes consuming the shared budget; only the user can judge whether the synthesis is already recognized. Presents the option set currently defined by Gs — with the budget spent that set is {Confirm})
 Phase 4 interrogate_answer (extension) → TextPresent+Proceed (free-response pathway, not a gate option: design-intent answers within placeholder discipline; factual unknowns recorded as ExposedUnknowns with the Inquire route; the gate is re-presented unchanged)
-Phase 4 materialize_unavailable_relay (extension) → TextPresent+Proceed (Materialize requested with the shared re-fan budget spent: state the exhaustion with its basis; Qmicro presents {Confirm} — no option of the presented set is ever mutated, and no path re-enters Materialize)
-Phase 3 insufficiency_after_materialization_relay (extension) → TextPresent+Proceed (budget spent on the user's own materialization and the contrast is still insufficient: state it with its basis and re-present the direction gate over the accumulated probes — the standing synthesis is Selectable there, since its probe now exists among the accumulated probes (type-preserving materialization of Select), and the original directions stay Selectable; this is NOT deficit misdiagnosis. ONE-SHOT: Λ.insufficiency_relayed marks the firing — a repeated insufficiency at the re-presented gate routes to insufficiency_standdown_relay, never to a second unchanged re-presentation)
-Phase 3 insufficiency_standdown_relay (extension) → TextPresent+Proceed (repeated insufficiency at the re-presented gate with the budget spent on Materialization: state that the accumulated contrast cannot make the futures recognizable and no re-fan remains; relay the contrast harvest as context to the regular gate; cleanup_verify enforced; terminate as EarlyExit via insufficiency_standdown — a withdrawal by consequence, mirroring stand_down_relay)
+Phase 4 materialize_unavailable_relay (extension) → TextPresent+Proceed (Materialize requested with the shared re-fan budget spent: state the exhaustion with its basis; Qmicro presents {Confirm})
+Phase 3 insufficiency_after_materialization_relay (extension) → TextPresent+Proceed (budget spent on the user's own materialization and the contrast is still insufficient: state it with its basis and re-present the direction gate over the accumulated probes — the standing synthesis is Selectable there, since its probe now exists among the accumulated probes (type-preserving materialization of Select), and the original directions stay Selectable; one-shot, marked by Λ.insufficiency_relayed)
+Phase 3 insufficiency_standdown_relay (extension) → TextPresent+Proceed (repeated insufficiency at the re-presented gate with the budget spent on Materialization: state that the accumulated contrast cannot make the futures recognizable and no re-fan remains; relay the contrast harvest as context to the regular gate; cleanup_verify enforced; terminate as EarlyExit via insufficiency_standdown)
 Phase 5 harvest (track)            → Internal state update (direction, deciding contrast rows, routed unknowns recorded before discard; the discard trace does not exist yet)
 Phase 5 cleanup (transform)        → Bash (the DESTRUCTION step inside cleanup_verify's typed sequence — per-probe artifact destruction, retry once on failure; every transition that names cleanup_verify runs this step first)
-Phase 5 cleanup_verify (observe)   → Bash, Read (the VERIFICATION step closing the same sequence: verify absence of each Path artifact after its destruction step; Disposition recorded per probe — verification never runs without the destruction step preceding it)
+Phase 5 cleanup_verify (observe)   → Bash, Read (the VERIFICATION step closing the same sequence: verify absence of each Path artifact after its destruction step; Disposition recorded per probe)
 Phase 5 assemble (track)           → Internal state update (terminal record built from the harvest and the completed discard trace — after cleanup, never before)
 converge (extension)               → TextPresent+Proceed (transformation trace: axes → deciding contrast rows → direction; unknowns with routes; per-probe discard disposition)
 withdraw (extension)               → TextPresent+Proceed (explicit free-response exit: partial transformation trace + residual declaration; cleanup_verify enforced; terminate as EarlyExit. A hard esc — tool-level escape — yields no turn, so cleanup cannot run: temp isolation's bounded scratch lifecycle is the backstop)
@@ -403,7 +307,6 @@ seam (extension)                    → TextPresent+Proceed (fires at deactivati
       refan_budget: ℕ,                         -- init 1; decremented by refan (insufficiency or materialization, shared)
       refan_kind: Option(RefanKind),           -- what the budget was spent on; None until the single refan is taken
       insufficiency_relayed: Bool,             -- init False; set when insufficiency_after_materialization_relay fires
-                                               --   (one-shot relay: a repeated insufficiency stands down)
       direction: Option(UserDecision),
       harvest: Option(Harvest),                -- recorded before discard; carries no discard trace
       discard_trace: DiscardTrace,             -- one entry per probe by terminal (invariant: discard_declared)
@@ -413,7 +316,7 @@ seam (extension)                    → TextPresent+Proceed (fires at deactivati
 --   a refan re-entry to Phase 1 HOLDS prior probes but generates nothing until its Qspec settles the revision
 --   (new axis, tier escalation, or revised target set)
 -- Guard: ∀ a ∈ axes: settled_at_Qspec(a) — a refan carrying a new axis re-enters Phase 1 before generating (breach condition 1)
--- Guard: Materialize ∉ presented(Qmicro) when refan_budget = 0 — budget-guarded constructor; no path re-enters it (termination)
+-- Guard: Materialize ∉ presented(Qmicro) when refan_budget = 0 — budget-guarded constructor
 -- Guard: ∀ p ∈ probes: p.artifact_ref = None ∨ temp_isolated(p.artifact_ref) (no permanent project file, ever)
 -- Guard at terminal: discard_declared(Λ) — every probe carries a declared Disposition
 
@@ -459,7 +362,7 @@ Surface shapes of the deficit (heuristic signals, not hard gates): a **principle
 
 ### Mode Deactivation
 
-Deactivates on any of four triggers. Direction constituted + harvest recorded + discard disposition declared (destruction verified, or its failure declared with handoff) emits DirectionalContrast, and the commitment proceeds under the constituted direction. The deficit dissolving in the spec-gate circulation (axes alone made the futures recognizable, or the activation premise collapsed) emits DissolutionExit: relay the basis, hand the enriched axes to a regular gate — a success stand-down; on a refan re-entry, already-generated probes are discarded with dispositions declared and the pending re-fan target set (the user-authored composition, or the revised candidates) is relayed as live candidates. A gap re-fan spent with the contrast still insufficient emits MisdiagnosisExit: misdiagnosis report + cleanup + routing handoff (①–③, or none when no row fits — the decision returns to a regular gate). A user withdrawal at any gate (explicit exit; a hard esc gives no turn — the bounded scratch lifecycle is the backstop), or a stand-down by consequence (an unprobed candidate named with the budget spent, or a repeated insufficiency at the re-presented gate), emits EarlyExit: partial trace + cleanup enforced + residual declared — with the contrast harvest relayed as context.
+Deactivates on any of four triggers. Direction constituted + harvest recorded + discard disposition declared emits **DirectionalContrast**, and the commitment proceeds under the constituted direction. The deficit dissolving in the spec-gate circulation (axes alone made the futures recognizable, or the activation premise collapsed) emits **DissolutionExit** — a success stand-down. A gap re-fan spent with the contrast still insufficient emits **MisdiagnosisExit**. A user withdrawal at any gate, or a stand-down by consequence (an unprobed candidate named with the budget spent, or a repeated insufficiency at the re-presented gate), emits **EarlyExit**. Each terminal's relay payload is in TOOL GROUNDING; cleanup runs on all four.
 
 ## Protocol
 
@@ -519,9 +422,9 @@ Every safeguard here is enforced by a numbered Rule or a formal-block invariant,
 6. **Probe-first presentation**: probes one at a time, then the per-axis contrast map, then new unknowns. A table placed first re-abstracts the concreta and reproduces the deficit in the presentation order. Each probe is presented from the concretum recorded at instantiation — the vignette narration re-presented as generated, the Mockup artifact walked through — never re-narrated from memory.
 7. **Common commitments declared**: design decisions forced uniformly across probes during instantiation are reported with the contrast map, so shared premises are never mistaken for divergence axes.
 8. **Direction-gate response discipline**: the gate offers two options — Select settles a probe-exposed direction (a constrained constructor: naming an unprobed candidate parses into the unprobed-candidate pathway, never as a Select); Synthesize opens the micro-gate (Confirm now vs Materialize as re-fan) because only the user can judge whether their synthesis is already recognized. Questioning a probe, declaring the contrast insufficient, and stepping out are **free-response pathways named in the pre-gate text, never peer options**: none of them settles a direction, so none carries a differential future. A design-intent question is answered within placeholder discipline; a factual unknown is recorded and routed to `/inquire`; an analogy request is answered as commentary that declares which axis the borrowed domain weights, never as contrast material; the gate then returns unchanged. Downstream routes for harvested unknowns: a pre-commit check goes to `/gap` at the point the direction becomes a committed action (that is where `/gap` activates — it does not act on direction commitments), a factual unknown to `/inquire`, and the constituted direction to `/ground` when it maps onto a familiar domain worth validating — a tag on the harvested direction itself, not an unknown.
-9. **One shared re-fan, and what it was spent on decides the ending**: contrast-insufficiency re-fan and synthesis materialization share a single re-fan. Materialize is offered only while the budget is live, so the synthesis path cannot loop. When the budget is spent and the contrast is still insufficient: if it went on a **gap** re-fan, the deficit was misdiagnosed — report it and hand off per the routing table (and when no row fits, say so plainly and return the decision to a regular gate). If it went on the user's **own materialization**, the deficit was not misdiagnosed — they recognized the contrast well enough to build on it — so re-present the direction gate over the probes already on the table. A direction the user has already recognized is never thrown away by a budget rule. That re-presentation is one-shot: a repeated insufficiency at the re-presented gate stands down as an early exit — cleanup runs and the decision returns to a regular gate with the contrast relayed as context — never a second unchanged re-presentation.
+9. **One shared re-fan, and what it was spent on decides the ending**: contrast-insufficiency re-fan and synthesis materialization share a single re-fan. When the budget is spent and the contrast is still insufficient: if it went on a **gap** re-fan, the deficit was misdiagnosed — report it and hand off per the routing table (and when no row fits, say so plainly and return the decision to a regular gate). If it went on the user's **own materialization**, the deficit was not misdiagnosed — they recognized the contrast well enough to build on it — so re-present the direction gate over the probes already on the table. A direction the user has already recognized is never thrown away by a budget rule. That re-presentation is one-shot: a repeated insufficiency at the re-presented gate stands down as an early exit — cleanup runs and the decision returns to a regular gate with the contrast relayed as context.
 10. **Harvest before discard**: harvest the direction, the deciding contrast rows only, and the routed unknowns — then discard, then assemble the record from the harvest and the completed discard trace. The trace is not part of the harvest; cleanup is what produces it. The durable record keeps the direction decision only; probe detail stays session-local.
-11. **Cleanup on every protocol-controlled exit path**: DirectionalContrast, EarlyExit (withdrawal), MisdiagnosisExit, and a DissolutionExit reached after generation all run cleanup verification; every probe carries a declared Disposition; a failed destruction is retried once and then declared with a manual-cleanup handoff, never silent. A hard esc — a tool-level escape that gives the protocol no turn — cannot run cleanup by nature; temp isolation's bounded scratch lifecycle is the backstop there, which is part of why probes never live outside it.
+11. **Cleanup on every protocol-controlled exit path**: DirectionalContrast, EarlyExit (withdrawal), MisdiagnosisExit, and a DissolutionExit reached after generation all run cleanup verification; every probe carries a declared Disposition; a failed destruction is retried once and then declared with a manual-cleanup handoff, never silent.
 12. **Convergence persistence, with the cheapest success honored**: the mode stays active until the direction is constituted, the harvest recorded, and the discard declared, or the user exits, or misdiagnosis is declared — or the deficit dissolves in the spec-gate circulation: axis derivation is itself description-sharpening, and when the sharpened description alone makes the futures recognizable (or collapses the activation premise), the protocol stands down as a success with the basis stated and the enriched axes handed back (on a refan re-entry, together with the per-probe dispositions and the pending re-fan target set — a user-authored composition is never lost to the stand-down). Convergence is demonstrated via the transformation trace, not asserted. Actually removing a stuck artifact is the environment's job — the protocol's own duty ends at the declared disposition and the manual-cleanup handoff; a constituted direction is never held hostage to a janitorial failure.
 13. **Context-Question Separation**: analysis, evidence, and the contrast presentation are text output before each gate; the gate contains the essential question and option-specific differential implications only.
 14. **Option-set relay test (Extension classification)**: a single dominant option (entropy → 0) is presented as relay with cited basis. Each Constitution option must be genuinely viable under different user value weightings; shared-trajectory options collapse to one; off-axis prompts surface as free-response pathways rather than peer options.


### PR DESCRIPTION
## 배경

페이스 레이어링 스윕의 2번째 대상. 1번째(aitesis)는 #704로 머지됐다. proplasma는 구조 신호 스캔에서 60건으로 최다(2위 analogia 30)이고 532줄로 510줄 가이드라인을 22줄 넘고 있었다. 선정 근거는 크기가 아니라 신호 밀도다.

## 이번 대상이 #704와 달랐던 점

aitesis는 **삭제된 정의를 되살리는** 문제였다. #703이 문단 단위로 지우면서 승격 사다리의 증명 장치와 함께 A2 권한 경계까지 가져갔고, #704가 구별만 최소 복원했다.

proplasma는 반대였다. 구별이 부족한 게 아니라 **같은 구별이 층마다 다시 논증되고** 있었다. 그래서 위험이 뒤집힌다 — 잘라서 구별을 잃는 게 아니라, 어느 반복이 실제로 그 층의 유일한 자리인지 오판해서 잘라내는 쪽이다.

편집 전 측정한 중복 분포:

| 구별 | 서술된 블록 수 | 붙어 있던 증명 문장 |
|---|---|---|
| 예산이 남아 있을 때만 재생성 선택지가 존재 | 6 | "종료 보장", "루프가 끝난다", "선택지 삭제가 아니다" |
| 불충분 재표시는 1회뿐 | 7 | "루프가 유계로 남는다", "같은 게이트를 두 번 다시 열지 않는다" |
| 모든 종료 경로에서 정리가 돈다 | 9 | (열거 자체의 반복) |
| 강제 종료는 턴을 주지 않아 정리 불가 | 6 | — |
| 미탐침 후보는 선택으로 파싱되지 않음 | 5 | — |
| 해소 종료가 대기 중인 대상 집합을 넘긴다 | 7 | — |
| 국소 증명 주석 | 5곳 | "순환 없음", "흐름이 전역적", "서수가 항목을 구별한다" |

## 판단 기준

#704의 반사실적 구별 테스트를 그대로 쓰되, 이번에 실제로 필요했던 것은 그 테스트가 아니라 **중복의 경계선**이었다. 자문(gpt-5.6-sol, xhigh)이 세운 선:

> 두 번째 블록이 같은 구별을 다시 적을 수 있는 것은 **그 블록 고유의 의무로 번역할 때뿐** — 생성자 정의역, 상태 전이, 기억되는 상태, 종단 방정식, 표시 의무, 명령형 규칙. 시나리오를 다시 서술하거나 왜 종료하는지 설명하면 스캐폴딩.

즉 #704가 말한 "정본 한 자리"는 *전역적으로 한 번만 언급*이 아니라 **독립적으로 필요한 의미 의무마다 한 번**이다.

## 제거한 것

- **종료 증명 witness 전부** — "termination guaranteed", "so the loop terminates", "cannot loop", "stays bounded", "never a second unchanged re-presentation", 반복되던 "not option deletion" 방어
- **국소 증명 주석** — "no circular ordering", "the flow is total", 서수가 항목을 구별한다는 설명, harvest 없이는 assemble이 미정의라는 설명, MisdiagnosisExit이 Materialization을 배제한다는 재논증
- **블록 간 시나리오 재서술** — FLOW의 정리·해소·예산 해설 묶음, LOOP의 두 분기 재서술, CONVERGENCE의 해소 2상태 증명, Mode Deactivation의 종단별 payload 열거

## 보존한 것 — 자문이 지목한 파괴 위험 5건

후보 집합을 그대로 실행했으면 잘려나갔을 구별들이다.

1. **미탐침 판정은 누적 탐침 기준**이지 `Λ.tgt` 기준이 아니다 — materialization이 tgt를 덮어쓰기 때문에 tgt로 판정하면 이미 탐침된 후보가 미탐침으로 오분류된다.
2. **첫 materialization 불충분은 누적 집합 위에서 재표시**한다 — 사용자의 합성이 이제 탐침으로 존재하므로 선택 가능해진다. 분기 내용이지 유계성 증명이 아니다.
3. **해소 종료의 두 정리 상태** — 생성 전 순환은 공허 충족, 재진입은 처분을 실제로 생산해야 한다. Phase 1의 조건부 정리를 지웠으면 의미 폐포에 구멍이 났다.
4. **DiscardFailed는 종단 처분을 여전히 충족**한다 — 정리 실패가 구성된 방향을 인질로 잡지 않고 수동 정리 인계로 가시화된다.
5. **미탐침 스탠드다운은 Phase 5 화살표를 우회**하므로 그 자리의 정리 호출이 `discard_declared`의 **유일한 생산자**다. 지웠으면 `EarlyExit` 결과 방정식이 요구하는 조건을 아무도 만들지 않는 상태가 됐다 — 정적 검사는 통과했을 것이다. 이번에 화살표(`stand_down_relay → cleanup_verify → unprobed_standdown`)로 명시화했다.

## 경계 판정 3건

- **`refan_budget: ℕ`** — 값이 1과 0뿐인 카운터라 표현 자체는 스캐폴딩에 가깝다. 하지만 붕괴시키면 상태 타입·가드·갱신·종단 술어가 함께 바뀌는 재설계이므로 제거 스윕의 범위 밖. 초기화 1과 감산에서 파생된 *증명*만 잘랐다.
- **`refan_kind`** — 원장처럼 보이지만 감사 기록이 아니라 살아 있는 제어 판별자다. Gap이면 오진단 종료, Materialization이면 1회성 재표시 — 지우면 서로 다른 허용 미래를 갖는 두 상태가 구별 불가능해진다. 느린 계층으로 유지.
- **강제 종료** — 실재하는 실현 경계지만 프로토콜의 전이 체계 밖이다(턴이 없으면 어떤 전이도 발화하지 않는다). TOOL GROUNDING(턴 없음 사실)과 Rule 4(스크래치 수명 백스톱) 두 자리만 남기고 TYPES·PHASE·LOOP·Mode Deactivation·Rule 11에서 제거.

## 자기 측정 (커밋 전)

#704에서 이 측정 없이 커밋했다가 하나의 구별을 다섯 블록에 서술한 것이 드러났으므로, 이번에는 커밋 전에 돌렸다.

- 줄 수: **532 → 435** (순 -97; +64 / -161)
- 구조 신호: **60건 → 40건**
- 구별당 서술 블록 수: 예산 가드 6 → 4, 1회성 래치 7 → 6(각각 고유 의무), 강제 종료 6 → 2, 대기 대상 집합 7 → 3
- 잔존 `terminate` 매치는 전부 종단 이름 호명이지 종료 증명이 아님

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → **149 pass / 0 fail / 0 warn**
- 심볼 잔존 스윕: `spec_gate_if_spec_revision` `insufficiency_relayed` `refan_kind` `refan_budget` `unprobed_standdown` `insufficiency_standdown` `cleanup_verify` `discard_declared` 모두 정의 + 사용 유지, 고아 참조 0
- 새 구성자·게이트·상태 필드·함수 추가 없음. MODE STATE 불변식과 종단 술어 불변
- 510줄 가이드라인은 경고 전용(`scripts/package.js`, `docs/verification.md`)이므로 줄 수는 목표가 아니라 결과다

## 범위 밖

- `refan_budget`의 표현 재설계 (위 경계 판정 참조)
- 스윕의 다음 대상: analogia 30 / anagoge 24 / horismos 23 / diairesis 16 — main에서 다시 컷해 별도 PR로 진행

자문 세션: `019fc48c-8a91-7861-a7e0-32f426a64244`
