### PR TITLE
refactor(principles): 하네스 로드 사실을 정본 한 곳으로 접음

### DIFF
--- a/.claude/principles/AGENTS.md
+++ b/.claude/principles/AGENTS.md
@@ -1,6 +1,6 @@
 # `.claude/principles/` — Demotion Zone
 
-**Purpose**: Lazy-load location for prescriptive content demoted from `.claude/rules/`. Per Tier Factorization, this directory realizes the **o-tier** axis (operational/runtime invocation frequency) at T2-T3 — sections invoked at authoring/verify/axiom-evolution time, not per-turn.
+**Purpose**: Location for prescriptive content demoted from `.claude/rules/`. Per Tier Factorization, this directory realizes the **o-tier** axis (operational/runtime invocation frequency) at T2-T3; §Distinction from `.claude/rules/` below states the load behavior that realizes it.
 
 This directory realizes the root `AGENTS.md` `## Progressive Disclosure` policy in three stages: at session start, nothing in this directory loads; when work touches this directory, its entry document (`AGENTS.md`, aliased as `CLAUDE.md`) is picked up by directory convention, bringing this index and the placement policy below into context; a specific principle document is then fetched via Read/Grep only when the utterance or current context names it. Other AI clients can adopt the same content via their own load conventions; the content itself is substrate-agnostic.
 

--- a/.claude/principles/architectural-principles.md
+++ b/.claude/principles/architectural-principles.md
@@ -2,13 +2,13 @@
 
 Project structure decisions; independent of the axiom system.
 
-> **Demotion zone**: lazy-load, not auto-loaded by the Claude Code harness. Per-section demotion rationale is recorded in the git record (commit history / PR bodies), not restated here.
+> **Demotion zone**: load behavior for this directory is stated in `AGENTS.md` §Distinction from `.claude/rules/`, the entry document that loads alongside this file. Per-section demotion rationale is recorded in the git record (commit history / PR bodies), not restated here.
 
 ## Tier Factorization
 
 Tier-classified artifacts in this project factor into a product of two orthogonal axes: an **epistemological** axis (axis_α — derivation status, model-improvement trajectory) and an **operational** axis (axis_β — invocation frequency, load-bearing strength). Neither dimension subsumes the other; the same artifact carries both annotations independently, and movement along one axis is independent of movement along the other.
 
-The factorization is realized by complementary mechanisms. File content typically carries axis_α — a `premise/` document carries the Axiom-tier classification by what it contains. Directory location or annotation typically carries axis_β — `.claude/rules/` realizes the auto-loaded T1 zone (per-turn invocation), `.claude/principles/` realizes the lazy-loaded T2–T3 zone (per-authoring or per-verify invocation). The same axis_α value can occupy either zone depending on observed invocation frequency. Lazy-load mechanisms operate on axis_β alone; demoted content retains its axis_α classification.
+The factorization is realized by complementary mechanisms. File content typically carries axis_α — a `premise/` document carries the Axiom-tier classification by what it contains. Directory location or annotation typically carries axis_β — `.claude/rules/` realizes the T1 zone and `.claude/principles/` the T2–T3 zone, each through its own load mechanism (stated in `AGENTS.md` §Distinction from `.claude/rules/`). The same axis_α value can occupy either zone depending on observed invocation frequency. Lazy-load mechanisms operate on axis_β alone; demoted content retains its axis_α classification.
 
 **Observed instances**:
 - Gate annotations: A2 §A5 coordination distinguishes Standing/Active authority (axis_α) from regret (axis_β) at the meta/design layer; the runtime annotation layer collapses to a single TOOL GROUNDING `(extension)`/`(constitution)` axis per A5 coextension — see `### Authority Mode: Standing/Active` below.


### PR DESCRIPTION
## 문제

"`.claude/rules/`는 세션 시작 시 로드되고 `.claude/principles/`는 그렇지 않다"는 **하나의 사실이 두 파일에 각각 두 번씩, 총 네 곳**에 쓰여 있었습니다. 루트 `AGENTS.md` `## Progressive Disclosure`가 "링크된 출처가 권위 있으면 미러링하지 말고 포인터를 두라"고 규정하는데, 그 규정을 어기는 상태였습니다. 이 규칙에는 강제 채널이 없어 정적 검사도 잡지 못합니다.

## PR #710이 만든 조건

이 정리는 #710 이전에는 하기 어려웠습니다. 두 가지가 갖춰졌습니다.

1. `.claude/principles/AGENTS.md` §Distinction from `.claude/rules/`가 스스로 정본임을 선언했습니다 — *"this section is the canonical statement of the load mechanism in this repository; other files point here rather than restating it"*. 가리킬 곳이 명시됐습니다.
2. 그 파일이 엔트리 문서가 되면서, 이 디렉터리를 건드리는 작업에는 자동으로 함께 로드됩니다. **같은 디렉터리 안에서 이 섹션을 가리키는 포인터는 역참조 비용이 0**입니다 — "포인터가 비싸니 복제한다"는 논거가 #710 이후로 성립하지 않습니다.

## 변경 (3곳)

| 위치 | 성격 | 처리 |
|---|---|---|
| `architectural-principles.md:5` 배너 | 사실 재진술 | 정본 섹션 포인터로 교체 + 함께 로드된다는 점 명시 |
| `architectural-principles.md:11` Tier Factorization | **논거의 일부** | 구조적 주장 유지, 구체적 메커니즘 서술만 포인터로 |
| `AGENTS.md:3` Purpose 줄 | **정확성 수정** | 아래 참조 |

`architectural-principles.md:11`은 문장을 통째로 뺄 수 없습니다. 여기서 디렉터리 매핑은 axis_β를 무엇이 담지하는지 보이는 *논거*이기 때문입니다. 구조적 주장(디렉터리 위치가 axis_β를 담지한다, 두 디렉터리가 각각 T1 / T2–T3 구역을 실현한다)은 유지하고, 각 구역의 로드 메커니즘 서술만 포인터로 바꿨습니다.

`AGENTS.md:3`은 중복 제거가 아니라 **정확성 수정**입니다. `Lazy-load location for prescriptive content`는 #710이 5행에서 고친 바로 그 평탄화를 3행에 남겨둔 것이었습니다. 엔트리 문서는 lazy-load가 아니라 디렉터리 관례로 로드되므로, 디렉터리 전체를 "lazy-load location"이라 부르면 두 로드 경로 중 하나를 지웁니다.

## 범위 밖 (의도적)

- 루트 `AGENTS.md` `## Design Placement`, `## Editing Conventions` — 각각 배치 규칙과 "어느 rules 파일이 로드되는가"라는 별개 사실
- `hermeneutic-cycle.md`, `outcome-equivalence.md`, `steer-trials.md`의 lazy-load 언급 — 각 파일 자신의 티어 배너

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
→ 149 pass / 0 fail / 0 warn

node --test scripts/package.test.js anamnesis/scripts/hypomnesis-write.test.mjs
→ 82 pass / 0 fail
```
