### PR TITLE
refactor(premise): separate shared wiring from host bindings

### DIFF
--- a/premise/README.md
+++ b/premise/README.md
@@ -6,29 +6,88 @@ moment each one is for. This file covers adopting them.
 They are a reference surface, not a package. There is no install script and nothing to run here —
 they are meant to be reached by URL, read, and used in one of two ways: **link to them** from your
 own global configuration or notes, the way you would cite any external reference, or **copy the
-parts you want** into your own instructions, verbatim or adapted. Each document stands on its own —
-it does not assume you know any particular project, tool, or vocabulary beyond what it defines
-itself — so a subset is a coherent adoption.
+parts you want** into your own instructions, verbatim or adapted. Each premise document stands on
+its own, so adopting a subset is coherent.
 
-The rest of this file routes to the first way, worked out concretely for each host — how to wire the
-documents in so they stand as a reference layer.
+The rest of this file defines the shared procedure for the first way. A host reference binds that
+procedure to one configuration root, marketplace-discovery mechanism, instruction surface,
+delivery mechanism, and verification check:
 
-**If you are an agent and someone handed you this URL**: identify the host you are running in, then
-follow that one file end to end. A go-ahead checkpoint before the global write pauses that
-procedure; once the person gives it, resume the same procedure and complete the section or file
-addition. Each host file is self-contained; following both would write two setups over each other.
+- **[Claude Code](references/claude-code.md)** — an always-loaded rules file imports the standing
+  documents.
+- **[Codex](references/codex.md)** — a global instruction section points an agent to the standing
+  documents because Codex expands no import directive.
 
-- **[Claude Code](references/claude-code.md)** — the documents are imported into an always-loaded
-  rules file, so the host itself puts them in context.
-- **[Codex](references/codex.md)** — the documents are named by a standing instruction to read them
-  at the moments that call for them, because Codex expands no import directive.
+**If you are an agent and someone handed you this URL**: identify the host you are running in, read
+this shared procedure and that host's reference before acting, then follow them as one procedure end
+to end. A go-ahead checkpoint before the global write pauses the procedure; once the person gives
+it, resume and complete the approved write. Follow one host reference only.
 
-Both procedures wire the machine the host is running on: each resolves a configuration directory
-there and writes an absolute path on that machine into it. A run isolated from those files — Codex
-cloud, or any remote sandbox — cannot follow either, and would have to establish the layer wherever
-its own instructions come from instead.
+Both adapters wire the machine the host is running on. A run isolated from its configuration and
+marketplace files cannot follow either path; establish the layer on the instruction surface that
+the isolated run actually receives instead.
 
-The shape is the same in both: the index and the two documents bearing on every turn are reached
-first, and the rest arrive when their moment does. Only the mechanism differs. If your host is
-neither, that shape is what generalizes — put the index wherever your instructions always load, and
-reach the rest at the moment its entry names.
+## Shared procedure
+
+### 1. Resolve the configuration root
+
+Use the selected host reference's resolver. Resolve the host's environment override and fallback
+once; do not assume the fallback is active.
+
+### 2. Discover the premise root
+
+Use the host reference's discovery mechanism and confirm that `AGENTS.md` appears beside the
+individual premise documents. The configuration root and premise root are separate coordinates: a
+marketplace sourced from a local checkout may live outside the configuration root.
+
+Keep the premise root as a literal absolute path. The global write in step 3 must point to the
+location the host actually reported, rather than leaving an environment variable or placeholder
+for a future session to resolve.
+
+### 3. Prepare and complete the global write
+
+Use the host reference's target, precedence rules, and template. Substitute every
+`<PREMISE_PATH>` with the absolute premise root from step 2.
+
+Before writing:
+
+- inspect the target and any host-specific file that can supersede it;
+- preserve all existing guidance;
+- show the person the exact text and destination;
+- flag existing guidance that overlaps a premise principle without resolving the overlap; and
+- get their go-ahead because the write affects every local session for that host.
+
+The checkpoint authorizes the write it previewed. Once approval arrives, perform that write and
+continue to verification rather than treating approval as completion.
+
+The standing layer carries the index plus `recognition-and-authority.md` and
+`approach-verification.md`, the two documents that bear on every turn. The index names when to read
+every other document.
+
+### 4. Verify in a fresh session
+
+Use the host reference's loading check, then ask the fresh session to reproduce the complete index
+entry for `matching-the-request.md`. That entry names four triggers: design level, fix scope,
+question granularity, and a time or date without a stated zone. Requiring all four makes the answer
+depend on the index rather than on a guess from the filename.
+
+A correct response establishes that the index was reached at the configured path in that session.
+It does not establish that the two other standing documents were also read, or that another session
+will behave the same way. Treat a wrong answer as an absent layer.
+
+## Keeping it current
+
+The host's plugin manager keeps its own marketplace clone in sync with upstream. Claude Code and
+Codex maintain separate clones, so they can temporarily carry different revisions even when both
+point to this repository. Removing or replacing a marketplace can make its recorded path disappear
+without a loud failure; repeat step 4 after either event.
+
+For a copy that changes only when you say so, clone the repository to a path you own and use that
+clone as the premise root. The rest of the procedure is unchanged.
+
+## Adapting
+
+The three standing documents above are one setup's choice, not a required set. A document you adopt
+governs the general principles within the scope you adopted it for; a document you do not adopt
+governs nothing. A project may bind a narrower or wider set on its own instruction surface without
+changing the global layer.

--- a/premise/README.md
+++ b/premise/README.md
@@ -14,8 +14,9 @@ The rest of this file routes to the first way, worked out concretely for each ho
 documents in so they stand as a reference layer.
 
 **If you are an agent and someone handed you this URL**: identify the host you are running in, then
-follow that one file end to end. Each is self-contained; following both would write two setups over
-each other.
+follow that one file end to end. A go-ahead checkpoint before the global write pauses that
+procedure; once the person gives it, resume the same procedure and complete the section or file
+addition. Each host file is self-contained; following both would write two setups over each other.
 
 - **[Claude Code](references/claude-code.md)** — the documents are imported into an always-loaded
   rules file, so the host itself puts them in context.

--- a/premise/references/claude-code.md
+++ b/premise/references/claude-code.md
@@ -1,55 +1,51 @@
-# Setting up this layer — Claude Code
+# Premise host adapter — Claude Code
 
-[`AGENTS.md`](../AGENTS.md) beside these documents describes what they are and the two ways to
-adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
-how to wire the documents into a Claude Code setup so they load as a standing reference layer.
+Use this adapter with the [shared setup procedure](../README.md). If someone handed you this page
+directly, read the shared procedure first, then return here and carry the combined procedure through
+verification.
 
-**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
-writes into that person's global configuration directory, so show them the file first and get their
-go-ahead before writing it.
-
-## What you end up with
-
-- The premise documents on disk, kept in sync by Claude Code's plugin manager.
-- One always-loaded rules file that states the split between the general principles (these
-  documents) and the operating rules of the host setup, and that loads the document index plus the
-  documents bearing on every turn.
-- Every other document reachable on demand, at the moment the index names for it.
+**Scope**: Claude Code running locally, with its configuration directory and marketplace files on
+the same machine. An isolated run needs the layer established on its own instruction surface.
 
 ## Prerequisite
 
-This repository's marketplace is already added — that is what puts these documents on disk, and the
-[root README](../../README.md)'s install covers it. For this reference layer alone, without any of the
-protocol plugins, adding the marketplace by itself is enough:
+The repository marketplace must already be added. For the premise layer alone, adding the
+marketplace is sufficient:
 
 ```bash
 claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
 ```
 
-## Step 1 — resolve the configuration directory
+## Host bindings
 
-Claude Code's configuration directory is `$CLAUDE_CONFIG_DIR` when that variable is set, and
-`$HOME/.claude` otherwise. Resolve it once rather than assuming either:
+### Configuration root
 
-```bash
-echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-```
-
-Both the clone and the rules file from step 3 live under that directory.
-
-## Step 2 — confirm the documents landed
+Claude Code uses `$CLAUDE_CONFIG_DIR` when it is set and `$HOME/.claude` otherwise:
 
 ```bash
-ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/marketplaces/epistemic-protocols/premise/"
+config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+printf '%s\n' "$config_dir"
 ```
 
-`AGENTS.md` should appear alongside the individual documents. Keep the absolute path this listed —
-step 3 needs it written out literally.
+### Premise root discovery
 
-## Step 3 — write the rules file
+The managed marketplace lives under the resolved configuration root:
 
-Markdown files under `<config-dir>/rules/` load automatically. Create `rules/premise.md` there, with
-this content:
+```bash
+premise_path="$config_dir/plugins/marketplaces/epistemic-protocols/premise"
+printf '%s\n' "$premise_path"
+ls "$premise_path"
+```
+
+Use the printed `premise_path` as the literal absolute `<PREMISE_PATH>` in the template below.
+
+### Delivery mechanism and global surface
+
+Markdown files under `<config-dir>/rules/` load automatically, and `@` imports in them load the
+referenced files. Import paths are literal, so the wiring session resolves the configuration root
+before writing them. The target is `<config-dir>/rules/premise.md`.
+
+Create that file with this content after applying the shared procedure's preview and approval gate:
 
 ```markdown
 # Premise Layer
@@ -73,37 +69,11 @@ are read on demand when their trigger fires.
 @<PREMISE_PATH>/approach-verification.md
 ```
 
-Three things to get right:
+An existing `rules/premise.md` is an existing wiring decision. Show the proposed integration and
+let the person decide how it joins that file; do not replace it as though it were empty.
 
-- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2.** `@` imports do not
-  expand environment variables, so `$CLAUDE_CONFIG_DIR` left in an import line will not resolve.
-- **Show the file before writing it.** It lands in a global configuration directory and takes effect
-  in every session that person runs.
-- **Do not write over an existing `rules/premise.md`.** Someone who already has that file has their
-  own wiring — show them what you would add and let them decide where it goes.
+### Verification
 
-Why those three imports and not all of them: an always-loaded layer costs context on every turn, so
-it carries the index — which names each document and the moment that calls for it — plus the two
-documents that bear on every turn. The rest arrive when their moment does.
-
-## Step 4 — check it took
-
-Start a fresh session and run `/context`. The new rules file should be listed under **Memory
-files**. If it is missing there, it did not load and nothing above it took effect.
-
-As a second check, ask which premise document the agent would read before taking a hard-to-reverse
-action. A wired setup answers `boundaries-and-safety.md` from the loaded index.
-
-## Keeping it current
-
-The plugin manager keeps the clone in sync with upstream, so these documents can change under a
-setup that points at it. For a copy that changes only when you say so, clone the repository yourself
-to a path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
-
-## Adapting
-
-The three imports above are one setup's choice, not a required set. Any subset works: a document you
-adopt governs the general principles within the scope you adopted it for, and a document you have
-not adopted governs nothing — `AGENTS.md` states that scoping rule. If your host is not Claude Code,
-the mechanism differs but the shape does not: put the index wherever your instructions always load,
-and reach the rest at the moment its entry names.
+Start a fresh session and run `/context`. The target rules file and its three imports should appear
+under **Memory files**. Then run the shared procedure's complete-entry question for
+`matching-the-request.md`.

--- a/premise/references/codex.md
+++ b/premise/references/codex.md
@@ -1,84 +1,62 @@
-# Setting up this layer — Codex
+# Premise host adapter — Codex
 
-[`AGENTS.md`](../AGENTS.md) beside these documents describes what they are and the two ways to
-adopt them: link to them, or copy the parts you want. This file covers the first way concretely —
-how to wire the documents into a Codex setup so they stand as a reference layer.
+Use this adapter with the [shared setup procedure](../README.md). If someone handed you this page
+directly, read the shared procedure first, then return here and carry the combined procedure through
+verification.
 
-Codex reaches them by pointer rather than by import. Its instruction loader reads each file's bytes
-and places the text into the instruction chain without interpreting it; no import directive is
-expanded, and nothing the text names is fetched on its behalf. So the layer is
-a standing instruction to read the documents at named moments, not a mechanism that loads them for
-you. Every difference below follows from that.
-
-**Scope**: Codex running locally — the CLI and the desktop app — where the configuration directory
-and the documents sit on the machine being wired. Codex cloud runs isolated from that machine's
-files and cannot follow these steps; the layer has to be established wherever a cloud run's own
-instructions come from. Whether every local surface follows the pointer in practice has not been
-established empirically — see step 4 for what the check does and does not settle.
-
-**If you are an agent and someone handed you this URL**: the steps below are yours to run. Step 3
-writes into that person's global configuration directory, so show them the text first and get their
-go-ahead before writing it.
-
-## What you end up with
-
-- The premise documents on disk, kept in sync by Codex's plugin manager.
-- One section in the global `AGENTS.md` that states the split between the general principles (these
-  documents) and the operating rules of the host setup, and that names the document index plus the
-  two documents bearing on every turn as required reading.
-- Every other document reachable on demand, at the moment the index names for it.
+**Scope**: the local Codex CLI and desktop app, with the configuration directory and premise
+documents on the same machine. Codex cloud cannot follow a pointer into those local files; establish
+the layer wherever a cloud run's own instructions come from.
 
 ## Prerequisite
 
-This repository's marketplace is already added — that is what puts these documents on disk, and the
-[root README](../../README.md)'s install covers it. For this reference layer alone, without any of
-the protocol plugins, adding the marketplace by itself is enough:
+The repository marketplace must already be added. For the premise layer alone, adding the
+marketplace is sufficient:
 
 ```bash
 codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
 ```
 
-## Step 1 — resolve the configuration directory
+## Host bindings
 
-Codex's configuration directory is `$CODEX_HOME` when that variable is set, and `$HOME/.codex`
-otherwise. Resolve it once rather than assuming either:
+### Configuration root
+
+Codex uses `$CODEX_HOME` when it is set and `$HOME/.codex` otherwise:
 
 ```bash
-echo "${CODEX_HOME:-$HOME/.codex}"
+config_dir="${CODEX_HOME:-$HOME/.codex}"
+printf '%s\n' "$config_dir"
 ```
 
-Both the clone and the file from step 3 live under that directory.
+### Premise root discovery
 
-## Step 2 — confirm the documents landed
-
-Ask Codex where it put the marketplace rather than assuming a path — a marketplace added from a
-local checkout resolves to that checkout, not to the managed location a GitHub-sourced one gets:
+Ask Codex for the marketplace root rather than deriving it from `config_dir`:
 
 ```bash
 codex plugin marketplace list
 ```
 
-Take the `ROOT` for `epistemic-protocols` from that output, and confirm the documents are under it:
+Take the `ROOT` for `epistemic-protocols`, append `/premise`, print that path in full, and confirm
+its contents. A marketplace added from a local checkout resolves to that checkout; a GitHub-sourced
+managed marketplace commonly sits under `<config-dir>/.tmp/`.
 
-```bash
-ls <ROOT>/premise/
-```
+Use the confirmed premise directory as the literal absolute `<PREMISE_PATH>` in the template below.
 
-`AGENTS.md` should appear alongside the individual documents. Write out `<ROOT>/premise` in full and
-keep it — step 3 needs that absolute path literally.
+### Delivery mechanism and global surface
 
-When the marketplace came from GitHub, that root sits under `<config-dir>/.tmp/`. The `.tmp` does not
-mean scratch: it is where Codex keeps marketplaces it manages, its own bundled ones among them, under
-sibling directories of the same parent.
+Codex expands no Markdown import directive. Its global instruction loader selects the first
+non-blank file from `<config-dir>/AGENTS.override.md` and `<config-dir>/AGENTS.md`; the premise layer
+therefore takes the form of a pointer in the file that actually loads.
 
-## Step 3 — add a section to the global AGENTS.md
+Resolve the target before previewing the write:
 
-Codex reads `<config-dir>/AGENTS.md` as global standing guidance. Two things it does not do decide
-the shape of what goes there: it does not expand `@path` imports, so an import line would arrive as
-literal text and load nothing; and `<config-dir>/rules/` is not a Markdown auto-load directory —
-`.rules` files there are sandbox and approval policy, so nothing belongs there for this purpose.
+- no override, or an override that is empty or whitespace only: append to `AGENTS.md` and leave the
+  empty override unchanged;
+- an override with content: append to that override and say that removing this temporary file will
+  remove the premise layer with it.
 
-What transfers is the pointer. Add this section:
+Append the following section after applying the shared procedure's preview and approval gate. Give
+the section the same heading level as the target file's other top-level sections.
 
 ```markdown
 # Premise Layer
@@ -100,65 +78,8 @@ premise document, read that document before acting on a case its operational wor
 already settle.
 ```
 
-Four things to get right:
+### Verification
 
-- **Substitute every `<PREMISE_PATH>` with the absolute path from step 2**, and give the section the
-  same heading level the file's other top-level sections use. The text arrives verbatim in the
-  instruction chain, so a path left as `$CODEX_HOME` would have to be resolved by the agent at read
-  time — which is the recall this layer exists to avoid.
-- **Append; never replace.** That file usually already carries someone's own guidance, and it takes
-  effect in every session they run.
-- **Check `AGENTS.override.md` in the same directory before touching anything.** Codex loads the
-  first of `AGENTS.override.md`, `AGENTS.md` whose contents are not blank — presence alone does not
-  decide it. Three cases, and they differ:
-  - No override, or an override that is empty or whitespace only → `AGENTS.md` is what loads; add the
-    section there and leave the empty override alone. **Writing into an empty override would make it
-    non-blank and drop the whole of `AGENTS.md` out of the instruction chain** — an append that
-    silently removes everything that file was carrying.
-  - An override with content → that is what loads, and `AGENTS.md` does not. Adding the section to
-    `AGENTS.md` would load nothing.
-  - Either way, an override is meant to be temporary. Say so when the section has to go into one:
-    removing that override later takes the premise layer with it.
-- **Flag overlap rather than resolving it.** Existing guidance in that file may already restate a
-  premise document's principle in its own words. Point out what overlaps and leave the removal to
-  the person whose file it is.
-
-Why those three documents and not all of them: standing instructions are read on every turn, so the
-layer carries the index — which names each document and the moment that calls for it — plus the two
-documents that bear on every turn. The rest arrive when their moment does.
-
-## Step 4 — check it took
-
-There is no import list to inspect here. Codex guarantees only that the `AGENTS.md` text reaches the
-instruction chain, not that the files it names get read — so the behavioral check is the check, and
-it has to be one the index actually settles.
-
-Start a fresh session and ask which premise document to read **when a time or date arrives without a
-stated zone**. A wired setup answers `matching-the-request.md`. Ask for the trigger phrasing too, so
-the answer has to come from the index rather than from the filename: the entry names that moment
-alongside three others about level, fix scope, and question granularity.
-
-The point of that particular question is that it cannot be guessed. A check like "which document
-before a hard-to-reverse action" invites the answer `boundaries-and-safety.md` from the topic word
-alone, and would pass on a setup where nothing was ever read.
-
-What this establishes and what it does not: a correct answer shows the index was reached at the path
-the section named. It says nothing about whether `recognition-and-authority.md` and
-`approach-verification.md` were also read, nor about any session other than the one you asked in.
-Nothing here fails loudly, so treat a wrong answer as the layer being absent rather than as a slip.
-
-## Keeping it current
-
-The plugin manager keeps the clone in sync with upstream, so these documents can change under a
-setup that points at it. The same clone is replaced when the marketplace upgrades and removed when
-the marketplace is removed — a path that disappears takes the layer with it silently, since nothing
-here fails loudly. For a copy that changes only when you say so, clone the repository yourself to a
-path you own and substitute that path in step 3 instead — the rest of the steps are unchanged.
-
-## Adapting
-
-The three documents above are one setup's choice, not a required set. Any subset works: a document
-you adopt governs the general principles within the scope you adopted it for, and a document you
-have not adopted governs nothing — `AGENTS.md` states that scoping rule. Codex layers project
-`AGENTS.md` files from the repository root down to the working directory, so a project that wants a
-narrower or wider set can name its own without touching the global section.
+Start a fresh local session and run the shared procedure's complete-entry question for
+`matching-the-request.md`. Codex guarantees that the pointer text reaches its instruction chain,
+not that the named files get read; this behavioral result is the loading check.


### PR DESCRIPTION
## What changed

- Moved the host-independent adoption flow into `premise/README.md`: configuration and premise-root resolution, approval, write completion, fresh-session verification, lifecycle, and adaptation.
- Reduced the Claude Code and Codex references to host adapters that bind their configuration variables, marketplace discovery, delivery mechanism, global instruction surface, precedence rules, and loading check.
- Clarified that an approved global write resumes and completes instead of ending at the approval checkpoint.
- Standardized both hosts on the full `matching-the-request.md` index entry as the behavioral proof that the index was reached.

## Why

The two references duplicated one wiring procedure while mixing shared obligations with host mechanics. That made the common contract harder to see and invited a false simplification in the other direction: a configuration root alone does not determine the marketplace root, active instruction surface, or valid loading check.

The split keeps environment-determined values observable through each host adapter while defining approval, preservation, completion, and verification once. It retains the guards introduced after earlier Codex review findings around local-checkout roots, non-blank `AGENTS.override.md` precedence, and guessable verification prompts.

## Impact

An agent starts from one shared procedure and one selected host adapter. `CLAUDE_CONFIG_DIR` and `CODEX_HOME` select their respective configuration roots; each adapter then resolves the authoritative premise root and materializes a literal absolute path on the host's actual instruction surface.

## Verification

- Exercised both adapters' configuration-root and premise-root discovery commands against the current local installations.
- `git diff --check`
- `node .claude/skills/verify/scripts/static-checks.js .` (`141` passed, `fail: []`, `warn: []`)
