### PR TITLE
feat(premise): Codex 배선 절차를 추가하고 호스트별 참조로 분리

### DIFF
--- a/premise/README.md
+++ b/premise/README.md
@@ -1,109 +1,19 @@
 # Setting up this layer
 
 [`AGENTS.md`](AGENTS.md) in this directory describes what these documents are and the two ways to
-adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
-how to wire the documents into a Claude Code setup so they load as a standing reference layer.
+adopt them: link to them, or copy the parts you want. This file routes to the first way, worked out
+concretely for each host — how to wire the documents in so they stand as a reference layer.
 
-**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
-writes into that person's global configuration directory, so show them the file first and get their
-go-ahead before writing it.
+**If you are an agent and someone handed you this URL**: identify the host you are running in, then
+follow that one file end to end. Each is self-contained; following both would write two setups over
+each other.
 
-## What you end up with
+- **[Claude Code](references/claude-code.md)** — the documents are imported into an always-loaded
+  rules file, so the host itself puts them in context.
+- **[Codex](references/codex.md)** — the documents are named by a standing instruction to read them
+  at the moments that call for them, because Codex expands no import directive.
 
-- The premise documents on disk, kept in sync by Claude Code's plugin manager.
-- One always-loaded rules file that states the split between the general principles (these
-  documents) and the operating rules of the host setup, and that loads the document index plus the
-  documents bearing on every turn.
-- Every other document reachable on demand, at the moment the index names for it.
-
-## Prerequisite
-
-This repository's marketplace is already added — that is what puts these documents on disk, and the
-[root README](../README.md)'s install covers it. For this reference layer alone, without any of the
-protocol plugins, adding the marketplace by itself is enough:
-
-```bash
-claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
-```
-
-## Step 1 — resolve the configuration directory
-
-Claude Code's configuration directory is `$CLAUDE_CONFIG_DIR` when that variable is set, and
-`$HOME/.claude` otherwise. Resolve it once rather than assuming either:
-
-```bash
-echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-```
-
-Both the clone and the rules file from step 3 live under that directory.
-
-## Step 2 — confirm the documents landed
-
-```bash
-ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
-```
-
-`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
-step 3 needs it written out literally.
-
-## Step 3 — write the rules file
-
-Markdown files under `<config-dir>/rules/` load automatically. Create `rules/premise.md` there, with
-this content:
-
-```markdown
-# Premise Layer
-
-The general principles behind your operating rules live outside this directory, at
-`<PREMISE_PATH>` — a git clone the plugin manager keeps in sync.
-Read from it freely; never write to it.
-
-The split: your own rules — this directory and the rest of your configuration — carry the
-operational side: when a principle fires here, what threshold applies, which tool or path it binds
-to, what this setup has settled on. The principle itself lives in `premise/`. When one of your rules
-names a premise document, read that document before acting on a case its operational wording does
-not already settle.
-
-The index loads below. It names each document and the moment that calls for it, so the moment is
-recognized rather than recalled. The two documents that bear on every turn load with it; the rest
-are read on demand when their trigger fires.
-
-@<PREMISE_PATH>/AGENTS.md
-@<PREMISE_PATH>/recognition-and-authority.md
-@<PREMISE_PATH>/approach-verification.md
-```
-
-Three things to get right:
-
-- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2.** `@` imports do not
-  expand environment variables, so `$CLAUDE_CONFIG_DIR` left in an import line will not resolve.
-- **Show the file before writing it.** It lands in a global configuration directory and takes effect
-  in every session that person runs.
-- **Do not write over an existing `rules/premise.md`.** Someone who already has that file has their
-  own wiring — show them what you would add and let them decide where it goes.
-
-Why those three imports and not all of them: an always-loaded layer costs context on every turn, so
-it carries the index — which names each document and the moment that calls for it — plus the two
-documents that bear on every turn. The rest arrive when their moment does.
-
-## Step 4 — check it took
-
-Start a fresh session and run `/context`. The new rules file should be listed under **Memory
-files**. If it is missing there, it did not load and nothing above it took effect.
-
-As a second check, ask which premise document the agent would read before taking a hard-to-reverse
-action. A wired setup answers `boundaries-and-safety.md` from the loaded index.
-
-## Keeping it current
-
-The plugin manager keeps the clone in sync with upstream, so these documents can change under a
-setup that points at it. For a copy that changes only when you say so, clone the repository yourself
-to a path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
-
-## Adapting
-
-The three imports above are one setup's choice, not a required set. Any subset works: a document you
-adopt governs the general principles within the scope you adopted it for, and a document you have
-not adopted governs nothing — `AGENTS.md` states that scoping rule. If your host is not Claude Code,
-the mechanism differs but the shape does not: put the index wherever your instructions always load,
-and reach the rest at the moment its entry names.
+The shape is the same in both: the index and the two documents bearing on every turn are reached
+first, and the rest arrive when their moment does. Only the mechanism differs. If your host is
+neither, that shape is what generalizes — put the index wherever your instructions always load, and
+reach the rest at the moment its entry names.

--- a/premise/README.md
+++ b/premise/README.md
@@ -13,6 +13,11 @@ each other.
 - **[Codex](references/codex.md)** — the documents are named by a standing instruction to read them
   at the moments that call for them, because Codex expands no import directive.
 
+Both procedures wire the machine the host is running on: each resolves a configuration directory
+there and writes an absolute path on that machine into it. A run isolated from those files — Codex
+cloud, or any remote sandbox — cannot follow either, and would have to establish the layer wherever
+its own instructions come from instead.
+
 The shape is the same in both: the index and the two documents bearing on every turn are reached
 first, and the rest arrive when their moment does. Only the mechanism differs. If your host is
 neither, that shape is what generalizes — put the index wherever your instructions always load, and

--- a/premise/references/claude-code.md
+++ b/premise/references/claude-code.md
@@ -1,0 +1,109 @@
+# Setting up this layer — Claude Code
+
+[`AGENTS.md`](../AGENTS.md) beside these documents describes what they are and the two ways to
+adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
+how to wire the documents into a Claude Code setup so they load as a standing reference layer.
+
+**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
+writes into that person's global configuration directory, so show them the file first and get their
+go-ahead before writing it.
+
+## What you end up with
+
+- The premise documents on disk, kept in sync by Claude Code's plugin manager.
+- One always-loaded rules file that states the split between the general principles (these
+  documents) and the operating rules of the host setup, and that loads the document index plus the
+  documents bearing on every turn.
+- Every other document reachable on demand, at the moment the index names for it.
+
+## Prerequisite
+
+This repository's marketplace is already added — that is what puts these documents on disk, and the
+[root README](../../README.md)'s install covers it. For this reference layer alone, without any of the
+protocol plugins, adding the marketplace by itself is enough:
+
+```bash
+claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
+```
+
+## Step 1 — resolve the configuration directory
+
+Claude Code's configuration directory is `$CLAUDE_CONFIG_DIR` when that variable is set, and
+`$HOME/.claude` otherwise. Resolve it once rather than assuming either:
+
+```bash
+echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+```
+
+Both the clone and the rules file from step 3 live under that directory.
+
+## Step 2 — confirm the documents landed
+
+```bash
+ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
+```
+
+`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
+step 3 needs it written out literally.
+
+## Step 3 — write the rules file
+
+Markdown files under `<config-dir>/rules/` load automatically. Create `rules/premise.md` there, with
+this content:
+
+```markdown
+# Premise Layer
+
+The general principles behind your operating rules live outside this directory, at
+`<PREMISE_PATH>` — a git clone the plugin manager keeps in sync.
+Read from it freely; never write to it.
+
+The split: your own rules — this directory and the rest of your configuration — carry the
+operational side: when a principle fires here, what threshold applies, which tool or path it binds
+to, what this setup has settled on. The principle itself lives in `premise/`. When one of your rules
+names a premise document, read that document before acting on a case its operational wording does
+not already settle.
+
+The index loads below. It names each document and the moment that calls for it, so the moment is
+recognized rather than recalled. The two documents that bear on every turn load with it; the rest
+are read on demand when their trigger fires.
+
+@<PREMISE_PATH>/AGENTS.md
+@<PREMISE_PATH>/recognition-and-authority.md
+@<PREMISE_PATH>/approach-verification.md
+```
+
+Three things to get right:
+
+- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2.** `@` imports do not
+  expand environment variables, so `$CLAUDE_CONFIG_DIR` left in an import line will not resolve.
+- **Show the file before writing it.** It lands in a global configuration directory and takes effect
+  in every session that person runs.
+- **Do not write over an existing `rules/premise.md`.** Someone who already has that file has their
+  own wiring — show them what you would add and let them decide where it goes.
+
+Why those three imports and not all of them: an always-loaded layer costs context on every turn, so
+it carries the index — which names each document and the moment that calls for it — plus the two
+documents that bear on every turn. The rest arrive when their moment does.
+
+## Step 4 — check it took
+
+Start a fresh session and run `/context`. The new rules file should be listed under **Memory
+files**. If it is missing there, it did not load and nothing above it took effect.
+
+As a second check, ask which premise document the agent would read before taking a hard-to-reverse
+action. A wired setup answers `boundaries-and-safety.md` from the loaded index.
+
+## Keeping it current
+
+The plugin manager keeps the clone in sync with upstream, so these documents can change under a
+setup that points at it. For a copy that changes only when you say so, clone the repository yourself
+to a path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
+
+## Adapting
+
+The three imports above are one setup's choice, not a required set. Any subset works: a document you
+adopt governs the general principles within the scope you adopted it for, and a document you have
+not adopted governs nothing — `AGENTS.md` states that scoping rule. If your host is not Claude Code,
+the mechanism differs but the shape does not: put the index wherever your instructions always load,
+and reach the rest at the moment its entry names.

--- a/premise/references/codex.md
+++ b/premise/references/codex.md
@@ -5,7 +5,8 @@ adopt them: link to them, or copy the parts you want. This file covers the first
 how to wire the documents into a Codex setup so they stand as a reference layer.
 
 Codex reaches them by pointer rather than by import. Its instruction loader reads each file's bytes
-and places the text into the instruction chain as-is; it expands no import directive. So the layer is
+and places the text into the instruction chain without interpreting it; no import directive is
+expanded, and nothing the text names is fetched on its behalf. So the layer is
 a standing instruction to read the documents at named moments, not a mechanism that loads them for
 you. Every difference below follows from that.
 
@@ -44,15 +45,25 @@ Both the clone and the file from step 3 live under that directory.
 
 ## Step 2 — confirm the documents landed
 
+Ask Codex where it put the marketplace rather than assuming a path — a marketplace added from a
+local checkout resolves to that checkout, not to the managed location a GitHub-sourced one gets:
+
 ```bash
-ls "${CODEX_HOME:-$HOME/.codex}/.tmp/marketplaces/epistemic-protocols/premise/"
+codex plugin marketplace list
 ```
 
-`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
-step 3 needs it written out literally.
+Take the `ROOT` for `epistemic-protocols` from that output, and confirm the documents are under it:
 
-The `.tmp` in that path does not mean scratch. It is where Codex keeps every installed marketplace,
-its own bundled ones included; `codex plugin marketplace list` reports the same root.
+```bash
+ls <ROOT>/premise/
+```
+
+`AGENTS.md` should appear alongside the individual documents. Write out `<ROOT>/premise` in full and
+keep it — step 3 needs that absolute path literally.
+
+When the marketplace came from GitHub, that root sits under `<config-dir>/.tmp/`. The `.tmp` does not
+mean scratch: it is where Codex keeps marketplaces it manages, its own bundled ones among them, under
+sibling directories of the same parent.
 
 ## Step 3 — add a section to the global AGENTS.md
 
@@ -85,15 +96,23 @@ already settle.
 
 Four things to get right:
 
-- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2**, and match the heading
-  level the file already uses. The text arrives verbatim in the instruction chain, so a path left as
-  `$CODEX_HOME` would have to be resolved by the agent at read time — which is the recall this layer
-  exists to avoid.
+- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2**, and give the section the
+  same heading level the file's other top-level sections use. The text arrives verbatim in the
+  instruction chain, so a path left as `$CODEX_HOME` would have to be resolved by the agent at read
+  time — which is the recall this layer exists to avoid.
 - **Append; never replace.** That file usually already carries someone's own guidance, and it takes
   effect in every session they run.
-- **Check for `AGENTS.override.md` in the same directory first.** When it is present Codex reads it
-  instead of `AGENTS.md`, so a section added to the latter would never load. Add it to whichever file
-  Codex actually reads.
+- **Check `AGENTS.override.md` in the same directory before touching anything.** Codex loads the
+  first of `AGENTS.override.md`, `AGENTS.md` whose contents are not blank — presence alone does not
+  decide it. Three cases, and they differ:
+  - No override, or an override that is empty or whitespace only → `AGENTS.md` is what loads; add the
+    section there and leave the empty override alone. **Writing into an empty override would make it
+    non-blank and drop the whole of `AGENTS.md` out of the instruction chain** — an append that
+    silently removes everything that file was carrying.
+  - An override with content → that is what loads, and `AGENTS.md` does not. Adding the section to
+    `AGENTS.md` would load nothing.
+  - Either way, an override is meant to be temporary. Say so when the section has to go into one:
+    removing that override later takes the premise layer with it.
 - **Flag overlap rather than resolving it.** Existing guidance in that file may already restate a
   premise document's principle in its own words. Point out what overlaps and leave the removal to
   the person whose file it is.
@@ -105,12 +124,22 @@ documents that bear on every turn. The rest arrive when their moment does.
 ## Step 4 — check it took
 
 There is no import list to inspect here. Codex guarantees only that the `AGENTS.md` text reaches the
-instruction chain, not that the files it names get read — so the behavioral check is the check.
+instruction chain, not that the files it names get read — so the behavioral check is the check, and
+it has to be one the index actually settles.
 
-Start a fresh session and ask which premise document the agent would read before taking a
-hard-to-reverse action. A wired setup answers `boundaries-and-safety.md`, having read the index at
-the path the section named. An answer that does not name a document, or names one that is not in the
-index, means the pointer is not being followed and the layer is not in effect.
+Start a fresh session and ask which premise document to read **when a time or date arrives without a
+stated zone**. A wired setup answers `matching-the-request.md`. Ask for the trigger phrasing too, so
+the answer has to come from the index rather than from the filename: the entry names that moment
+alongside three others about level, fix scope, and question granularity.
+
+The point of that particular question is that it cannot be guessed. A check like "which document
+before a hard-to-reverse action" invites the answer `boundaries-and-safety.md` from the topic word
+alone, and would pass on a setup where nothing was ever read.
+
+What this establishes and what it does not: a correct answer shows the index was reached at the path
+the section named. It says nothing about whether `recognition-and-authority.md` and
+`approach-verification.md` were also read, nor about any session other than the one you asked in.
+Nothing here fails loudly, so treat a wrong answer as the layer being absent rather than as a slip.
 
 ## Keeping it current
 

--- a/premise/references/codex.md
+++ b/premise/references/codex.md
@@ -10,6 +10,12 @@ expanded, and nothing the text names is fetched on its behalf. So the layer is
 a standing instruction to read the documents at named moments, not a mechanism that loads them for
 you. Every difference below follows from that.
 
+**Scope**: Codex running locally — the CLI and the desktop app — where the configuration directory
+and the documents sit on the machine being wired. Codex cloud runs isolated from that machine's
+files and cannot follow these steps; the layer has to be established wherever a cloud run's own
+instructions come from. Whether every local surface follows the pointer in practice has not been
+established empirically — see step 4 for what the check does and does not settle.
+
 **If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
 writes into that person's global configuration directory, so show them the text first and get their
 go-ahead before writing it.

--- a/premise/references/codex.md
+++ b/premise/references/codex.md
@@ -1,0 +1,129 @@
+# Setting up this layer — Codex
+
+[`AGENTS.md`](../AGENTS.md) beside these documents describes what they are and the two ways to
+adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
+how to wire the documents into a Codex setup so they stand as a reference layer.
+
+Codex reaches them by pointer rather than by import. Its instruction loader reads each file's bytes
+and places the text into the instruction chain as-is; it expands no import directive. So the layer is
+a standing instruction to read the documents at named moments, not a mechanism that loads them for
+you. Every difference below follows from that.
+
+**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
+writes into that person's global configuration directory, so show them the text first and get their
+go-ahead before writing it.
+
+## What you end up with
+
+- The premise documents on disk, kept in sync by Codex's plugin manager.
+- One section in the global `AGENTS.md` that states the split between the general principles (these
+  documents) and the operating rules of the host setup, and that names the document index plus the
+  two documents bearing on every turn as required reading.
+- Every other document reachable on demand, at the moment the index names for it.
+
+## Prerequisite
+
+This repository's marketplace is already added — that is what puts these documents on disk, and the
+[root README](../../README.md)'s install covers it. For this reference layer alone, without any of
+the protocol plugins, adding the marketplace by itself is enough:
+
+```bash
+codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
+```
+
+## Step 1 — resolve the configuration directory
+
+Codex's configuration directory is `$CODEX_HOME` when that variable is set, and `$HOME/.codex`
+otherwise. Resolve it once rather than assuming either:
+
+```bash
+echo "${CODEX_HOME:-$HOME/.codex}"
+```
+
+Both the clone and the file from step 3 live under that directory.
+
+## Step 2 — confirm the documents landed
+
+```bash
+ls "${CODEX_HOME:-$HOME/.codex}/.tmp/marketplaces/epistemic-protocols/premise/"
+```
+
+`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
+step 3 needs it written out literally.
+
+The `.tmp` in that path does not mean scratch. It is where Codex keeps every installed marketplace,
+its own bundled ones included; `codex plugin marketplace list` reports the same root.
+
+## Step 3 — add a section to the global AGENTS.md
+
+Codex reads `<config-dir>/AGENTS.md` as global standing guidance. Two things it does not do decide
+the shape of what goes there: it does not expand `@path` imports, so an import line would arrive as
+literal text and load nothing; and `<config-dir>/rules/` is not a Markdown auto-load directory —
+`.rules` files there are sandbox and approval policy, so nothing belongs there for this purpose.
+
+What transfers is the pointer. Add this section:
+
+```markdown
+# Premise Layer
+
+The general principles behind the rules in this file live at
+`<PREMISE_PATH>` — a git clone Codex's plugin manager keeps in sync.
+Read from it freely; never write to it.
+
+`<PREMISE_PATH>/AGENTS.md` is the index: it names each document and the moment that calls for it.
+Read it at the start of a session, before the first substantive action, so those moments are
+recognized rather than recalled. Read `<PREMISE_PATH>/recognition-and-authority.md` and
+`<PREMISE_PATH>/approach-verification.md` alongside it — those two bear on every turn. Read any
+other document at the moment the index names for it.
+
+The split: the rest of this file and the rest of your configuration carry the operational side —
+when a principle fires here, what threshold applies, which tool or path it binds to, what this setup
+has settled on. The principle itself lives in the premise documents. When one of your rules names a
+premise document, read that document before acting on a case its operational wording does not
+already settle.
+```
+
+Four things to get right:
+
+- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2**, and match the heading
+  level the file already uses. The text arrives verbatim in the instruction chain, so a path left as
+  `$CODEX_HOME` would have to be resolved by the agent at read time — which is the recall this layer
+  exists to avoid.
+- **Append; never replace.** That file usually already carries someone's own guidance, and it takes
+  effect in every session they run.
+- **Check for `AGENTS.override.md` in the same directory first.** When it is present Codex reads it
+  instead of `AGENTS.md`, so a section added to the latter would never load. Add it to whichever file
+  Codex actually reads.
+- **Flag overlap rather than resolving it.** Existing guidance in that file may already restate a
+  premise document's principle in its own words. Point out what overlaps and leave the removal to
+  the person whose file it is.
+
+Why those three documents and not all of them: standing instructions are read on every turn, so the
+layer carries the index — which names each document and the moment that calls for it — plus the two
+documents that bear on every turn. The rest arrive when their moment does.
+
+## Step 4 — check it took
+
+There is no import list to inspect here. Codex guarantees only that the `AGENTS.md` text reaches the
+instruction chain, not that the files it names get read — so the behavioral check is the check.
+
+Start a fresh session and ask which premise document the agent would read before taking a
+hard-to-reverse action. A wired setup answers `boundaries-and-safety.md`, having read the index at
+the path the section named. An answer that does not name a document, or names one that is not in the
+index, means the pointer is not being followed and the layer is not in effect.
+
+## Keeping it current
+
+The plugin manager keeps the clone in sync with upstream, so these documents can change under a
+setup that points at it. The same clone is replaced when the marketplace upgrades and removed when
+the marketplace is removed — a path that disappears takes the layer with it silently, since nothing
+here fails loudly. For a copy that changes only when you say so, clone the repository yourself to a
+path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
+
+## Adapting
+
+The three documents above are one setup's choice, not a required set. Any subset works: a document
+you adopt governs the general principles within the scope you adopted it for, and a document you
+have not adopted governs nothing — `AGENTS.md` states that scoping rule. Codex layers project
+`AGENTS.md` files from the repository root down to the working directory, so a project that wants a
+narrower or wider set can name its own without touching the global section.


### PR DESCRIPTION
[#725](https://github.com/jongwony/epistemic-protocols/pull/725) 후속. `premise/README.md` 가 Claude Code 배선만 다루고 있었는데, Codex 플러그인 생태계에서 기구가 다른지 `/elicit` 으로 확인한 결과를 반영합니다.

Codex 세션 안에서 euporia 를 돌려 자기 기질을 역추적하게 했고, 결정적 주장은 이쪽에서 재검증했습니다.

## 확정된 사실

**`@path` 임포트가 Codex 에는 없습니다.** Codex 0.146.0 의 AGENTS 로더는 파일 바이트를 문자열로 읽어 지시문 체인에 그대로 넣습니다.

```rust
let text = String::from_utf8_lossy(&data).to_string();
loaded.entries.push(InstructionEntry { contents: text, ... });
```
<sub>openai/codex <code>rust-v0.146.0</code> <code>codex-rs/core/src/agents_md.rs</code> — 직접 받아 확인</sub>

Claude Code Step 3 전체가 그 지시자 위에 서 있었으므로, 경로 치환으로는 이식되지 않습니다.

나머지 확인 결과:

| 주장 | 검증 |
|---|---|
| `rules/` 는 마크다운 자동적재가 아님 | `~/.codex/rules/default.rules` — 명령 실행 정책 |
| 설정 디렉터리 = `CODEX_HOME` (기본 `~/.codex`) | 바이너리 문자열 + 로더 소스 |
| `AGENTS.override.md` 가 있으면 그쪽이 대신 읽힘 | 로더의 `candidate_filenames` 우선순위 |
| 클론은 `<config>/.tmp/marketplaces/<name>/`, `premise/` 포함 | `codex plugin marketplace list` |
| 플러그인 캐시에는 `premise/` 없음 | `install-codex.sh` 는 마켓플레이스만 추가 |

**기각한 사전 관찰**: "`.tmp` 아래라서 폐기 가능한 경로일 것" — 틀렸습니다. `codex plugin marketplace list` 가 OpenAI 번들 마켓플레이스까지 `.tmp` 아래로 보고합니다. 이름에서 성질을 추론한 것이 근거였고, 그건 근거가 아니었습니다. 이 확인으로 "정식 경로 = 마켓플레이스 클론" 이라는 Claude 쪽 결정의 Codex 이전을 막던 비유사성이 해소됐습니다.

## 선택: 포인터 모드

`<config>/AGENTS.md` 에 정식 경로를 가리키는 지시문 절만 추가하고 문서 사본은 두지 않습니다.

**기각한 대안** — 색인과 상시 문서 2개를 인라인 복사: 호스트 차원의 적재는 보장되지만 매 실행 120줄 이상이 상주하고, 상류 변경이 사본에 반영되지 않아 동기화가 수동 부채로 남습니다.

포인터 모드의 대가는 정직하게 적었습니다. Codex 는 AGENTS 텍스트가 지시문 체인에 들어가는 것만 보장하고 그 텍스트가 지목한 파일이 읽히는지는 보장하지 않으므로, Step 4 의 행동 확인이 유일한 검증입니다.

## 구조: 호스트별 참조 분리

```
premise/
├── README.md              라우터
├── AGENTS.md              (변경 없음)
└── references/
    ├── claude-code.md     #725 내용 그대로 + 이동 3줄
    └── codex.md           신규
```

단일 파일 안에서 호스트별로 분기하는 안(공통 단계 안에 코드블록 두 벌)을 먼저 시도했다가 되돌렸습니다 — 절차를 처음부터 끝까지 따라가는 독자에게는 자기완결성이 중복 제거보다 우선합니다. `claude-code.md` 는 `0ca6ecf8` 내용 그대로이며, 이동에 따른 3줄만 다릅니다(제목 호스트 명시, 상대 링크 깊이 2건).

## 별도 결함으로 라우팅

- **`/bound`** — "Codex 생태계" 의 적용 범위(CLI/데스크톱/IDE, 전역/프로젝트), 기존 `AGENTS.md` 블록의 소유권과 갱신 권한
- **`/inquire`** — 포인터 지시문이 모든 Codex 표면·샌드박스에서 이행되는지. 이번 세션에서 읽히는 것은 확인했으나 일반 동작의 증거는 아닙니다.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
→ fail: 0, warn: 0
```

상대 링크 7건 전부 해소 확인. 체리픽 결과 트리가 원 커밋 `cfe3f089` 와 동일함을 확인했습니다.

## 브랜치 이력 참고

이 커밋은 처음에 `feat/premise-setup-readme` 에 올라갔는데, 그 브랜치의 PR #725 는 이미 머지된 뒤였습니다. `origin/main` 에서 새로 자른 브랜치로 체리픽했습니다. 구 브랜치에 남은 `cfe3f089` 는 내용상 이 PR 의 커밋과 동일합니다.


---

## Codex 리뷰 반영 (`b582c377`, `206978e3`)

PR 을 Codex 에 리뷰시켰습니다. `references/codex.md` 는 Codex 에이전트가 실행할 절차이므로 실행 주체 본인에게 판정시켰습니다. 판정은 **변경 요청**이었고, 지적된 결함을 아래와 같이 처리했습니다.

### High — `AGENTS.override.md` 처리가 사용자 전역 지침을 삭제할 수 있었다

전역 로더는 존재하는 첫 파일이 아니라 **비어 있지 않은** 첫 파일을 고릅니다.

```rust
for candidate in [LOCAL_AGENTS_MD_FILENAME, DEFAULT_AGENTS_MD_FILENAME] {
    if !String::from_utf8_lossy(&data).trim().is_empty() { return ... }
}
```
<sub>openai/codex <code>rust-v0.146.0</code> <code>codex-rs/codex-home/src/instructions/mod.rs</code> — 직접 받아 확인</sub>

기존 문구("override 가 있으면 그쪽이 읽히니 거기 넣어라")를 빈 override 가 있는 머신에서 그대로 따르면, 절을 쓰는 순간 그 파일이 non-empty 가 되어 사용자의 `AGENTS.md` 전체가 지시문 체인에서 빠집니다. "덧붙이고 대체하지 말 것"이라는 안전장치를 지키면서 전역 지침이 통째로 사라지는 경로였습니다. 세 경우로 분기하고 override 의 임시성을 명시했습니다.

원인: 앞서 `core/src/agents_md.rs`(프로젝트 체인)를 확인하고 전역 파일 선택으로 일반화했습니다. 두 파일은 다른 로더입니다.

### High — Step 4 검증이 위양성을 냈다

"되돌리기 어려운 행동 전에 읽을 문서" 의 정답 `boundaries-and-safety.md` 는 주제어에서 그대로 유추됩니다 — 아무것도 읽지 않은 설정도 통과합니다. Codex 쪽은 이것이 유일한 검증이었습니다.

색인을 읽어야만 답이 나오는 질문으로 교체했습니다: "시간·날짜가 존대 없이 올 때" → `matching-the-request.md`. 트리거 문구까지 요구해 답이 파일 내용에 의존하게 했고, 이 확인이 무엇을 입증하고 무엇을 입증하지 않는지도 적었습니다.

### Medium — Step 2 가 절대경로를 내놓지 않았고 로컬 마켓플레이스를 처리하지 못했다

`ls DIR` 은 디렉터리 이름이 아니라 내용을 출력하는데 "이 출력이 보인 절대경로를 보관하라"고 적혀 있었습니다. 또 경로를 GitHub 소스 마켓플레이스 루트로 하드코딩해, 루트 README 가 개발용으로 안내하는 `codex plugin marketplace add /path/to/...` 설정에서는 전제가 충족돼도 Step 2 가 실패했습니다. `codex plugin marketplace list` 의 `ROOT` 를 읽는 방식으로 두 결함을 함께 해소했습니다.

### Medium — 라우터의 Codex 분기가 로컬 전제를 말하지 않았다

지원 범위를 **로컬 표면(CLI + 데스크톱)** 으로 선언하고 클라우드를 명시적으로 범위 밖에 뒀습니다. 라우터에는 호스트 중립으로 적었습니다 — 두 절차 모두 호스트가 돌고 있는 머신의 경로를 써넣으므로 Claude Code 웹 표면에도 같은 경계가 걸립니다. `references/claude-code.md` 는 손대지 않았습니다.

### Low — 과잉 일반화 문구 3건

`.tmp` 가 모든 마켓플레이스를 담는다는 서술(실제로는 번들·런타임이 각기 다른 형태), 바이트를 "그대로" 넣는다는 서술(손실 디코딩 + 공백 정리), heading level 지시의 모호성을 각각 정정했습니다.

## `/inquire` — 도달 가능성은 미확정으로 남습니다

Aitesis 판정은 **일반적 예/아니오를 지지하지 않음** 이었습니다.

확정된 것: 지시문 텍스트가 모델 문맥에 도달하는 것, 컨텍스트 압축이 그 계층을 버리지 않는 것(`compact.rs` 초기 컨텍스트 재주입). 둘 다 "텍스트가 거기 있다"이지 "지목한 파일이 읽힌다"가 아닙니다.

미확정으로 남은 축: 모델·추론 강도·샌드박스 프로파일·세션 길이, 대화형 CLI 와 `codex exec` 의 차이, 데스크톱 표면, 작업 트리 바깥 경로의 샌드박스 도달성, 압축 전후 대상 파일 읽힘, 그리고 "작동한다"의 성공률 기준(사람 소유 결정).

Codex 의 실증 탐침은 중첩 샌드박스에서 실패했습니다(`failed to initialize in-process app-server client: Operation not permitted`). 본인이 명시했듯 긍정도 부정도 아닌 결과이며, 탐침은 Codex 세션 바깥에서 직접 돌려야 합니다.

문서는 이 미확정을 숨기지 않고 범위 절과 step 4 에 적어 뒀습니다.
