### PR TITLE
refactor(scripts): load-protocols.js 죽은 코드 제거 — 소비자가 떠난 자리

### DIFF
--- a/scripts/load-protocols.js
+++ b/scripts/load-protocols.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Filesystem-walk loader for protocol/utility plugin set.
  *
@@ -6,7 +5,7 @@
  * per-plugin plugin.json self-description. This module derives all
  * enumeration shapes (PLUGINS, PROTOCOL_METADATA, PROTOCOL_ORDER,
  * PROTOCOL_FILES, etc.) from the filesystem so consumers (package.js,
- * static-checks.js, agent-symlinks sync) never carry a hand-curated list.
+ * static-checks.js) never carry a hand-curated list.
  *
  * Active set = filesystem plugin dirs minus those whose plugin.json carries
  * "deprecated": true. Deprecation lives in per-plugin self-description per
@@ -97,10 +96,6 @@ function extractTypeSignature(skillMd) {
   const fromBody = skillMd.content.match(re);
   if (fromBody) return { deficit: fromBody[1], resolution: fromBody[2] };
   return { deficit: null, resolution: null };
-}
-
-function capitalize(s) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 /**
@@ -219,24 +214,6 @@ function discoverPlugins(options = {}) {
 // over discoverPlugins() — recompute is cheap (per-call memoization keeps
 // reads at one per plugin.json).
 
-function pluginsTuples(options) {
-  return discoverPlugins(options).map(p => ({ dir: p.dir, skill: p.skill }));
-}
-
-function protocolMetadata(options) {
-  const records = discoverPlugins(options).filter(p => p.isProtocol);
-  const out = {};
-  for (const r of records) {
-    out[r.dir] = {
-      name: capitalize(r.dir),
-      command: `/${r.skill}`,
-      deficit: r.deficit,
-      resolution: r.resolution,
-    };
-  }
-  return out;
-}
-
 // Display order = Anamnesis (recall, session start) + canonical-precedence
 // linear extension + Katalepsis (structurally last).
 function protocolOrder(options) {
@@ -251,45 +228,12 @@ function protocolFiles(options) {
   );
 }
 
-function sourcePluginDirs(options) {
-  const records = discoverPlugins(options);
-  return [...new Set(records.map(r => r.dir))];
-}
-
 module.exports = {
   CANONICAL_PRECEDENCE,
   CANONICAL_CLUSTERS,
   discoverPlugins,
-  pluginsTuples,
-  protocolMetadata,
   protocolOrder,
   protocolFiles,
-  sourcePluginDirs,
   parseSkillFrontmatter,
   extractTypeSignature,
 };
-
-// CLI mode: shell scripts consume the active plugin/skill set via line-
-// delimited stdout. JSON-strict deprecated handling lives in this loader
-// (not in shell grep), so shell consumers inherit the same equality
-// semantics the JS code uses (PR #351 review M2).
-if (require.main === module) {
-  const arg = process.argv[2];
-  switch (arg) {
-    case '--list-plugin-dirs': {
-      const dirs = sourcePluginDirs();
-      process.stdout.write(dirs.join('\n') + '\n');
-      break;
-    }
-    case '--list-skill-tuples': {
-      const tuples = pluginsTuples().map(p => `${p.dir}/${p.skill}`);
-      process.stdout.write(tuples.join('\n') + '\n');
-      break;
-    }
-    default:
-      process.stderr.write(
-        'usage: load-protocols.js [--list-plugin-dirs|--list-skill-tuples]\n'
-      );
-      process.exit(1);
-  }
-}


### PR DESCRIPTION
## 무엇을 하는가

`scripts/load-protocols.js`에서 호출자가 없는 코드를 걷어낸다. 1파일 +1/-57.

## 제거한 것과 그 근거

| 항목 | 근거 |
|---|---|
| CLI 모드 전체(`--list-plugin-dirs` / `--list-skill-tuples`) + shebang | `--list-skill-tuples`는 `aa315058`에서 `scripts/sync-agents-symlinks.sh`를 위해 들어왔고(PR #351 리뷰 M2 — "JSON-strict 동등성을 helper 한곳에서 보장"), 그 소비자가 `52a2211c` "Remove Agent Skills symlink view"에서 삭제됨. `--list-plugin-dirs`는 같은 커밋에 함께 들어왔으나 **이력상 호출된 적이 한 번도 없음** |
| `sourcePluginDirs`, `pluginsTuples` | 유일한 호출자가 그 CLI 블록. `sourcePluginDirs`는 그 전에 검증·심링크 쪽 소비자도 있었으나 `52a2211c`와 `a98d73c9`("리뷰 CI를 /lens-review 스킬로 전환")에서 차례로 사라짐 |
| `protocolMetadata` | 호출자 전무. `package.js:74`가 같은 모양을 `_records`에서 직접 만들고 있어 중복 |
| `capitalize` | 유일한 호출자가 `protocolMetadata`이고 export되지 않음 |

**투기적 API가 아니라 소비자가 떠난 자리였다.** 이 구분이 처분을 바꾸지는 않았지만, "쓰인 적 없는 것"과 "쓰이다 만 것"은 다른 이야기이므로 기록해 둔다.

## 남긴 것

- `protocolFiles` — `.claude/skills/verify/scripts/static-checks.js`가 18행에서 import하고 39행에서 호출한다
- `parseSkillFrontmatter`, `extractTypeSignature` — 둘 다 함수는 내부에서 살아 있고(`load-protocols.js:189`, `:191`) export 항목만 미사용이다. 실행되지 않는 구현을 걷어내는 것과 모듈의 공개 표면을 좁히는 것은 다른 판단이라 후보로만 남긴다. 좁히기로 한다면 둘을 함께 본다

> **정정** — 이 본문과 커밋 메시지(`011221ec`)는 처음에 "`protocolFiles`, `extractTypeSignature` — static-checks.js가 쓴다"라고 적었습니다. `extractTypeSignature`는 틀렸습니다. `static-checks.js`에서 그 이름은 49행 **주석에만** 나오고 import되지 않습니다. 같은 스윕에서 `capitalize`에 대해서는 "다른 파일 등장은 주석"임을 확인해놓고 이 심볼에는 같은 확인을 하지 않았습니다 — `rg -l`이 파일 목록만 주기 때문입니다. 처분(남긴다)은 바뀌지 않지만 근거가 달랐습니다. 커밋 메시지는 이미 푸시돼 수정하지 않으며, 정정은 여기에 둡니다.

## 부재 주장이 한 번 틀렸던 기록

첫 스윕은 `protocolFiles`도 죽은 것으로 분류했다. **ripgrep이 기본으로 숨김 경로를 건너뛰어 `.claude/` 전체가 보이지 않았고**, 그 안의 `static-checks.js:39`가 호출자였다. `rg --hidden`으로 다시 훑어 확정했다.

이걸 잡은 것은 테스트다 — `package.test.js`가 `static-checks.js`를 띄우다 `TypeError: protocolFiles is not a function`으로 실패했다. 미실행 판정의 사정거리는 그것을 지탱한 기록만큼이고, 이 경우 기록이 저장소의 절반을 빠뜨리고 있었다.

## 후속으로 남기는 제안 (이 PR 범위 밖)

이 저장소에는 린터도 dead-code 도구도 없고(devDependencies가 husky 단독), 근사한 정적검사 둘은 JS에 닿지 않는다 — `checkGraphIntegrity`의 orphaned-node는 `graph.json`만, `checkSpecVsImpl`의 미참조 TYPES는 SKILL.md 안쪽만 본다. `.husky/pre-commit`는 이 파일을 건드릴 때마다 도는데 "이 export를 누가 부르는가"를 묻는 단언이 없다. 그래서 이번 항목들이 조용히 쌓였다.

처음에는 "미사용 export 탐지는 결정적이므로 검사의 몫"이라는 이유로 전용 검사 추가를 제안했다. **자문을 받고 철회한다.**

"미사용 export"는 결정적이지 않다. 그 판정에는 **선언된 진입점**과 **공개 인터페이스 경계**가 먼저 있어야 하는데 이 저장소에는 둘 다 선언돼 있지 않다. 그것 없이 만든 저장소 전용 정규식이나 얕은 의존성 워커는 동적 CommonJS 접근과 외부 소비자에 대해 **이번에 실제로 겪은 것과 같은 종류의 거짓 확신**을 다시 만들어낼 뿐이다. 기존 검사 둘이 좁은 도메인 검사라는 사실도 그것을 JavaScript 분석기로 키울 근거가 되지 않는다.

죽은 export가 반복되면 순서는 이렇다 — 먼저 어떤 모듈이 내부 진입점인지 선언하고, 그다음에 유지보수되는 분석기 도입이나 정확한 export 계약 테스트를 별건으로 검토한다.

## 검증

- `node --test scripts/package.test.js anamnesis/scripts/hypomnesis-write.test.mjs` → exit 0
- `node .claude/skills/verify/scripts/static-checks.js .` → exit 0, FAIL 0, WARN 0
- `node scripts/package.js --dry-run` → exit 0
- `node scripts/generate-routing-map.js` → exit 0 (출력 동일, 재생성 차분 없음)
