### PR TITLE
feat(premise): 공리 신설 — 쌓인 컨텍스트와 사용자 발화를 일차 근거로

### DIFF
--- a/premise/AGENTS.md
+++ b/premise/AGENTS.md
@@ -13,7 +13,7 @@ Each document below stands on its own: it does not assume you know any particula
 
 ## Documents
 
-Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, and when presenting a set of options for someone to choose from.
+Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a criterion belongs in a specification at all or must be left to resolve at runtime.
 
 Read [`interaction-factorization.md`](interaction-factorization.md) when designing the options offered at a checkpoint, and when judging whether those options genuinely diverge or collapse to one dominant answer dressed up as several.
 

--- a/premise/AGENTS.md
+++ b/premise/AGENTS.md
@@ -13,7 +13,7 @@ Each document below stands on its own: it does not assume you know any particula
 
 ## Documents
 
-Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a criterion belongs in a specification at all or must be left to resolve at runtime.
+Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a specification may fix a criterion's answer in advance or must leave it to resolve at runtime.
 
 Read [`interaction-factorization.md`](interaction-factorization.md) when designing the options offered at a checkpoint, and when judging whether those options genuinely diverge or collapse to one dominant answer dressed up as several.
 

--- a/premise/recognition-and-authority.md
+++ b/premise/recognition-and-authority.md
@@ -1,6 +1,6 @@
 # Recognition and Authority
 
-This document covers the foundational split in any human-AI collaboration: what an AI system may resolve on its own, and what requires the human's judgment — plus the presentational discipline (recognition over recall) that makes each kind of resolution legible to the person it affects.
+This document covers the foundational split in any human-AI collaboration: what an AI system may resolve on its own, and what requires the human's judgment — plus the presentational discipline (recognition over recall) that makes each kind of resolution legible to the person it affects, and which coordinates must stay open to that judgment rather than being settled in advance.
 
 ## Recognition over Recall (Axiom)
 
@@ -34,6 +34,16 @@ Single test: "Is the AI acting as a relay, or exercising authority?" Five indica
 **Dynamic observation scope**: non-destructive observation of a live system (including a test run with cleanup) is relay. Environment mutation (installation, a persistent state change) is constitution. Operational constraint: observation must not modify existing artifacts, and anything it creates must be cleaned up afterward.
 
 **Visibility principle**: what determines sufficiency is that the resolution's basis is cited somewhere — timing (immediate or deferred) is immaterial. A convergence trace, a summary, or a post-hoc report all satisfy visibility when the basis is cited. A progress-count-only display with no cited basis forces recall instead of recognition.
+
+## Context and Utterance as First-Class Ground (Axiom)
+
+A criterion whose right answer varies with the accumulated context and what the user has actually said stays open to runtime resolution; it is not closed in advance. What settles it is live ground — not an ungrounded authorial default, and not an answer embedded in the type.
+
+This is a constraint on what a specification may fix, not a courtesy about tone. Closing such a coordinate converts a live question into a settled one, and the settling happens where the user is not present: the specification removes the very utterance it exists to elicit, because the answer was already written before anyone was asked. A stronger model makes this more pressing rather than less — the better it is at producing plausible structure from incomplete evidence, the more readily its own competence closes what should have stayed open.
+
+This demotes none of the other standing sources of evidence. Accumulated context and the user's utterance take their place among them as first-class ground, not above them. What lacks standing is scaffolding — repeated boilerplate, incidental narration, and micro-detail that no decision turns on. Material earns its place by a decision-relevant path from the current ground; mere availability is not one.
+
+First-class standing is not unbounded authority: denotation stays open, provenance stays bound. A summary may navigate or compress, but where the wording itself or an unresolved denotation is what the decision turns on, it cannot stand in as equivalent evidence — there the source is cited in the user's own words. A summary substituted at such a point reads as the same evidence while having already resolved the openness this principle protects.
 
 ## Surfacing over Deciding (Derived)
 


### PR DESCRIPTION
`recognition-and-authority.md`에 Axiom 등급 절 "Context and Utterance as First-Class Ground"를 신설한다. 2026-08-03~04 사이 일곱 세션에 걸쳐 같은 원칙이 반복 발화되고 재적용되었으나 어디에도 기록되지 않은 채로 있었다. 초안을 작성하고 외부 자문 검토를 거쳐 자문이 지정한 다섯 항목을 수정했으며, 메인테이너가 확정한 문안이다. PR #708이 이 기록을 남은 후속 항목으로 지목한 바 있다.

## 무엇을 새기는가

- 축적된 컨텍스트와 사용자의 실제 발화에 따라 옳은 답이 달라지는 판정 기준은 사전에 닫지 않고 런타임 해소에 열어 둔다. 그것을 닫는 근거 없는 저자 기본값이나 타입에 박힌 답은 허용되지 않는다.
- 이는 어조의 문제가 아니라 명세가 무엇을 고정할 수 있는지에 대한 제약이다. 좌표를 닫으면 사용자가 부재한 자리에서 살아있는 질문이 이미 답해진 채로 확정되며, 모델이 강해질수록 불완전한 증거로 그럴듯한 확정 구조를 만드는 능력도 강해지므로 이 제약은 오히려 더 중요해진다.
- 축적된 컨텍스트와 사용자 발화는 다른 기존 근거원을 대체하지 않고 그 위에 일급으로 추가된다. 근거로 서지 못하는 것은 반복되는 상용구·부수적 서술·어떤 결정도 좌우하지 않는 미세 디테일 같은 스캐폴딩이며, 자격은 현재 근거로부터 결정에 닿는 경로로 얻는다.
- 일급 지위가 무제한 권한은 아니다. 의미는 열려 있어도 출처는 묶인다 — 요약은 탐색·압축에 쓸 수 있지만, 문언 자체나 미결 의미가 결정을 좌우하는 자리에서는 요약이 동등한 증거로 설 수 없고 사용자 원문이 출처로 인용되어야 한다.

## 근거

새로 만든 원칙이 아니라, 이미 반복 발화되었으나 어디에도 기록되지 않은 것을 옮겨 적은 것이다. 모두 세션 원본으로 확인했고 파생 인덱스 요약은 근거로 쓰지 않았다.

1. 25a5641e (08-03 04:40Z) 발단. "근거는 쌓인 컨텍스트와 사용자 발화에 따라 다를 수 있습니다. 나머지는 일급 객체가 아닙니다." 같은 세션에서 즉시 diff를 "일급(유지)/비일급(제거)"으로 분류하는 데 사용됨.
2. e020a992 (08-03 15:46Z) 11시간 뒤 "일급"이라는 말 없이 같은 실질을 재진술. "기준은 쌓인 컨텍스트와 사용자의 발화에 따라 달라지는 것입니다." 이후 세션 내내 축 위치 판정 테스트로 반복 사용.
3. 5b7f7c3d (08-03~04 01:43Z) 자기적용. 리뷰 루프 2~7라운드가 2번의 발화와 어긋나 있었고, 요약으로 들고 있는 동안 어긋남이 보이지 않다가 원문 재독으로 드러났다. 그 수리의 결론이 "의미는 열되 출처는 묶는다"이다.
4. 48f63ee2 (08-04 02:25Z) 적재 근거. "발화+컨텍스트에서 지정하지 않으면 로드되지 않습니다. 이것이 발화+컨텍스트를 일급으로 지정하려는 이유입니다."
5. d92d8b08 (08-04 06:20Z) 목적과 연결 — 타입이 분기를 미리 닫으면 이끌어낼 발화가 사라진다. 프로젝트 고유 문구는 일반형으로만 반영.
6. 74864160 (08-04 09:21Z) 기록 후보에 올랐다가 결과 이슈에서 누락.
7. 95153c8f (08-04 09:58~10:39Z) 검증 설계로 확장.

6번은 원칙의 부재를 보일 뿐 내용을 보태지 않아 근거에서 제외했다. 7번 당시의 자문 회신("premise 추가 불필요")은 다른 질문에 답한 것이라 선례로 쓰지 않았고, 이번 자문도 같은 판단을 확인했다.

## 자문

gpt-5.6-sol, xhigh — session 019fcefb-8731-77b3-bf45-321f233dc370

등급은 Axiom이 맞다. 강한 모델이 더 강하게 행사하는 능력 — 불완전한 증거를 그럴듯한 확정 구조로 바꾸는 능력 — 을 제약하므로, 준수율이 함께 개선되더라도 규범적 무게는 커진다. 기존 여섯 공리 중 어느 것도 이를 함의하지 않는다. 최근접 이웃인 Checkpoint Policy는 체크포인트가 제시된 이후를 규율하므로 중복이 아니라 그 토대에 해당한다. 단 초안 그대로 새기지는 말 것. 지정된 다섯 수정을 모두 반영했다.

## 기각한 대안

- "나머지는 일급이 아니다"의 문자적 확장: 코드베이스·규칙·환경까지 발화 아래로 내리게 되어, 이미 병합된 SubstrateChannel의 다섯 채널 타입과 충돌한다. 실제 적용 대상이었던 스캐폴딩으로 한정했다.
- "지명되지 않으면 적재되지 않는다": 닫힌 세계 규칙이라, 코드베이스·규칙·환경 스캔에서 나온 관련 증거를 사용자가 지명하지 않았다는 이유만으로 배제하게 된다. "현재 근거로부터 결정에 닿는 경로" 요건으로 교체했다.
- "미리 정해 둔 규칙보다 근거가 우선": 인용된 관례·상위 목표·선행 결정이 방향을 정당하게 확정할 수 있다는 기존 규칙과 충돌한다. 대립항을 "근거 없는 저자 기본값 / 타입에 박힌 답"으로 좁혔다.
- 출처 결속의 무조건화: 요약이 탐색·압축에 쓰이는 것은 허용하고, 문언이나 미결 의미가 결정을 좌우하는 자리에서만 동등한 증거로 설 수 없도록 한정했다.

## 후속

- 타입 시스템이 일으키는 편향. 분기가 형식적으로 열려 있으나 도달 가능성이 기울어지는 경우로, 현재 문안은 완전한 사전 확정만 잡는다. 이 공리 아래 세울 타입 파생 원칙에서 다룬다.
- 공리 개정 규정. "공리는 조우에 의해 개정된다"는 공리 체계에 대한 진술이므로 tiering-and-scope.md(메타이론 층)에 앉는다. 현재 premise/의 개정 규정은 Actionable Revision Criterion(Safeguard 등급 전용)뿐이다.
- premise/는 프로젝트 전용 표면이 아니므로, 해석이 갈리는 항목은 공리에 넣지 않고 후속으로 분리했다.
- PR #708의 "남은 것" 항목은 이 PR로 부분적으로 해소된다 — 공리 본체(런타임 개방 원칙)는 여기서 새겨졌고, 타입 계층 파생분은 위 후속 항목으로 남아 열려 있다.

## 검증

`node .claude/skills/verify/scripts/static-checks.js .` 실행 결과: `"fail": []`, `"warn": []` — 전 항목 통과 (exit code 0).

주요 통과 항목:
- `language-purity`: 138개 텍스트 파일 스캔, 화이트리스트 밖 한국어 문자 없음
- `notation` / `xref` / `structure`: 전 스킬 SKILL.md 통과
- `single-axis-soundness`, `formal-blocks-rule`, `gate-integrity-rule`, `emit-load-discipline`, `framing-readout-enforcement`, `gate-firing-anchor`, `ink-body-identity`: 전부 통과

전체 출력(발췌, pass 항목 다수는 각 스킬·프로토콜별 반복 항목이라 생략):

```
{
  "pass": [ ...138개 항목 전부 통과... ],
  "fail": [],
  "warn": []
}
```
