### PR TITLE
fix(epistemic-cooperative): white-bear SKILL.md 하드코딩된 개수 표현 제거

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/white-bear/SKILL.md
+++ b/epistemic-cooperative/skills/white-bear/SKILL.md
@@ -11,7 +11,7 @@ A semantic audit of LLM-facing prose for the White Bear authoring principle: kee
 
 ## Purpose
 
-Surface prose that holds the model's attention on an unnecessary competing target, before it ships. Three forms of one failure: **prohibition framing** names a forbidden act, **superseded-path mention** names a retired path, **negated anchoring** names a rejected alternative — each keeps the non-target available as a competing action candidate. This drift survives deterministic structural checks — it is a meaning-level pattern, so a semantic reviewer catches what literal pattern matching cannot.
+Surface prose that holds the model's attention on an unnecessary competing target, before it ships. **Prohibition framing** names a forbidden act, **superseded-path mention** names a retired path, **negated anchoring** names a rejected alternative — each keeps the non-target available as a competing action candidate. This drift survives deterministic structural checks — it is a meaning-level pattern, so a semantic reviewer catches what literal pattern matching cannot.
 
 ## Inputs
 


### PR DESCRIPTION
## 배경

이 저장소는 "count-free protocol cardinality"를 settled direction으로 선언한다
(`CLAUDE.md` §Settled Directions): 개수가 늘어나면 거짓이 되는 하드코딩된 개수
표현을 prose·주석·테스트명·메타데이터에서 배제한다. PR #728에서 `premise/` 문서들과
`.claude/principles/safeguards.md`에서 이 결함을 제거했지만, Plugin Encapsulation
규칙상 `SKILL.md`는 `premise/`를 참조하지 않고 원칙을 직접 inline하기 때문에
컴파일된 사본 한 곳이 그대로 남아 있었다.

## 변경 내용

`epistemic-cooperative/skills/white-bear/SKILL.md` 14번째 줄(`## Purpose` 문단)에서
"Three forms of one failure"라는 개수 표현을 제거했다. 네 번째 실패 형태가 향후
distinguish되면 "Three forms"라는 문장은 거짓이 되므로, 그 위험을 없앴다.

- 열거 구조(굵은 글씨로 강조된 세 형태 — **prohibition framing**,
  **superseded-path mention**, **negated anchoring** — 동일 순서, 개별적으로
  이름 붙은 형태)와 통합 절("each keeps the non-target available as a competing
  action candidate")은 그대로 유지했다. 산문으로 풀어 쓰지 않았다 — 이 열거는
  스캐닝을 위한 구조이기 때문이다.
- 리드인 문구는 완전히 제거하고 열거 자체가 "before it ships." 뒤를 바로
  이어받게 했다 ("Forms of one failure:"라는 count-free 리드인 후보도 검토했으나,
  단독으로 읽을 때 다소 끊기는 느낌이 있어 채택하지 않았다).

## 부수 변경

`docs/co-change.md`의 "Any protocol change requires plugin.json version bump"
규칙에 따라, 그리고 Codex 매니페스트 동시 커밋 요구사항(`docs/co-change.md:16`)에
따라 다음 두 파일의 버전을 `4.18.0` → `4.18.1`로 함께 올렸다:
- `epistemic-cooperative/.claude-plugin/plugin.json`
- `epistemic-cooperative/.codex-plugin/plugin.json`

## 검증

`node .claude/skills/verify/scripts/static-checks.js .` 결과는 편집 전후 동일:
**142 pass / 0 fail / 0 warn**. `scripts/package.test.js`는 커밋 훅에서
자동 실행되어 74/74 통과했다 (직접 별도 실행하지는 않음).

## 불확실하게 남긴 점

작업 브리프는 base commit을 `3f1f2c94`, 버전을 `4.17.2`로 전제했으나, `fetch` 시점에
`origin/main`은 이미 `6d7ae088`(PR #732 병합 포함)로, `plugin.json` 버전은 이미
`4.18.0`으로 앞서 있었다. 두 선행 갱신 모두 이 PR이 건드리는 파일에는 영향이 없어,
별도 확인 없이 최신 `origin/main`에서 브랜치를 잘라 그대로 진행했다.
