### PR TITLE
feat(premise): premise 계층 배선 방법을 README로 외부화

### DIFF
--- a/premise/README.md
+++ b/premise/README.md
@@ -1,0 +1,104 @@
+# Setting up this layer
+
+[`AGENTS.md`](AGENTS.md) in this directory describes what these documents are and the two ways to
+adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
+how to wire the documents into a Claude Code setup so they load as a standing reference layer.
+
+**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 4
+writes into that person's global configuration directory, so show them the file first and get their
+go-ahead before writing it.
+
+## What you end up with
+
+- The premise documents on disk, kept in sync by Claude Code's plugin manager.
+- One always-loaded rules file that states the split between the general principles (these
+  documents) and the operating rules of the host setup, and that loads the document index plus the
+  documents bearing on every turn.
+- Every other document reachable on demand, at the moment the index names for it.
+
+## Step 1 — get the documents on disk
+
+```bash
+claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
+```
+
+Adding the marketplace clones the whole repository, `premise/` included. No protocol plugin needs to
+be installed for this — install those only if you also want the protocols themselves (`/frame`,
+`/elicit`, and the rest; see the repository README).
+
+## Step 2 — resolve the configuration directory
+
+Claude Code's configuration directory is `$CLAUDE_CONFIG_DIR` when that variable is set, and
+`$HOME/.claude` otherwise. Resolve it once rather than assuming either:
+
+```bash
+echo "${CLAUDE_CONFIG_DIR-$HOME/.claude}"
+```
+
+Both the clone from step 1 and the rules file from step 4 live under that directory.
+
+## Step 3 — confirm the documents landed
+
+```bash
+ls "${CLAUDE_CONFIG_DIR-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
+```
+
+`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
+step 4 needs it written out literally.
+
+## Step 4 — write the rules file
+
+Markdown files under `<config-dir>/rules/` load automatically. Create `rules/premise.md` there, with
+this content:
+
+```markdown
+# Premise Layer
+
+The general principles behind these rules live outside this directory, at
+`<PREMISE_PATH>` — a git clone the plugin manager keeps in sync.
+Read from it freely; never write to it.
+
+The split: files in this directory carry the operational side — when a principle fires here, what
+threshold applies, which tool or path it binds to, what this setup has settled on. The principle
+itself lives in `premise/`. When a rule here names a premise document, read that document before
+acting on a case its operational wording does not already settle.
+
+The index loads below. It names each document and the moment that calls for it, so the moment is
+recognized rather than recalled. The two documents that bear on every turn load with it; the rest
+are read on demand when their trigger fires.
+
+@<PREMISE_PATH>/AGENTS.md
+@<PREMISE_PATH>/recognition-and-authority.md
+@<PREMISE_PATH>/approach-verification.md
+```
+
+Two things to get right:
+
+- **Substitute every `<PREMISE_PATH>` with the absolute path from step 3.** `@` imports do not
+  expand environment variables, so `$CLAUDE_CONFIG_DIR` left in an import line will not resolve.
+- **Show the file before writing it.** It lands in a global configuration directory and takes effect
+  in every session that person runs.
+
+Why those three imports and not all of them: an always-loaded layer costs context on every turn, so
+it carries the index — which names each document and the moment that calls for it — plus the two
+documents that bear on every turn. The rest arrive when their moment does.
+
+## Step 5 — check it took
+
+Start a fresh session and ask the agent which premise document it would read before taking a
+hard-to-reverse action. A wired setup answers `boundaries-and-safety.md` from the loaded index; an
+unwired one guesses.
+
+## Keeping it current
+
+The plugin manager keeps the clone in sync with upstream, so these documents can change under a
+setup that points at it. For a copy that changes only when you say so, clone the repository yourself
+to a path you own and substitute that path in step 4 instead — the rest of the steps are unchanged.
+
+## Adapting
+
+The three imports above are one setup's choice, not a required set. Any subset works: a document you
+adopt governs the general principles within the scope you adopted it for, and a document you have
+not adopted governs nothing — `AGENTS.md` states that scoping rule. If your host is not Claude Code,
+the mechanism differs but the shape does not: put the index wherever your instructions always load,
+and reach the rest at the moment its entry names.

--- a/premise/README.md
+++ b/premise/README.md
@@ -4,7 +4,7 @@
 adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
 how to wire the documents into a Claude Code setup so they load as a standing reference layer.
 
-**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 4
+**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
 writes into that person's global configuration directory, so show them the file first and get their
 go-ahead before writing it.
 
@@ -16,37 +16,37 @@ go-ahead before writing it.
   documents bearing on every turn.
 - Every other document reachable on demand, at the moment the index names for it.
 
-## Step 1 — get the documents on disk
+## Prerequisite
+
+This repository's marketplace is already added — that is what puts these documents on disk, and the
+[root README](../README.md)'s install covers it. For this reference layer alone, without any of the
+protocol plugins, adding the marketplace by itself is enough:
 
 ```bash
 claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
 ```
 
-Adding the marketplace clones the whole repository, `premise/` included. No protocol plugin needs to
-be installed for this — install those only if you also want the protocols themselves (`/frame`,
-`/elicit`, and the rest; see the repository README).
-
-## Step 2 — resolve the configuration directory
+## Step 1 — resolve the configuration directory
 
 Claude Code's configuration directory is `$CLAUDE_CONFIG_DIR` when that variable is set, and
 `$HOME/.claude` otherwise. Resolve it once rather than assuming either:
 
 ```bash
-echo "${CLAUDE_CONFIG_DIR-$HOME/.claude}"
+echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 ```
 
-Both the clone from step 1 and the rules file from step 4 live under that directory.
+Both the clone and the rules file from step 3 live under that directory.
 
-## Step 3 — confirm the documents landed
+## Step 2 — confirm the documents landed
 
 ```bash
-ls "${CLAUDE_CONFIG_DIR-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
+ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
 ```
 
 `AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
-step 4 needs it written out literally.
+step 3 needs it written out literally.
 
-## Step 4 — write the rules file
+## Step 3 — write the rules file
 
 Markdown files under `<config-dir>/rules/` load automatically. Create `rules/premise.md` there, with
 this content:
@@ -54,14 +54,15 @@ this content:
 ```markdown
 # Premise Layer
 
-The general principles behind these rules live outside this directory, at
+The general principles behind your operating rules live outside this directory, at
 `<PREMISE_PATH>` — a git clone the plugin manager keeps in sync.
 Read from it freely; never write to it.
 
-The split: files in this directory carry the operational side — when a principle fires here, what
-threshold applies, which tool or path it binds to, what this setup has settled on. The principle
-itself lives in `premise/`. When a rule here names a premise document, read that document before
-acting on a case its operational wording does not already settle.
+The split: your own rules — this directory and the rest of your configuration — carry the
+operational side: when a principle fires here, what threshold applies, which tool or path it binds
+to, what this setup has settled on. The principle itself lives in `premise/`. When one of your rules
+names a premise document, read that document before acting on a case its operational wording does
+not already settle.
 
 The index loads below. It names each document and the moment that calls for it, so the moment is
 recognized rather than recalled. The two documents that bear on every turn load with it; the rest
@@ -72,28 +73,32 @@ are read on demand when their trigger fires.
 @<PREMISE_PATH>/approach-verification.md
 ```
 
-Two things to get right:
+Three things to get right:
 
-- **Substitute every `<PREMISE_PATH>` with the absolute path from step 3.** `@` imports do not
+- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2.** `@` imports do not
   expand environment variables, so `$CLAUDE_CONFIG_DIR` left in an import line will not resolve.
 - **Show the file before writing it.** It lands in a global configuration directory and takes effect
   in every session that person runs.
+- **Do not write over an existing `rules/premise.md`.** Someone who already has that file has their
+  own wiring — show them what you would add and let them decide where it goes.
 
 Why those three imports and not all of them: an always-loaded layer costs context on every turn, so
 it carries the index — which names each document and the moment that calls for it — plus the two
 documents that bear on every turn. The rest arrive when their moment does.
 
-## Step 5 — check it took
+## Step 4 — check it took
 
-Start a fresh session and ask the agent which premise document it would read before taking a
-hard-to-reverse action. A wired setup answers `boundaries-and-safety.md` from the loaded index; an
-unwired one guesses.
+Start a fresh session and run `/context`. The new rules file should be listed under **Memory
+files**. If it is missing there, it did not load and nothing above it took effect.
+
+As a second check, ask which premise document the agent would read before taking a hard-to-reverse
+action. A wired setup answers `boundaries-and-safety.md` from the loaded index.
 
 ## Keeping it current
 
 The plugin manager keeps the clone in sync with upstream, so these documents can change under a
 setup that points at it. For a copy that changes only when you say so, clone the repository yourself
-to a path you own and substitute that path in step 4 instead — the rest of the steps are unchanged.
+to a path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
 
 ## Adapting
 


### PR DESCRIPTION
## 문제

`premise/` 는 저장소에 있지만, **이걸 자기 설정에 물리는 방법이 어디에도 적혀 있지 않았습니다.**

- `scripts/install.sh` 는 `premise` 를 한 번도 언급하지 않음 — 이 디렉터리는 마켓플레이스 클론의 부산물로 딸려올 뿐입니다.
- 실제로 작동하는 유일한 레시피는 개별 사용자의 로컬 `~/.claude/rules/premise.md` 한 파일에만 존재했습니다.

결과적으로 `premise/AGENTS.md` 가 선언한 두 채택 모드 중 "Link to it" 쪽은 재현 가능한 절차가 없는 상태였습니다.

## 변경

`premise/README.md` 하나 추가. GitHub이 디렉터리 진입 시 렌더하는 위치라, **URL 하나만 세션에 던지면 에이전트가 읽고 배선까지 수행**하도록 실행 지시서 형태로 작성했습니다.

전제(루트 README 설치 완료) + 4단계: 설정 디렉터리 해석 → 클론 확인 → 규칙 파일 작성 → `/context` 로 로드 확인.

## 확정한 좌표 (`/elicit`)

| 좌표 | 채택 | 기각한 대안 |
|---|---|---|
| 독자 | 에이전트 실행 지시서 | 사람이 손으로 따라 하는 산문형 / 둘 겸용 — 겸하면 유지할 경로가 둘이 됨 |
| 정식 경로 | 플러그인 마켓플레이스 클론 | 독자 소유 클론 — 동기화 대가가 있어 고정 사본 대안으로 한 문단 남김 |

## 적용성 점검 (`/contextualize`)

초안을 "URL을 받은 에이전트가 남의 머신에서 실행한다"는 맥락에 대고 훑었습니다.

**문서 확인으로 해소 (수정 없음)**

- `@` 임포트 절대경로 형식 — 공식 문서가 "Both relative and absolute paths are allowed" 로 명시. 이 저장소 생태계에 `~/` 형식 전례만 있다는 이유로 의심했으나 근거 없음.
- `rules/` 자동 로드 — "Personal rules in `~/.claude/rules/` apply to every project on your machine" 로 네이티브 기능 확인.

**수정 반영**

- **전제 도입** — 루트 README 설치 완료를 Prerequisite 절로 올려 Step 1의 마켓플레이스 명령을 흡수. 원래 루트 README에 있던 내용이라 같은 지침이 두 표면에 중복돼 있었습니다. 단계 5→4로 축소.
- **검증 절차 교체** — 에이전트 자기보고 질문 → `/context` 의 **Memory files** 목록 확인. 공식 문서가 지정하는 방법이고 조용한 실패를 실제로 잡습니다.
- **덮어쓰기 단서 추가** — 기존 `rules/premise.md` 를 대체하지 말 것. 대상 독자인 Claude Code 에이전트는 Write 도구가 미독 파일 덮어쓰기를 거부해 이미 막히지만, 다른 에이전트를 위한 비용 0짜리 보험입니다.
- **`${CLAUDE_CONFIG_DIR:-...}`** — `-` → `:-`. 빈 문자열도 기본값으로 넘깁니다.
- **템플릿 문구** — "these rules" 두 곳. `rules/` 가 비어 있는 신규 채택자에겐 가리킬 대상이 없는 표현이었습니다.

**기각** — README_ko 짝 부재는 관례 위반 아님 (`design/`, `references/`, `.claude/hooks/` 모두 짝 없이 존재; ko 짝은 사용자 대면 플러그인 문서의 관례).

## 짚어둘 점

**`premise/AGENTS.md` 는 손대지 않았습니다.** 5행의 "패키지가 아님" 선언과 충돌하지 않습니다 — 같은 파일 7행이 "Link to it from your own global configuration" 을 두 채택 모드 중 하나로 이미 선언하고 있고, 새 README는 그 모드의 구체적 실행 절차이지 별도 설치 경로가 아닙니다.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
→ fail: 0, warn: 0
```

`docs/co-change.md` 의 어느 행에도 해당하지 않습니다 (모두 원칙/프로토콜 내용 변경에 관한 항목).

---

후속: Codex 배선 절차와 호스트별 참조 분리는 #727 에서 다룹니다.
