### PR TITLE
fix(premise): 하류가 답의 형태에 기대는 것까지 부정하던 문장을 좁힌다

### DIFF
--- a/premise/specification-and-judgment.md
+++ b/premise/specification-and-judgment.md
@@ -14,9 +14,9 @@ The two are not ends of one scale, and an indeterminate step does not become det
 
 ## What a Type Layer Does on the Indeterminate Side (Architectural)
 
-On the determinate side a type is a guarantee: it says what a value is, and the procedure downstream may rely on that. On the indeterminate side it cannot be that, because nothing downstream is entitled to rely on how a judgment came out. What it is instead is a narrowing.
+On the determinate side a type is a guarantee: it says what a value is, and the procedure downstream may rely on that. On the indeterminate side it cannot be that, because nothing downstream is entitled to rely on the judgment being right. It may still route on which form the answer took — that form is what the specification fixed, and it is not the judgment. What it is instead is a narrowing.
 
-Typing an indeterminate step means cutting down what the judgment looks at and giving that material structure — one claim per unit rather than several bundled together, a named channel on each piece of evidence rather than undifferentiated text, a positive statement rather than a negation, and whatever is rewritten on every pass left out because it carries no signal. Two units shaped that way can be set beside one another and their overlap means something.
+Typing an indeterminate step means cutting down what the judgment looks at and giving that material structure — one claim to a unit rather than several bundled together, each piece of evidence on a named channel rather than run together as undifferentiated text, a positive statement rather than a negation, and whatever every unit restates identically left out, because what does not vary carries no signal.
 
 That is the whole of the contribution, and it is worth making: it raises the odds the judgment lands right without pretending to make it. The distinction is between shaping a judgment's input and supplying its output.
 


### PR DESCRIPTION
#809를 머지한 뒤, 그 리뷰(`/review-loop codex 809`) 2라운드가 올렸으나 커밋에 담기지 못한 두 건을 반영합니다. 둘 다 `premise/specification-and-judgment.md` §2에 있고, 둘 다 검증된 high입니다.

## 하나 — 하류 의존을 통째로 부정하던 문장

**있던 것**

> On the indeterminate side it cannot be that, because nothing downstream is entitled to rely on **how a judgment came out**.

`recognition-and-authority`의 typed answer와 `tiering-and-scope`의 Checkpoint Policy는 둘 다 하류가 **어느 답이 왔는지에 따라 서로 다른 경로로 갈라지는 것**을 전제합니다 — 명세가 정하는 것이 바로 그 선택 구조입니다. "어떻게 나왔는지"가 도출 과정을 뜻하면 참이지만 나온 결과를 뜻하면 그 둘과 부딪치고, 문장은 어느 쪽인지 말하지 않았습니다.

**고친 것** — 부정의 과녁을 옮겼습니다.

> On the indeterminate side it cannot be that, because nothing downstream is entitled to rely on **the judgment being right**. It may still route on which form the answer took — that form is what the specification fixed, and it is not the judgment.

이 문서는 남이 통째로 가져다 쓰는 표면이라, 고치지 않으면 채택한 독자가 멀쩡한 답 carrier와 분기를 걷어낼 수 있습니다.

#809에서 이 지적의 절반만 걷어냈던 것을 여기서 마저 고칩니다. 당시 지적은 두 갈래(과잉 부정 + 열거 금지)였는데 뒤엣것만 손댔고, 2라운드가 같은 자리를 다시 high로 올렸습니다.

## 둘 — 좁히기 설명이 §1의 세 예시 중 하나만 덮던 것

§1은 비결정 판단의 예로 셋을 듭니다 — **둘이 같은 것인지**, 어떤 주장이 정당한지, 어떤 읽기가 지금 상황에 맞는지. 그런데 §2 문단은 이렇게 끝났습니다:

> Two units shaped that way can be set beside one another and their overlap means something.

나란히 놓을 두 단위가 있는 것은 **첫째뿐**입니다. 나머지 둘에는 비교할 상대가 없습니다. 같은 자리에서 "매 회차"도 무엇의 회차인지 문서 안에 없어, 이 저장소를 모르는 독자에게 해소되지 않았습니다. 저장소 이름을 하나도 부르지 않고 일어나는 누출이라 #809 본문의 키워드 부재 검사가 닿지 않는 종류였습니다.

마지막 문장을 들어내고 목록의 어휘를 회차 개념 없이 다시 적었습니다.

**택하지 않은 길**: 세 예시를 모두 덮도록 문단을 늘리는 것. 문서 자신이 "고침은 또 하나의 경우가 아니라 빼기"라 하고, 좁히기의 값어치는 바로 다음 문단이 일반형으로 이미 담고 있습니다("판단이 옳게 떨어질 확률을 올린다"). 다만 **이 선택은 구체적인 payoff 한 줄을 잃습니다** — 세 경우를 다 적는 쪽이 낫다고 보시면 그 문장을 되살리는 대신 나머지 둘도 함께 적어야 합니다.

## 크기

문서 전체가 797 → 810 단어로 늘었습니다. 문서 자신이 적어둔 크기 신호는 "좌표를 여는 수정"에 걸리는데 이 둘은 좌표를 열지 않습니다 — 앞엣것은 잘못 그어진 경계를 옮기고 뒤엣것은 과하게 일반화된 주장을 걷어냅니다. 그래도 늘어난 쪽이라 적어둡니다.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .   → 139 pass / 0 fail / 0 warn
node scripts/package.js --dry-run                        → 정상
node --test scripts/package.test.js …                    → 109 pass / 0 fail
```

## 여전히 열려 있는 것

#809에서 사람 판단으로 넘긴 채 남아 있습니다. 이 PR은 손대지 않았습니다.

- **배치** — 별도 문서냐 기존 문서의 절이냐. `premise/AGENTS.md`가 `recognition-and-authority`에 이미 이 순간을 붙여두고 있습니다: *"when deciding whether a specification may fix a criterion's answer in advance or must leave it to resolve at runtime."*
- **tier 라벨** — 세 절 전부 `(Architectural)`인데, §1은 `Axiom` 두 조항(파생의 바닥 / 모델이 좋아질수록 중요해짐)을 다 만족하고 §2·§3은 `Derived` 쪽으로 읽힙니다. 라벨을 떼는 것도 선택지입니다.
- **§3 크기 신호의 서술 강도** — "늘어났다면 연 것이 아니다"가 단정형인데 문단은 스스로 "신호"라 부릅니다.
- **"scaffolding" 용어 충돌** — `recognition-and-authority.md`가 이미 다른 뜻으로 씁니다.
