### PR TITLE
feat: AI 판단의 단단함을 어조와 분리해 표시 (덩어리 A)

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.18.13",
+  "version": "4.18.14",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.18.13",
+  "version": "4.18.14",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -111,6 +111,21 @@ Basis points to evidence for an inference that is not obvious: a user utterance 
 - `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission breaks basis traceability — the user cannot distinguish AI inference from environmental relay.
 - `basis-as-paraphrase`: citing the user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
 
+### Firmness, Held Apart from Register
+
+`Basis:` says what a reading rests on; firmness says how tightly it is held. They are separate axes and either can be missing while the other is stated.
+
+Let a judgment's firmness track what the judgment rests on, not the register the surrounding text happens to be written in. In some languages one grammatical marking carries a politeness register and a confidence register at once, so a softened sentence reads as an uncertain one whether or not the judgment behind it is. Two failures follow, and they are not the two ends of one dial:
+
+- **The register reaching the claim** — softening everything to sound courteous, so a firmly-grounded reading and a guess arrive in the same wrapper and the reader cannot tell which is which.
+- **Flattening the wording instead of fixing the leak** — writing decisively to sound sure, which strips the hedge off the guesses too and delivers a weak reading with a strong one's force.
+
+Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. A reading whose firmness is not stated and not obvious is one `Basis:` should carry, since the cited evidence is what a reader weighs it by.
+
+A form instruction reaches the wording and not the marking. Asked for a plainer or a more decisive register, change how the round reads while a weakly-held reading stays marked as weakly held — the same relation Form feedback names between what surrounds a pinned element and the element itself.
+
+**When to emit**: per-judgment, where the firmness differs from what the surrounding wording would suggest. Self-regulating — a mechanical relay asserts no judgment of its own and needs no marker.
+
 ## Protocol Recommendations
 
 When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -120,7 +120,7 @@ Let a judgment's firmness track what the judgment rests on, not the register the
 - **The register reaching the claim** — softening everything to sound courteous, so a firmly-grounded reading and a guess arrive in the same wrapper and the reader cannot tell which is which.
 - **Flattening the wording instead of fixing the leak** — writing decisively to sound sure, which strips the hedge off the guesses too and delivers a weak reading with a strong one's force.
 
-Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. A reading whose firmness is not stated and not obvious is one `Basis:` should carry, since the cited evidence is what a reader weighs it by.
+Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. Where a reading already carries `Basis:`, the cited evidence is also what a reader weighs its firmness by; where it does not, the firmness is stated in the prose rather than routed to a marker whose emit conditions are its own.
 
 A form instruction reaches the wording and not the marking. Asked for a plainer or a more decisive register, change how the round reads while a weakly-held reading stays marked as weakly held — the same relation Form feedback names between what surrounds a pinned element and the element itself.
 

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -159,7 +159,7 @@ Let a judgment's firmness track what the judgment rests on, not the register the
 - **The register reaching the claim** — softening everything to sound courteous, so a firmly-grounded reading and a guess arrive in the same wrapper and the reader cannot tell which is which.
 - **Flattening the wording instead of fixing the leak** — writing decisively to sound sure, which strips the hedge off the guesses too and delivers a weak reading with a strong one's force.
 
-Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. A reading whose firmness is not stated and not obvious is one `Basis:` should carry, since the cited evidence is what a reader weighs it by.
+Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. Where a reading already carries `Basis:`, the cited evidence is also what a reader weighs its firmness by; where it does not, the firmness is stated in the prose rather than routed to a marker whose emit conditions are its own.
 
 A form instruction reaches the wording and not the marking. Asked for a plainer or a more decisive register, change how the round reads while a weakly-held reading stays marked as weakly held — the same relation Form feedback names between what surrounds a pinned element and the element itself.
 

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -150,6 +150,21 @@ Basis points to evidence for an inference that is not obvious: a user utterance 
 - `never-basis`: silently omitting `Basis:` to avoid scrutiny → opacity. Guard: when AI interpretation materially shaped an output, omission breaks basis traceability — the user cannot distinguish AI inference from environmental relay.
 - `basis-as-paraphrase`: citing the user's own words as evidence for what the user explicitly said → false transparency. Guard: must cite evidence for an inference the user did not make.
 
+### Firmness, Held Apart from Register
+
+`Basis:` says what a reading rests on; firmness says how tightly it is held. They are separate axes and either can be missing while the other is stated.
+
+Let a judgment's firmness track what the judgment rests on, not the register the surrounding text happens to be written in. In some languages one grammatical marking carries a politeness register and a confidence register at once, so a softened sentence reads as an uncertain one whether or not the judgment behind it is. Two failures follow, and they are not the two ends of one dial:
+
+- **The register reaching the claim** — softening everything to sound courteous, so a firmly-grounded reading and a guess arrive in the same wrapper and the reader cannot tell which is which.
+- **Flattening the wording instead of fixing the leak** — writing decisively to sound sure, which strips the hedge off the guesses too and delivers a weak reading with a strong one's force.
+
+Turning hedging up or down fixes neither, because both are the same misplacement: firmness attached to tone rather than to ground. What fixes it is naming what the firmness rests on — what would change the reading, or that the reading is weakly held and why. A reading whose firmness is not stated and not obvious is one `Basis:` should carry, since the cited evidence is what a reader weighs it by.
+
+A form instruction reaches the wording and not the marking. Asked for a plainer or a more decisive register, change how the round reads while a weakly-held reading stays marked as weakly held — the same relation Form feedback names between what surrounds a pinned element and the element itself.
+
+**When to emit**: per-judgment, where the firmness differs from what the surrounding wording would suggest. Self-regulating — a mechanical relay asserts no judgment of its own and needs no marker.
+
 ## Protocol Recommendations
 
 When recommending a protocol, emit a single-line nudge prefixed with ↗ arrow:


### PR DESCRIPTION
파킹 백로그 실행 계획(`/apportion` → `/conduct` 2026-08-12)의 **덩어리 A**입니다. 실행단위 6이 들어 있습니다. (같은 덩어리의 실행단위 2는 편집 없이 끝났습니다 — 아래 참조.)

## 무엇을 고쳤나

`Basis:`는 판단이 **무엇에 기대는지**를 말합니다. 얼마나 **단단히 쥐고 있는지**를 말하는 자리는 없었습니다. Output Style에 형제 절로 답니다.

핵심은 헤지의 양이 아니라 헤지가 **무엇에 붙어 있는가**입니다. 실패가 둘인데 한 다이얼의 양 끝이 아닙니다:

- **어조가 주장까지 닿음** — 정중하게 들리려고 전부 누그러뜨려서, 단단히 근거 있는 판단과 짐작이 같은 포장으로 도착합니다.
- **새는 곳 대신 문면을 납작하게 함** — 단정하게 들리려고 평평하게 써서, 짐작에서도 헤지가 벗겨지고 약한 판단이 강한 판단의 힘으로 나갑니다.

## 자리를 어떻게 정했나 — 갈래가 아니라 **선례**였습니다

`/place`(실행단위 0)를 앞에 세운 값이 여기서 나왔습니다. `docs/structural-specs.md:143`이 `Basis:` **자신의 이전**을 기록하고 있습니다:

> 프로토콜 소유 TOOL GROUNDING에서 세션 층 관찰 층으로의 이 이전은 **Session-level observer exception(Audience Reach)**을 따른다 — nudge를 다스리는 것과 같은 구조적 패턴.

같은 가족(AI의 해석이 기계적 도출을 넘을 때 그것을 표시하는 통로)의 형제이므로 같은 자리로 갑니다. 뒷받침 둘:

- `checkEmitLoadDiscipline`이 모든 SKILL.md에 강제하는 라벨은 넷인데(`Context-Question Separation` · `Plain emit discipline` · `Round-local salience bundling` · `Form feedback`), **`Basis Marker`는 그 넷에 없습니다.**
- `Basis:`를 지고 있는 SKILL.md는 katalepsis 하나뿐이고, 그것도 사본이 아니라 **면제 선언**입니다 — "Socratic 검증은 AI 판단의 불투명함을 요구하므로 의도적으로 없음"(`katalepsis/skills/grasp/SKILL.md:150`).

## 계획 기록의 정정

**Task #11에 적힌 "한 구간을 넘침"은 틀렸습니다.** 그 판정은 이 내용이 `Plain emit discipline`을 타고 열여섯 SKILL.md로 번진다는 전제 위에 있었고, Session-level observer exception이 그 전제를 자릅니다. 만진 파일은 넷입니다.

단위 6이 혼자 판단했으면 넘친다고 보고 쪼갰을 것입니다 — `/place`를 앞에 세운 것이 그 값을 냈습니다.

## 내용의 근거

- LLM은 사용자 문체를 따라가도록 강하게 학습돼 표면 헤지를 내부 상태와 분리하지 못합니다 — arXiv 2605.28778.
- 헤지를 억누르면 확신 찬 오답 과신이라는 반대쪽 부작용이 나옵니다 — LessWrong n=900, d=2.67.

그래서 "헤지를 줄여라"도 "늘려라"도 처방이 아닙니다. 둘 다 같은 잘못 놓임 — 단단함이 지반이 아니라 어조에 붙어 있는 것 — 의 양면입니다.

## 계획 조건 둘 (확인함)

**#12 규율 진술 사이에 모순이 없다.** 충돌 후보를 하나 찾아 문장으로 끊었습니다: `Form feedback`은 사용자의 형식 지시가 다음 라운드까지 이어진다고 하고 자기 범위를 "밀도·순서·길이"로 못박는데, "단정하게 써 달라"는 지시가 위 둘째 실패로 읽힐 여지가 있었습니다. → **형식 지시는 문면에 닿고 표시에는 닿지 않는다**를 명시했습니다. `Form feedback` 자신이 "고정된 요소가 아니라 그 둘레를 바꾸라"고 말하는 관계와 같습니다.

**#13 PR #763이 세운 상태를 안 깬다.** 두 스타일 파일 모두 **15줄 추가 · 0줄 삭제**(순수 추가). #763이 세운 `Vocabulary rendering` · `Form feedback` · `Drift tracking`이 양쪽에 그대로 있습니다. `Drift tracking`의 사본 명단은 건드리지 않았습니다 — 이 절은 SKILL.md로 복사되지 않는 것이 판정의 요지이므로.

## 미러 처리

`ink-body-identity`가 두 스타일 파일의 본문 **바이트 동일**을 강제하므로, 손으로 같은 편집을 반복하지 않고 본문을 정본에서 재생성했습니다.

**한 번 틀렸다가 잡은 것**: 첫 재생성에서 `proactive` 쪽의 `# Per-Turn Reminder` 절을 날렸습니다(본문을 파일 끝까지로 봤음). 검사가 잡았습니다. 두 번째로 잡은 것은 그 절 앞의 **빈 줄**인데, `ink-body-identity`는 본문 슬라이스만 대조하므로 **검사가 잡지 않습니다** — 눈으로 확인해 복원했습니다. 리뷰하실 때 그 경계를 한 번 봐 주시면 좋겠습니다.

## 같은 덩어리의 실행단위 2 — 편집 없이 끝남

"사용자의 게이트 답변에서 확신 눈금이 typed 답변으로 환원될 때 사라진다"는 빈틈을 `anamnesis`(`/recollect`)로 보내자는 제안이 있었고, **기각했습니다.**

- `anamnesis/skills/recollect/SKILL.md:266` — `empty_intention(V) ≡ ∃ context(c, prior) : knows_exists(user, c) ∧ ¬can_locate(user, c)`. **이전** 맥락을 못 짚는 상태에 대한 존재 주장입니다.
- `:299` — Skip: "User provides specific reference (file path, session ID, issue number, exact quote)".

헤지는 둘 중 어느 쪽도 아닙니다. 게이트 답변은 지금 묻는 것에 답하는 것이지 이전 맥락을 되찾으려는 것이 아니고, 정확히 지목한 선택지도 헤지될 수 있으므로 인용의 정밀함과도 직교합니다.

저장소의 모든 `deficit:` 선언을 훑은 결과 **이 빈틈을 덮는 프로토콜 결핍이 없습니다.** 이것은 이 PR이 답하지 않는 열린 항목입니다 — 읽는 쪽(사용자 발화의 확신)은 여전히 자리가 없고, 이 PR은 쓰는 쪽(AI 출력의 확신)만 다룹니다.

## 검증

`node .claude/skills/verify/scripts/static-checks.js .` → `fail: []`, `warn: []`.

## 같이 여는 PR

#765 (덩어리 B, 실행단위 1·3)가 같은 계획에서 나옵니다. **두 PR이 `epistemic-cooperative`를 같은 버전(4.18.14)으로 올립니다 — 나중에 머지되는 쪽은 버전 한 칸을 올려야 합니다.**
