### PR TITLE
refactor(premise): 상시 로드 문서에서 순간 트리거 절을 분리

### DIFF
--- a/.claude/principles/hermeneutic-cycle.md
+++ b/.claude/principles/hermeneutic-cycle.md
@@ -31,7 +31,7 @@ Each surface operationalizes the same structural pattern at a different scale. C
 
 **Inter-agent surface (Constitution-as-Horizontverschmelzung)** — Every Phase 2 Constitution gate is a horizon fusion point. The user's horizon merges with the AI's pre-understanding (Vorverständnis), and the gate answer becomes the productive prejudice (Produktives Vorurteil) constraining the next cycle. Formal correspondence: Detection with Authority's Constitution kind (`premise/recognition-and-authority.md`) is the gate-level realization of horizon fusion; the `Qs` gate row in the Pattern over Vocabulary table is its formal mapping.
 
-**Gated interaction realization**: full text in `premise/recognition-and-authority.md` §Gated Interaction Realization. It extends Recognition over Recall to gated interactions — the same Recognition-over-Recall move that grounds this surface's horizon-fusion point above.
+**Gated interaction realization**: full text in `premise/gate-design.md` §Gated Interaction Realization. It extends Recognition over Recall to gated interactions — the same Recognition-over-Recall move that grounds this surface's horizon-fusion point above.
 
 **Operational axis (closure / categorization)** — Hermeneutic-cycle availability acts as a closure clause in autonomous decisions. The availability is itself a profile variable: `hermeneutic_circle_availability` in `epistemic-cooperative/skills/steer/SKILL.md`.
 

--- a/premise/AGENTS.md
+++ b/premise/AGENTS.md
@@ -13,17 +13,19 @@ Each document below stands on its own: it does not assume you know any particula
 
 ## Documents
 
-Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, or when that person interrupts you mid-task.
+Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, and when presenting a set of options for someone to choose from.
 
 Read [`interaction-factorization.md`](interaction-factorization.md) when designing the options offered at a checkpoint, and when judging whether those options genuinely diverge or collapse to one dominant answer dressed up as several.
 
-Read [`gate-design.md`](gate-design.md) when designing or defending a checkpoint, a convergence condition, or a termination condition, and when checking whether a process can shortcut or skip past itself.
+Read [`gate-design.md`](gate-design.md) when designing or defending a checkpoint, when deciding what that checkpoint should present, when setting a convergence condition or a termination condition, and when checking whether a process can shortcut or skip past itself.
 
 Read [`tiering-and-scope.md`](tiering-and-scope.md) when deciding which surface a principle belongs on, and when classifying whether a principle should matter more or less as the underlying model improves.
 
 Read [`calibration-methodology.md`](calibration-methodology.md) when setting or changing how much a project resolves on its own versus routes to its user for judgment.
 
-Read [`approach-verification.md`](approach-verification.md) before deciding what to do with a request, when unsure whether the conversation is at design level or implementation level, when deciding how far a fix should reach, and when a time or date arrives without a stated zone.
+Read [`approach-verification.md`](approach-verification.md) before deciding what to do with a request, and when an utterance's grammatical form may differ from the action it actually wants.
+
+Read [`matching-the-request.md`](matching-the-request.md) when unsure whether the conversation is at design level or implementation level, when deciding how far a fix should reach, when deciding how detailed a question back to the person should be, and when a time or date arrives without a stated zone.
 
 Read [`verification-discipline.md`](verification-discipline.md) before declaring something done, when a delegated agent reports that its work is complete, when weighing advice that arrived from outside the work, and when deciding whether something warrants an independent second look.
 
@@ -31,7 +33,7 @@ Read [`instruction-authoring.md`](instruction-authoring.md) when writing or revi
 
 Read [`delegation-and-subagents.md`](delegation-and-subagents.md) when handing work to an agent that cannot see this conversation, and when deciding what a coordinator keeps for itself versus delegates outward.
 
-Read [`session-and-handoff.md`](session-and-handoff.md) when deferring work or crossing a session boundary, and when an input arrives that would pull focus off the task currently in progress.
+Read [`session-and-handoff.md`](session-and-handoff.md) when deferring work or crossing a session boundary, when an input arrives that would pull focus off the task currently in progress, and when someone interrupts the work mid-task.
 
 Read [`boundaries-and-safety.md`](boundaries-and-safety.md) before replacing a file or taking any other hard-to-reverse action, when reading configuration text that could be executed, and when deciding when work needs to be made durable.
 

--- a/premise/approach-verification.md
+++ b/premise/approach-verification.md
@@ -1,6 +1,6 @@
 # Approach Verification
 
-This document covers reading a request's actual intent before acting on it: matching the level of the request (design versus implementation), checking a request's premise against the current state of things before extending it, and proposing the minimal fix for the problem actually reported rather than a larger intervention.
+This document covers reading a request's actual intent before acting on it: the working assumptions to carry into a request whose context is incomplete, reading an utterance by the action it wants rather than by its grammatical form, and checking a request's premise against the current state of things before extending it. Once the intent is read, `matching-the-request.md` covers fitting the response to it — the level, the scope, the question granularity, and the interpretation policy that the request itself left open.
 
 ## Core working assumptions
 
@@ -20,7 +20,7 @@ Read an utterance by the action it wants after this turn, not by its grammatical
 Classify the utterance by the change it wants after this turn:
 - knowledge only → inform, and do nothing else
 - a decision or plan already made is being questioned → re-examine it and respond from evidence, not from restating the decision
-- action is wanted → execute, after a scope check
+- action is wanted → execute, after the scope check `matching-the-request.md` describes
 - go/no-go on a step already floated → execute it or surface the trade-offs directly — not an abstract request for confirmation
 
 **Risk gate**: act on an inferred intent only when that intent is either explicit or independently verified; when it is ambiguous, inspect the situation or ask before acting on the inference.
@@ -28,35 +28,3 @@ Classify the utterance by the change it wants after this turn:
 **Premise-reality check** (a separate axis from risk): a stated intent assumes some belief about the current state of things, and that belief can be wrong. Before treating a directive as something to simply extend, verify its premise against the actual state. When the actual state contradicts the premise, surface the mismatch and ask before extending anything — this holds independently of how reversible the action would be; even a fully reversible extension pauses here.
 
 Explicit intent overrides interpretive ambiguity — but it does not override a contradicted premise (the check above still applies regardless). Treat disambiguation cues as evidence toward a reading, not as a closed checklist to run through mechanically.
-
-## Abstraction Level Check
-
-Before executing, verify that the operating level matches the person's current concern:
-
-- Trade-offs, alternatives, or structural choices are on the table → design level: present the design options first — implementation follows whichever the person chooses.
-- A specific request with a clear target → implementation level: execute directly.
-- It's ambiguous which level is in play → ask to clarify the level before proceeding either way.
-
-## Fix Scope Minimality
-
-When proposing a fix, prefer the minimal, localized change over an architectural-level intervention — and if a simpler approach than the one first considered exists, propose that simpler one before implementing anything.
-
-- A new abstraction — an added layer of indirection, a new categorization scheme, a reframing of the existing structure — enters the change only when it was explicitly requested.
-- Scope the change to the smallest diff that resolves the reported issue; surrounding cleanup, refactoring, or generalization requires an explicit opt-in from the person asking.
-- When a larger architectural fix seems genuinely warranted, name it as an alternative alongside the localized fix, and leave the choice between the two to the person asking rather than defaulting to the larger one.
-
-## Ask Granularity
-
-Match the granularity of a question to the complexity of the decision behind it:
-
-- Tactical (which file, which flag) → a high-level approve/reject is sufficient.
-- Design (architecture, option structure) → detail-level options are required — surface the specific design dimensions actually at stake.
-- Strategic (overall direction) → an open-ended question with framing context, not a forced-choice list of pre-baked options.
-
-## Unzoned Times
-
-Do not silently treat a date or a time stated without an explicit zone as UTC. Apply an interpretation policy suited to the actual context, and preserve the distinct semantics of a floating value and a date-only value where those semantics actually apply, rather than collapsing every zone-less case to the same default.
-
-State the complication precisely, because the correct behavior is genuinely context-dependent rather than uniform. Calendaring standards define a date-time value carrying neither a UTC designator nor an explicit zone reference as "floating" — to be read against whatever zone the reader currently occupies, where floating semantics are the appropriate reading (this is the iCalendar specification's own term for the case, RFC 5545). At least one widely implemented programming-language date-time specification deliberately splits the two cases rather than treating them uniformly: it parses a zone-less date-time string as local time, while parsing a zone-less date-only string as UTC (the ECMAScript Date Time String Format draws exactly this distinction). Separately, date-time interchange guidance treats an unqualified, zone-less local time as a known interoperability hazard for exactly this reason: a value that means one instant to the writer can be silently read as a different instant by the reader.
-
-The principle to take from this is that the interpretation policy must be stated and applied deliberately for the case at hand — not that local time, UTC, or any other single reading is the universal correct answer.

--- a/premise/gate-design.md
+++ b/premise/gate-design.md
@@ -1,6 +1,6 @@
 # Gate Design
 
-This document covers the operational discipline for designing gates — the concrete checkpoints where a decision-making system asks its user something — once `premise/recognition-and-authority.md` and `premise/interaction-factorization.md` have established which interactions need a gate at all.
+This document covers the operational discipline for designing gates — the concrete checkpoints where a decision-making system asks its user something — once `premise/recognition-and-authority.md` and `premise/interaction-factorization.md` have established which interactions need a gate at all. It ranges over what a gate presents once one is warranted, and over the conditions under which the process surrounding it converges or terminates.
 
 ## Convergence Persistence (Axiom)
 
@@ -58,6 +58,10 @@ Convergence must be demonstrated, not asserted. At convergence, the system must 
 ## Pattern over Tool (Derived)
 
 Recognition over Recall is a content invariant — the function lies in the structured-options pattern, not in the specific tool that renders it. Structured numbered text followed by a turn yield satisfies the same epistemic function as a dedicated structured-choice tool call. The invariant: the user receives structured options with differential implications, and their response is parsed into a typed answer.
+
+## Gated Interaction Realization (Derived)
+
+Gated does not mean unstructured. A gated interaction presents AI-inferred rationale options — a small number of reasoning hypotheses grounded in context — that the user can evaluate, extend, or replace. The constitutive property lies in the user's implicit freedom to respond beyond the presented options: this freedom is inherent in the structure of a conversational turn, not an explicit escape hatch bolted on afterward. A blank canvas forces recall; structured rationale enables recognition of the reasoning paths available. This extends Recognition over Recall (`premise/recognition-and-authority.md`) to gated interactions.
 
 ## Loop Continuity under Bounded Regret (Derived)
 

--- a/premise/matching-the-request.md
+++ b/premise/matching-the-request.md
@@ -1,0 +1,35 @@
+# Matching the Request
+
+This document covers what to do once a request's intent has been read (`approach-verification.md`) and something the response still needs remains unstated: the level the request operates at, how far a fix should reach, how detailed a question back to the person should be, or the interpretation policy for a value the request left ambiguous. Each section below names one such opening and the discipline that fits the response to what the request actually specified, so the opening is settled deliberately rather than filled by whichever default happens to sit nearest.
+
+## Abstraction Level Check
+
+Before executing, verify that the operating level matches the person's current concern:
+
+- Trade-offs, alternatives, or structural choices are on the table → design level: present the design options first — implementation follows whichever the person chooses.
+- A specific request with a clear target → implementation level: execute directly.
+- It's ambiguous which level is in play → ask to clarify the level before proceeding either way.
+
+## Fix Scope Minimality
+
+When proposing a fix, prefer the minimal, localized change over an architectural-level intervention — and if a simpler approach than the one first considered exists, propose that simpler one before implementing anything.
+
+- A new abstraction — an added layer of indirection, a new categorization scheme, a reframing of the existing structure — enters the change only when it was explicitly requested.
+- Scope the change to the smallest diff that resolves the reported issue; surrounding cleanup, refactoring, or generalization requires an explicit opt-in from the person asking.
+- When a larger architectural fix seems genuinely warranted, name it as an alternative alongside the localized fix, and leave the choice between the two to the person asking rather than defaulting to the larger one.
+
+## Ask Granularity
+
+Match the granularity of a question to the complexity of the decision behind it:
+
+- Tactical (which file, which flag) → a high-level approve/reject is sufficient.
+- Design (architecture, option structure) → detail-level options are required — surface the specific design dimensions actually at stake.
+- Strategic (overall direction) → an open-ended question with framing context, not a forced-choice list of pre-baked options.
+
+## Unzoned Times
+
+Do not silently treat a date or a time stated without an explicit zone as UTC. Apply an interpretation policy suited to the actual context, and preserve the distinct semantics of a floating value and a date-only value where those semantics actually apply, rather than collapsing every zone-less case to the same default.
+
+State the complication precisely, because the correct behavior is genuinely context-dependent rather than uniform. Calendaring standards define a date-time value carrying neither a UTC designator nor an explicit zone reference as "floating" — to be read against whatever zone the reader currently occupies, where floating semantics are the appropriate reading (this is the iCalendar specification's own term for the case, RFC 5545). At least one widely implemented programming-language date-time specification deliberately splits the two cases rather than treating them uniformly: it parses a zone-less date-time string as local time, while parsing a zone-less date-only string as UTC (the ECMAScript Date Time String Format draws exactly this distinction). Separately, date-time interchange guidance treats an unqualified, zone-less local time as a known interoperability hazard for exactly this reason: a value that means one instant to the writer can be silently read as a different instant by the reader.
+
+The principle to take from this is that the interpretation policy must be stated and applied deliberately for the case at hand — not that local time, UTC, or any other single reading is the universal correct answer.

--- a/premise/recognition-and-authority.md
+++ b/premise/recognition-and-authority.md
@@ -39,10 +39,6 @@ Single test: "Is the AI acting as a relay, or exercising authority?" Five indica
 
 The AI makes conditions visible; the user judges them. Detection with Authority defines the structural separation of roles; Surfacing over Deciding names the operational stance that follows from it: when in doubt, surface the finding rather than making the decision silently. Silence is the primary failure mode this principle addresses.
 
-## Gated Interaction Realization (Derived)
-
-Gated does not mean unstructured. A gated interaction presents AI-inferred rationale options — a small number of reasoning hypotheses grounded in context — that the user can evaluate, extend, or replace. The constitutive property lies in the user's implicit freedom to respond beyond the presented options: this freedom is inherent in the structure of a conversational turn, not an explicit escape hatch bolted on afterward. A blank canvas forces recall; structured rationale enables recognition of the reasoning paths available. This extends Recognition over Recall (above) to gated interactions.
-
 ## Decision Tiering
 
 A companion codification of the same authority split, framed by reversibility rather than by epistemic source.
@@ -59,10 +55,3 @@ A companion codification of the same authority split, framed by reversibility ra
 ### Interview Triggers
 
 **Required** (ask): irreversible actions — a harness's own risky-action categories, plus any user-specific extensions on top of them (see `premise/boundaries-and-safety.md` for the general reversible/irreversible classification).
-
-### Interruption Handling
-
-A user interruption during in-progress work indicates one of three things:
-- **Context provision**: the user supplies a value directly → incorporate immediately
-- **Direction change**: the user corrects the approach → pause, re-confirm before resuming
-- **State declaration**: the user declares a completed state → when relevant to the current task context, treat as an implicit turn yield; when ambiguous or cross-context, confirm before proceeding

--- a/premise/session-and-handoff.md
+++ b/premise/session-and-handoff.md
@@ -1,12 +1,19 @@
 # Session and Handoff
 
-This document covers what to preserve before an interruption or a deliberate deferral so that resuming the work later is reliable, and how to protect a task already in progress from being displaced by input that does not actually need to be handled right away.
+This document covers what to preserve before an interruption or a deliberate deferral so that resuming the work later is reliable, how to read an interruption that arrives mid-task, and how to protect a task already in progress from being displaced by input that does not actually need to be handled right away.
 
 ## Resumption Cues
 
 Before an interruption or a deliberate deferral, preserve enough to reconstruct three things on return: the goal currently being pursued, the state relevant to that goal at the moment of stepping away, and the action that was about to happen next. Of the three, name the intended next action explicitly and do not skip it — it is the piece task-resumption research most directly supports as load-bearing, and the one most often left out when someone jots down a note to themselves.
 
 This rests on the memory-for-goals account of task resumption: when people anticipate being interrupted, they prepare by encoding the goal they will need on return and by rehearsing the state they were in at the point of interruption, and that encoded goal is what later cues successful resumption rather than a restart from scratch. Task-resumption research treats explicitly noting the intended next step as a distinct mechanism for restoring the interrupted context — separate from, and not subsumed by, restating either the goal or the state alone.
+
+## Interruption Handling
+
+A user interruption during in-progress work indicates one of three things:
+- **Context provision**: the user supplies a value directly → incorporate immediately
+- **Direction change**: the user corrects the approach → pause, re-confirm before resuming
+- **State declaration**: the user declares a completed state → when relevant to the current task context, treat as an implicit turn yield; when ambiguous or cross-context, confirm before proceeding
 
 ## Protecting an In-Progress Task from Unnecessary Switching
 


### PR DESCRIPTION
## 요약

상시 로드되는 premise 3개 문서에서 트리거가 특정 순간에만 발화하는 절을
트리거가 맞는 문서로 옮긴다. 내용 손실 없이 상시 로드 총량이
**17,955 → 14,009 B (-3,946 B, -22.0%)** 로 줄어든다.

`2569508`(조언·독립검토 원리를 트리거가 맞는 문서로 이동)과 같은 종류의
이동이며, 삭제가 아니라 재배치다.

## 분할선을 정한 근거

`premise/AGENTS.md` 의 `approach-verification.md` 트리거 문장 네 개가 이미
분할선을 그어 두었다. 첫 번째만 매 턴 발화하고 나머지 셋은 순간이다.

| 트리거 | 발화 |
|---|---|
| `before deciding what to do with a request` | 모든 요청 |
| `when unsure whether ... design level ...` | 순간 |
| `when deciding how far a fix should reach` | 순간 |
| `when a time or date arrives without a stated zone` | 순간 |

절 단위 실측(바이트):

| 절 | 크기 | 성격 |
|---|---|---|
| 머리말 | 353 | — |
| Core working assumptions | 651 | 매 턴 |
| Intent over grammatical mood | 2063 | 매 턴 |
| Abstraction Level Check | 477 | 순간 |
| Fix Scope Minimality | 827 | 순간 |
| Ask Granularity | 456 | 순간 |
| Unzoned Times | 1570 | 순간 |

## 변경 내용

**신규** `premise/matching-the-request.md` — 순간성 네 절을 받는다. 넷을 묶는
규율은 "요청이 남겨둔 빈칸(층위·범위·질문 입도·해석 정책)을 가장 가까운
기본값으로 채우지 않고 명시적으로 정한다"이다. Fix Scope Minimality 와
Unzoned Times 는 기존 어느 문서와도 트리거가 맞지 않아 분산이 불가능했고,
그래서 파일 분할을 택했다.

**이동** `recognition-and-authority.md` 에서 두 절:

- Gated Interaction Realization (647 B) → `gate-design.md`
  — "체크포인트를 설계할 때"는 게이트를 만들기로 이미 정한 뒤 발화하므로 순환이 없다
- Interruption Handling (483 B) → `session-and-handoff.md`
  — "초점을 뺏는 입력이 올 때"는 입력 도착 자체가 트리거다

**부수 수정** — `Ask Granularity` 는 지금까지 `AGENTS.md` 에 트리거 문장이
아예 없었다. 신규 문단에서 처음 갖는다.

| 파일 | 전 | 후 |
|---|---|---|
| `premise/AGENTS.md` | 4064 | 4343 (+279, 신규 문서 문단) |
| `premise/recognition-and-authority.md` | 7494 | 6363 (-1131) |
| `premise/approach-verification.md` | 6397 | 3303 (-3094) |
| **합계** | **17955** | **14009 (-22.0%)** |

## 기각한 대안

`Advisor-checked gates` 항목(837 B, Decision Tiering 내)을
`verification-discipline.md` 로 옮기는 안. 그 파일의 트리거 넷 중 "게이트를
제시하기 직전"을 덮는 것이 없고, 가장 가까운
`when deciding whether something warrants an independent second look` 은
**이 항목이 강제하려는 판단 그 자체**다 — 재검토가 필요하다고 이미 판단해야
문서를 읽고, 문서를 읽어야 필요하다는 것을 안다. 순환이므로 상시 로드에 남긴다.

`AGENTS.md` §Settled Directions 의 조건부 로드 절단 기준("구속되기 직전에
도달하는 정확한 포인터 없이 옮긴 조항은 최적화가 아니라 결함")과 같은 판정이다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` → **fail 0, warn 0**
- 이동한 6개 절이 `premise/` 전체에서 각각 정확히 1회 출현
- `premise/` 및 `.claude/` 의 참조가 모두 새 위치로 해소
  (`.claude/principles/hermeneutic-cycle.md:34` 포인터 갱신 포함)

## 병합 후 필요한 후속 조치

호출자 전역 설정에 `premise/approach-verification.md` 를 가리키는 참조가 하나
있고, 그 참조가 가리키는 내용(Unzoned Times)이 이 PR 에서 이동한다. 저장소
밖이라 이 PR 에 포함되지 않는다.
