### PR TITLE
fix(verify): notation 검사 무조건 pass 기록 결함 수정

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -212,6 +212,10 @@ function checkNotation() {
 
   const mdFiles = walkFiles(projectRoot, e => e.name.endsWith('.md'), 'notation');
 
+  // Track this check's own warnings against the shared array so `pass` can't
+  // assert a clean result while violations were actually found below.
+  const warnCountBefore = results.warn.length;
+
   for (const mdPath of mdFiles) {
     let content;
     try {
@@ -240,11 +244,13 @@ function checkNotation() {
     }
   }
 
-  results.pass.push({
-    check: 'notation',
-    file: 'all .md files',
-    message: 'Notation consistency check completed'
-  });
+  if (results.warn.length === warnCountBefore) {
+    results.pass.push({
+      check: 'notation',
+      file: 'all .md files',
+      message: 'Notation is consistent across all scanned .md files'
+    });
+  }
 }
 
 // ============================================================


### PR DESCRIPTION
## 무엇을 고쳤나

`checkNotation()`이 위반을 `results.warn`에 쌓으면서도 루프 종료 후
무조건 `results.pass`에 "완료" 항목을 push하던 결함을 고쳤다. 이제
이 검사 자신이 warn을 하나도 추가하지 않았을 때만 pass가 남는다.

근거와 양방향 검증 결과는 커밋 메시지 참고.

## 범위

`.claude/skills/verify/scripts/static-checks.js`의 `checkNotation()`
함수만 수정. warn의 심각도와 검출 패턴은 변경하지 않았고, plugin.json
버전도 건드리지 않았다 (SKILL.md 콘텐츠 변경 없음).
