### PR TITLE
refactor(principles): 상태 표면 Demotion Ledger 제거 + README.md를 AGENTS.md/CLAUDE.md 컨벤션으로 이름 변경

### DIFF
--- a/.claude/principles/AGENTS.md
+++ b/.claude/principles/AGENTS.md
@@ -6,24 +6,20 @@ This directory realizes the root `AGENTS.md` `## Progressive Disclosure` policy 
 
 ## Distinction from `.claude/rules/`
 
-| Location | o-tier | Mechanism | Invocation frequency |
-|----------|--------|-----------|----------------------|
-| `.claude/rules/` | T1 | Auto-loaded by harness at session start | Per-turn |
-| `.claude/principles/` | T2-T3 | Entry document (`AGENTS.md`/`CLAUDE.md`) loads by directory convention when work touches this directory; principle documents lazy-load via Read/Grep when named | Per-directory-visit (entry) / per-session / per-authoring (principle documents) |
+- **`.claude/rules/`** — o-tier T1. Auto-loaded by the harness at session start, so it is invoked per-turn.
+- **`.claude/principles/`** — o-tier T2-T3, with two load paths. The entry document (`AGENTS.md`, aliased `CLAUDE.md`) loads by directory convention when work touches this directory, so it is invoked once per directory visit. Each principle document lazy-loads via Read/Grep only when named, so it is invoked per-session or per-authoring.
 
-This table is the canonical statement of the load mechanism in this repository; other files point here rather than restating it. Naming this index `AGENTS.md` with the `CLAUDE.md` alias — the only file in this directory that carries that name — is what makes the directory-convention pickup happen, which is why it stays short and current.
+This section is the canonical statement of the load mechanism in this repository; other files point here rather than restating it. Naming this index `AGENTS.md` with the `CLAUDE.md` alias — the only file in this directory that carries that name — is what makes the directory-convention pickup happen, which is why it stays short and current.
 
 The split realizes the orthogonal e-tier × o-tier mapping established in this project (`.claude/principles/architectural-principles.md` §Authority Mode's A5 coordination note). e-tier (epistemological status: Axiom/Derived/Architectural/Safeguard) is realized by file content; o-tier (operational frequency) is realized by directory location.
 
 ## Index
 
-| File | Current contents |
-|------|------------------|
-| `architectural-principles.md` | Tier Factorization, Epistemic Cost Topology, Unix Philosophy Homomorphism, Session Text Composition, Cross-Session Knowledge Composition, Task Externalization Boundary, Reference over Copy, Dual Advisory Layer, Coexistence over Mirroring, Three-Tier Termination, Plugin Encapsulation, Utility Skills delegation |
-| `hermeneutic-cycle.md` | Pattern over Vocabulary (Gadamerian formal-block mapping) + 6 surface catalog (Primary / Secondary / Tertiary / Inter-version / Inter-agent / Operational axis) |
-| `safeguards.md` | Actionable revision criterion, Literature Application Discipline, Rule Classification Framework, Adversarial Anticipation, White Bear Avoidance, Gate Type Soundness — all authoring/audit/verify-time; the runtime-critical Gate Integrity guards are carried by `premise/gate-design.md` |
-| `project-profile-calibration.md` | Profile Variables (six) and Calibration Rule, Scope Boundary — authoring/calibration-time reference, not per-turn |
-| `outcome-equivalence.md` | Outcome Equivalence (whole section) — Derived tier, runtime-inert argument chain |
+- **`architectural-principles.md`** — Tier Factorization, Epistemic Cost Topology, Unix Philosophy Homomorphism, Session Text Composition, Cross-Session Knowledge Composition, Task Externalization Boundary, Reference over Copy, Dual Advisory Layer, Coexistence over Mirroring, Three-Tier Termination, Plugin Encapsulation, Utility Skills delegation.
+- **`hermeneutic-cycle.md`** — Pattern over Vocabulary (Gadamerian formal-block mapping), plus the six-surface catalog: Primary, Secondary, Tertiary, Inter-version, Inter-agent, Operational axis.
+- **`safeguards.md`** — Actionable revision criterion, Literature Application Discipline, Rule Classification Framework, Adversarial Anticipation, White Bear Avoidance, Gate Type Soundness. All are authoring/audit/verify-time; the runtime-critical Gate Integrity guards are carried by `premise/gate-design.md` instead.
+- **`project-profile-calibration.md`** — Profile Variables (six) and Calibration Rule, Scope Boundary. Authoring/calibration-time reference, not per-turn.
+- **`outcome-equivalence.md`** — Outcome Equivalence (whole section). Derived tier, runtime-inert argument chain.
 
 ## Philosophy
 

--- a/.claude/principles/AGENTS.md
+++ b/.claude/principles/AGENTS.md
@@ -2,16 +2,16 @@
 
 **Purpose**: Lazy-load location for prescriptive content demoted from `.claude/rules/`. Per Tier Factorization, this directory realizes the **o-tier** axis (operational/runtime invocation frequency) at T2-T3 — sections invoked at authoring/verify/axiom-evolution time, not per-turn.
 
-The Claude Code harness does not auto-load files in this directory. Files here are fetched via Read/Grep when relevant. Other AI clients can adopt the same content via their own load conventions; the content itself is substrate-agnostic.
+This directory realizes the root `AGENTS.md` `## Progressive Disclosure` policy in three stages: at session start, nothing in this directory loads; when work touches this directory, its entry document (`AGENTS.md`, aliased as `CLAUDE.md`) is picked up by directory convention, bringing this index and the placement policy below into context; a specific principle document is then fetched via Read/Grep only when the utterance or current context names it. Other AI clients can adopt the same content via their own load conventions; the content itself is substrate-agnostic.
 
 ## Distinction from `.claude/rules/`
 
 | Location | o-tier | Mechanism | Invocation frequency |
 |----------|--------|-----------|----------------------|
 | `.claude/rules/` | T1 | Auto-loaded by harness at session start | Per-turn |
-| `.claude/principles/` | T2-T3 | Lazy-load via Read/Grep | Per-session / per-authoring |
+| `.claude/principles/` | T2-T3 | Entry document (`AGENTS.md`/`CLAUDE.md`) loads by directory convention when work touches this directory; principle documents lazy-load via Read/Grep when named | Per-directory-visit (entry) / per-session / per-authoring (principle documents) |
 
-This table is the canonical statement of the load mechanism in this repository; other files point here rather than restating it.
+This table is the canonical statement of the load mechanism in this repository; other files point here rather than restating it. Naming this index `AGENTS.md` with the `CLAUDE.md` alias — the only file in this directory that carries that name — is what makes the directory-convention pickup happen, which is why it stays short and current.
 
 The split realizes the orthogonal e-tier × o-tier mapping established in this project (`.claude/principles/architectural-principles.md` §Authority Mode's A5 coordination note). e-tier (epistemological status: Axiom/Derived/Architectural/Safeguard) is realized by file content; o-tier (operational frequency) is realized by directory location.
 

--- a/.claude/principles/CLAUDE.md
+++ b/.claude/principles/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.claude/principles/README.md
+++ b/.claude/principles/README.md
@@ -11,45 +11,24 @@ The Claude Code harness does not auto-load files in this directory. Files here a
 | `.claude/rules/` | T1 | Auto-loaded by harness at session start | Per-turn |
 | `.claude/principles/` | T2-T3 | Lazy-load via Read/Grep | Per-session / per-authoring |
 
-The split realizes the orthogonal e-tier × o-tier mapping established in this project (`architectural-principles.md` §Authority Mode's A5 coordination note + PR #270/#273 reclassification ⊥ compression + PR introducing this directory). e-tier (epistemological status: Axiom/Derived/Architectural/Safeguard) is realized by file content; o-tier (operational frequency) is realized by directory location.
+This table is the canonical statement of the load mechanism in this repository; other files point here rather than restating it.
+
+The split realizes the orthogonal e-tier × o-tier mapping established in this project (`.claude/principles/architectural-principles.md` §Authority Mode's A5 coordination note). e-tier (epistemological status: Axiom/Derived/Architectural/Safeguard) is realized by file content; o-tier (operational frequency) is realized by directory location.
 
 ## Index
 
-| File | Source | Demoted sections |
-|------|--------|------------------|
-| `architectural-principles.md` | `.claude/rules/architectural-principles.md` | Tier Factorization, Epistemic Cost Topology, Unix Philosophy Homomorphism, Session Text Composition, Cross-Session Knowledge Composition, Task Externalization Boundary, Reference over Copy, Dual Advisory Layer, Coexistence over Mirroring, Three-Tier Termination, Plugin Encapsulation, Utility Skills delegation |
-| `hermeneutic-cycle.md` | `docs/structural-specs.md` | Pattern over Vocabulary (Gadamerian formal-block mapping) + 6 surface catalog (Primary / Secondary / Tertiary / Inter-version / Inter-agent / Operational axis) |
-| `safeguards.md` | `.claude/rules/safeguards.md` (whole file relocated) | Actionable revision criterion, Literature Application Discipline, Rule Classification Framework, Adversarial Anticipation, White Bear Avoidance, Gate Type Soundness — all authoring/audit/verify-time; the runtime-critical Gate Integrity guards are carried by `premise/gate-design.md` |
-| `project-profile-calibration.md` | `.claude/rules/project-profile-calibration.md` (whole file relocated; §Cross-Project Corroboration deliberately deleted in transit — audit item S9, 2026-07-03 — and the Self-containment policy's historical opening clause trimmed — S11) | Profile Variables, Calibration Rule, Scope Boundary — authoring/calibration-time reference, not per-turn |
-| `outcome-equivalence.md` | `.claude/rules/derived-principles.md` | Outcome Equivalence (whole section) — Derived tier, runtime-inert argument chain |
-
-## Demotion Ledger
-
-| Section | Source file | Demotion date | Reason |
-|---------|-------------|---------------|--------|
-| Unix Philosophy Homomorphism | `architectural-principles.md` | 2026-04-27 | T2 — invoked at protocol design time, not per-turn |
-| Session Text Composition (incl. Stigmergy signal constraint) | `architectural-principles.md` | 2026-04-27 | T2 — inter-protocol architecture decision, infrequent invocation |
-| Cross-Session Knowledge Composition (incl. Formal layer boundary, Pollution caveat) | `architectural-principles.md` | 2026-04-27 | T2-T3 — Anamnesis hypomnesis design context, narrow scope |
-| Dual Advisory Layer (incl. Advisory cycle convergence, Emergent boundary annotations, Definitional-Observational convergence, Authoring checkpoint) | `architectural-principles.md` | 2026-04-27 | T2-T3 — graph.json + nudge architecture, authoring guidance |
-| Coexistence over Mirroring | `architectural-principles.md` | 2026-04-27 | T2 — plugin design boundary, infrequent invocation |
-| Three-Tier Termination | `architectural-principles.md` | 2026-04-27 | T2 — protocol exit design, per-protocol authoring |
-| Audience Reach (incl. Session-level observer exception, Bidirectional Reach) | `architectural-principles.md` | 2026-04-27 | T2-T3 — plugin encapsulation context, infrequent |
-| Utility Skills — Adversarial Anticipation Delegation | `architectural-principles.md` | 2026-04-27 | T3 — utility skill authoring guidance only |
-| Direction over Accumulated Workload | `architectural-principles.md` | 2026-04-27 | T2 — contributor authoring decision principle |
-| Pattern over Vocabulary (Gadamerian formal-block mapping + Primary/Secondary surfaces) | `structural-specs.md` | 2026-05-14 | T2-T3 — extracted to dedicated `hermeneutic-cycle.md` as canonical home; structural-specs slimmed to gate runtime semantics only |
-| Safeguards (whole file) | `safeguards.md` | 2026-05-27 | T2-T3 — every section is authoring/audit/verify-time (Rule Classification Framework methodology, Literature Application Discipline, Adversarial Anticipation authoring guards, Gate Type Soundness verify check); no per-turn runtime dependency after `axioms.md` inlined the Gate Integrity guards. White Bear's prior auto-load dependency converted to on-demand Read in `white-bear` SKILL.md |
-| Epistemic Cost Topology | `architectural-principles.md` | 2026-05-27 | Recurring framing-contamination: T1 auto-load made it top-of-mind, entering analyses as a one-sided cost-only prior (observed: surface-invariance pre-loaded into delegation prompts, biasing toward minimality before independent root-need assessment). Reverses prior deliberate T1 retention; non-reducible content (project-profile-calibration depends on the meta/execution asymmetry) → demoted, not deleted. |
-| Tier Factorization | `.claude/rules/architectural-principles.md` | 2026-07-03 | T2 — meta/design-time cross-reference (axis_α × axis_β), not per-turn load-bearing; `.claude/rules/architectural-principles.md` keeps only §Epistemic Completeness Boundary as T1. |
-| project-profile-calibration.md (whole file) | `.claude/rules/project-profile-calibration.md` | 2026-07-03 | T2-T3 — six-variable derivation and Scope Boundary are authoring/calibration-time reference; `project-profile.md` (rules layer) carries the per-turn operative Calibration Result and stays in `.claude/rules/`. In transit, §Cross-Project Corroboration was deliberately deleted (audit item S9) and the Self-containment policy's historical opening clause was trimmed (S11). |
-| Outcome Equivalence | `.claude/rules/derived-principles.md` | 2026-07-03 | T2-T3 — empirical-corollary argument chain (A4 + realization-completeness) invoked at authoring/verify time, not per-turn; A4 itself retains a one-line pointer in `axioms.md`. |
-| A5 Composition Scope | `.claude/rules/axioms.md` | 2026-07-28 | T2-T3 — authoring/design-time cross-protocol composition question (does the G = R(p) ∘ A factorization compose across protocol boundaries), not per-turn load-bearing; appended into `architectural-principles.md §Session Text Composition`, the section it names as the inter-protocol composition mechanism. |
-| A2 Authority Mode: Standing/Active | `.claude/rules/axioms.md` | 2026-07-28 | T2-T3 — second-order authority-allocation design question (Standing vs. Active authority source), not per-turn load-bearing; A2 retains its 1st-order operative core (AI detects, User judges; the Extension/Constitution distinction and indicator table) plus a one-line pointer. Appended into `architectural-principles.md §Tier Factorization` as `### Authority Mode: Standing/Active`, materializing the axis_α × axis_β observed-instance example already named there. |
-| A5 Gated interaction realization | `.claude/rules/axioms.md` | 2026-07-28 | T2-T3 — gate-presentation authoring guidance (rationale-option structure, user's implicit freedom to extend/replace), not per-turn load-bearing; A5 retains the factorization statement, the Extension/Constitution classification, and the full Option-set-level relay test, plus a one-line pointer. Appended into `hermeneutic-cycle.md §Inter-agent surface`, alongside the horizon-fusion gate description it elaborates. |
-| Task Externalization Boundary (whole section) | `.claude/rules/derived-principles.md` | 2026-07-28 | T2-T3 — durable-record externalization criteria (what crosses to the ledger, event-based trigger discipline) are authoring/session-design guidance, not per-turn load-bearing; the principle is actively cited elsewhere (`docs/analysis/periagoge-decompose-recovery-move.md`, `docs/analysis/task-externalization-evidence.md`), so a one-line pointer remains in `derived-principles.md`. Appended into `architectural-principles.md §Task Externalization Boundary`, alongside Cross-Session Knowledge Composition. |
-| Reference over Copy (whole section) | `.claude/rules/derived-principles.md` | 2026-07-28 | T2-T3 — handoff-boundary reference/copy criteria for context crossing tool/agent/session/turn boundaries are authoring-time design guidance, not per-turn load-bearing; the principle is actively cited elsewhere (`docs/analysis/task-externalization-evidence.md`), so a one-line pointer remains in `derived-principles.md`. Appended into `architectural-principles.md §Reference over Copy`, immediately after Task Externalization Boundary. |
+| File | Current contents |
+|------|------------------|
+| `architectural-principles.md` | Tier Factorization, Epistemic Cost Topology, Unix Philosophy Homomorphism, Session Text Composition, Cross-Session Knowledge Composition, Task Externalization Boundary, Reference over Copy, Dual Advisory Layer, Coexistence over Mirroring, Three-Tier Termination, Plugin Encapsulation, Utility Skills delegation |
+| `hermeneutic-cycle.md` | Pattern over Vocabulary (Gadamerian formal-block mapping) + 6 surface catalog (Primary / Secondary / Tertiary / Inter-version / Inter-agent / Operational axis) |
+| `safeguards.md` | Actionable revision criterion, Literature Application Discipline, Rule Classification Framework, Adversarial Anticipation, White Bear Avoidance, Gate Type Soundness — all authoring/audit/verify-time; the runtime-critical Gate Integrity guards are carried by `premise/gate-design.md` |
+| `project-profile-calibration.md` | Profile Variables (six) and Calibration Rule, Scope Boundary — authoring/calibration-time reference, not per-turn |
+| `outcome-equivalence.md` | Outcome Equivalence (whole section) — Derived tier, runtime-inert argument chain |
 
 ## Philosophy
 
 This directory is not an archive (content remains canonical and current) and not a docs/ replacement (docs/ holds investigation/research products, not prescriptive principles). It is a **Tier Factorization o-tier zone** — same content, different invocation frequency, different load mechanism.
 
 The demotion zone reduces auto-load memory pressure (Epistemic Cost Topology applied to the loading dimension) while keeping the demoted content canonical and editable. The split is one-directional by default: there is no formal re-promotion pathway. A demoted section returning to `.claude/rules/` is a contributor-judgment decision per case, not an inscribed criterion.
+
+Per-section demotion history — which section moved from where, when, and why — is not restated here; it is recorded in the git record (commit messages, PR bodies), per this project's Ledger binding (`AGENTS.md` §Settled Directions).

--- a/.claude/principles/architectural-principles.md
+++ b/.claude/principles/architectural-principles.md
@@ -2,7 +2,7 @@
 
 Project structure decisions; independent of the axiom system.
 
-> **Demotion zone**: lazy-load, not auto-loaded by the Claude Code harness. Per-section demotion rationale: `.claude/principles/README.md` Demotion Ledger.
+> **Demotion zone**: lazy-load, not auto-loaded by the Claude Code harness. Per-section demotion rationale is recorded in the git record (commit history / PR bodies), not restated here.
 
 ## Tier Factorization
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -48,7 +48,7 @@ Contributors are expected to dogfood the protocols they edit — the list above 
 - [ ] `premise/instruction-authoring.md` — the derived principles governing how instructions and durable records are written
 - [ ] `premise/tiering-and-scope.md` — the tier vocabulary plus the architectural principles in portable form, including the Epistemic Completeness Boundary that marks where epistemic judgment ends and substrate enforcement begins; this repo's own instances of them live in `.claude/principles/architectural-principles.md` (T2-T3, lazy-load)
 - [ ] `.claude/principles/safeguards.md` — Safeguard-tier principles (LESS important as models improve); demoted from `.claude/rules/` (authoring/verify-time, not per-turn) (~5 min)
-- [ ] `.claude/principles/README.md` — demotion zone overview, demotion ledger
+- [ ] `.claude/principles/README.md` — demotion zone overview, index of current principle files
 - [ ] `docs/structural-specs.md` — SKILL.md Formal Block Anatomy (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, LOOP, TOOL GROUNDING, MODE STATE, COMPOSITION)
 - [ ] `docs/verification.md` — what each static check enforces
 - [ ] `docs/co-change.md` — ripple patterns (protocol change → plugin.json version bump → /verify)

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -48,7 +48,7 @@ Contributors are expected to dogfood the protocols they edit — the list above 
 - [ ] `premise/instruction-authoring.md` — the derived principles governing how instructions and durable records are written
 - [ ] `premise/tiering-and-scope.md` — the tier vocabulary plus the architectural principles in portable form, including the Epistemic Completeness Boundary that marks where epistemic judgment ends and substrate enforcement begins; this repo's own instances of them live in `.claude/principles/architectural-principles.md` (T2-T3, lazy-load)
 - [ ] `.claude/principles/safeguards.md` — Safeguard-tier principles (LESS important as models improve); demoted from `.claude/rules/` (authoring/verify-time, not per-turn) (~5 min)
-- [ ] `.claude/principles/README.md` — demotion zone overview, index of current principle files
+- [ ] `.claude/principles/AGENTS.md` — demotion zone overview, index of current principle files
 - [ ] `docs/structural-specs.md` — SKILL.md Formal Block Anatomy (FLOW, MORPHISM, TYPES, PHASE TRANSITIONS, LOOP, TOOL GROUNDING, MODE STATE, COMPOSITION)
 - [ ] `docs/verification.md` — what each static check enforces
 - [ ] `docs/co-change.md` — ripple patterns (protocol change → plugin.json version bump → /verify)


### PR DESCRIPTION
## 배경

`.claude/principles/README.md`의 `## Demotion Ledger`(24행)는 어느 섹션이 언제, 왜 이동했는지를 기록한 순수 then-record였다. 이 저장소의 정착된 방향(`AGENTS.md` `## Settled Directions` → **Ledger binding**)에 따르면 이 프로젝트의 정본 ledger는 git 기록(커밋 메시지 + issue/PR 본문)이고, then-record(narrative, provenance, trade-off, 기각된 대안)는 그쪽에 써야 하며, 상태 표면(state surface)은 지금-단정하는(now-asserting) 운영적 내용만 담아야 한다 — always-loaded 지침 파일일수록 엄격하게.

더 심각한 문제는, 최근 병합된 PR #709(`refactor/premise-externalization`)가 `.claude/rules/axioms.md`, `.claude/rules/derived-principles.md`, `.claude/rules/architectural-principles.md` 세 규칙 파일을 삭제했는데, Demotion Ledger의 여러 행이 이 삭제된 파일들에 대해 여전히 현재형으로 (거짓) 주장을 하고 있었다는 점이다. 예:

- "`.claude/rules/architectural-principles.md`는 §Epistemic Completeness Boundary만 T1으로 남긴다" — 해당 파일 삭제됨
- "A4는 `axioms.md`에 한 줄 포인터를 남긴다" — 삭제됨
- "A2는 1차 운영 핵심 + 한 줄 포인터를 유지한다" — 삭제된 `axioms.md` 지칭
- "A5는 팩터화 진술 + 한 줄 포인터를 유지한다" — 동일
- "`derived-principles.md`에 한 줄 포인터가 남는다" (2행) — 삭제된 파일 지칭

git이 이미 모든 행과 그 blame 이력을 보존하고 있으므로, 다른 곳에 다시 옮겨 적는 것은 ledger 이원화를 낳을 뿐이다. 개별 행을 고치는 대신 README를 **현재 상태 인덱스**로 재정의하고, 이력은 git 기록에 맡긴다.

## 1차 변경 — Demotion Ledger 제거 (커밋 `0240757`)

### `.claude/principles/README.md`
- `## Demotion Ledger` 섹션 전체 삭제 (헤딩 포함)
- `## Distinction from .claude/rules/` 표 뒤에 "이 표가 이 저장소의 로드 메커니즘 정본 진술"이라는 한 문장 추가 — 다른 파일들이 이를 재서술하지 않고 여기를 가리키도록
- e-tier × o-tier 문장에서 PR 인용(#270/#273 재분류 + 디렉토리 도입 PR) provenance 절 제거. `architectural-principles.md` 참조를 전체 경로 `.claude/principles/architectural-principles.md`로 명확화 (동명의 `.claude/rules/` 파일이 삭제되어 생긴 모호성 해소)
- `## Index` 표에서 "Source" 컬럼(provenance) 전체 삭제 → `File` / `Current contents` 2컬럼으로 전환. "Demoted sections" 내용은 "Current contents"로 유지
- `## Philosophy` 말미에 섹션별 demotion 이력은 git 기록(커밋 메시지 · PR 본문)에서 찾으라는 문장 추가, `AGENTS.md` Ledger binding을 근거로 명시

### Index 표 검증 결과
다섯 파일(`architectural-principles.md`, `hermeneutic-cycle.md`, `safeguards.md`, `project-profile-calibration.md`, `outcome-equivalence.md`) 각각을 열어 실제 `##` 헤딩과 대조했다.

- **`project-profile-calibration.md` 행을 수정함**: PR #709가 "Profile Variables (six)"와 "Calibration Rule" 두 개의 `##` 섹션을 "Profile Variables (six) and Calibration Rule" 하나로 병합했는데, 기존 Index 행은 여전히 별개 섹션 3개(Profile Variables, Calibration Rule, Scope Boundary)인 것처럼 서술하고 있었다. 실제 파일의 현재 헤딩(병합된 섹션 + Scope Boundary, 2개)에 맞춰 정정
- 나머지 네 파일의 Index 행은 정정 불필요했음. 특히 `architectural-principles.md`는 PR #709가 "Audience Reach"와 "Direction over Accumulated Workload" 두 섹션을 삭제했지만, 기존 Index 행이 애초에 그 두 섹션을 나열하지 않아 이미 정확한 상태였음

### `.claude/principles/architectural-principles.md:5`
Demotion Ledger를 가리키던 "Per-section demotion rationale" 포인터가 고아가 되므로, git 기록(커밋 히스토리 / PR 본문)을 가리키도록 재작성. lazy-load 진술은 그대로 유지.

## 2차 변경 — README.md → AGENTS.md 이름 변경 + CLAUDE.md 심링크 (커밋 `5f2d14a4`)

이 저장소는 이미 루트(`AGENTS.md`/`CLAUDE.md`)와 `premise/`에서 같은 패턴을 쓴다: 정본 내용은 `AGENTS.md`(모드 `100644`)에 두고, `CLAUDE.md`는 `AGENTS.md`를 가리키는 상대 심링크(모드 `120000`, blob `47dc3e3d`)로 둔다.

- `git mv .claude/principles/README.md .claude/principles/AGENTS.md` (git이 rename으로 기록)
- `.claude/principles/CLAUDE.md`를 `ln -s AGENTS.md CLAUDE.md`로 생성. 상대 심링크, 대상은 bare 문자열 `AGENTS.md`. blob 해시(`47dc3e3d`)가 기존 두 심링크와 동일함을 확인

**이름 변경의 실제 동기**: 단순히 기존 명명 컨벤션과 맞추는 것이 아니라, 루트 `AGENTS.md`의 `## Progressive Disclosure` 정책을 이 디렉토리에서 실제로 작동시키는 변경이다. 로드는 3단계로 일어난다 — (1) 세션 시작 시점엔 이 디렉토리의 아무것도 로드되지 않는다, (2) 이 디렉토리를 건드리는 작업이 시작되면 엔트리 문서(`AGENTS.md`, `CLAUDE.md` alias)가 디렉토리 관례에 의해 로드되어 인덱스와 배치 정책이 그 시점에 컨텍스트로 들어온다, (3) 개별 principle 문서는 발화나 현재 컨텍스트가 이름을 지목할 때만 Read/Grep으로 fetch된다. 이 인덱스 파일에 정확히 `AGENTS.md`/`CLAUDE.md` 이름을 붙이는 것 자체가 (2)단계를 성립시키는 조건이며, 이 디렉토리에서 그 이름을 가진 파일은 이 파일 하나뿐이다.

이에 맞춰 기존 문장("이 디렉토리의 모든 파일은 auto-load되지 않고 Read/Grep으로 lazy-load된다")을 정정했다 — 그 포괄 부정 진술은 (2)단계를 부정하는 거짓이 되기 때문이다. 3단계를 긍정형으로 서술하고, `## Distinction from .claude/rules/` 표의 `.claude/principles/` 행도 Mechanism/Invocation frequency 컬럼을 이 3단계와 합치하도록 갱신했다.

### `ONBOARDING.md:51`
경로를 `.claude/principles/README.md`에서 `.claude/principles/AGENTS.md`로 갱신.

## 범위 밖 (의도적으로 미수정)
`docs/analysis/derived-principles-provenance.md:25`도 Demotion Ledger와 `.claude/principles/README.md` 경로를 참조하지만, `docs/analysis/**`는 역사적 스냅샷이므로 표준 지침에 따라 건드리지 않음 — 알려진 stale 포인터로 남김.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
→ 149 pass / 0 fail / 0 warn (심링크가 language-purity 등 정적 체크에 걸리지 않음)

node --test scripts/package.test.js anamnesis/scripts/hypomnesis-write.test.mjs
→ 82 pass / 0 fail

git grep -n "Demotion Ledger"
→ 유일한 잔존 히트: docs/analysis/derived-principles-provenance.md (범위 밖, 의도적)

git grep -n "principles/README"
→ 유일한 잔존 히트: docs/analysis/derived-principles-provenance.md (범위 밖, 의도적)

git ls-files -s .claude/principles/
→ AGENTS.md 100644, CLAUDE.md 120000 (blob 47dc3e3d, 루트/premise/와 동일)

git cat-file -p 47dc3e3d863cfb5727b87d785d09abf9743c0a72
→ AGENTS.md

git show --stat HEAD
→ rename .claude/principles/{README.md => AGENTS.md}로 기록 (삭제+추가 아님)
```


---

## 커밋 3 — `dfd8814f` 진입 문서의 두 표를 불렛 구조로 전환

커밋 2에서 이 파일이 디렉토리 엔트리 문서가 되면서, 읽는 주체가 렌더된 마크다운을 훑는 사람이 아니라 디렉토리 관례로 내용을 컨텍스트에 올려받는 에이전트가 되었다. 두 표 모두 한 셀만 문단 길이로 부풀어 표 형식이 방해가 되던 상태라 불렛으로 전환했다.

- `## Distinction from .claude/rules/` — Mechanism 셀이 세미콜론으로 두 문장을, Invocation frequency 셀이 슬래시로 세 값을 잇고 있었다. 두 로드 경로(엔트리 문서 = 디렉토리 방문당, 개별 principle 문서 = 호명 시)를 각각 완결된 인과 문장으로 분리
- `## Index` — 두 번째 열이 최대 12개 항목의 쉼표 나열이었다. `hermeneutic-cycle.md`의 `+ 6 surface catalog (…)` 축약을 실제 6개 이름으로 폈고, 대시로 이어붙인 단서절들을 별도 문장으로 분리

내용 변경 없음, 표현 구조만 변경. 검증: 149 pass / 0 fail / 0 warn, 82 tests pass. 심링크 모드 `120000` 유지 확인.
