### PR TITLE
fix(premise): 색인의 순간 겹침과 scaffolding 용어 충돌을 없앤다

### DIFF
--- a/premise/AGENTS.md
+++ b/premise/AGENTS.md
@@ -8,7 +8,7 @@ Where a document depends on a concept from another, it says so and names the fil
 
 Each entry below names a moment rather than a subject, so what fires it is recognizing that moment in the work at hand — an inference drawn from what is actually happening, not from what the work is nominally about. A document here reaches a conversation about a contract, a summary, or a diagnosis as readily as one about code.
 
-Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a specification may fix a criterion's answer in advance or must leave it to resolve at runtime.
+Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a specification may fix a criterion's answer in advance at all.
 
 Read [`interaction-factorization.md`](interaction-factorization.md) when designing the options offered at a checkpoint, and when judging whether those options genuinely diverge or collapse to one dominant answer dressed up as several.
 
@@ -16,7 +16,7 @@ Read [`gate-design.md`](gate-design.md) when designing or defending a checkpoint
 
 Read [`tiering-and-scope.md`](tiering-and-scope.md) when deciding which surface a principle belongs on, and when classifying whether a principle should matter more or less as the underlying model improves.
 
-Read [`specification-and-judgment.md`](specification-and-judgment.md) when writing or revising a specification for a step whose result depends on a judgment rather than following from its inputs, and when cases keep accumulating around one coordinate a specification has already tried to settle.
+Read [`specification-and-judgment.md`](specification-and-judgment.md) when a criterion has to stay open to the run and the question is what the specification carries in place of the answer, and when cases keep accumulating around one coordinate a specification has already tried to settle.
 
 Read [`calibration-methodology.md`](calibration-methodology.md) when setting or changing how much a project resolves on its own versus routes to its user for judgment.
 

--- a/premise/specification-and-judgment.md
+++ b/premise/specification-and-judgment.md
@@ -22,7 +22,7 @@ That is the whole of the contribution, and it is worth making: it raises the odd
 
 A type layer doing this well is recognizable by what it does not contain — no comparison operator standing in for the judgment, no stated default for the case where it does not resolve. What it contains is the narrowed carrier and the instruction to judge.
 
-## The Scaffolding Failure (Architectural)
+## Cases in Place of a Judgment (Architectural)
 
 A specification that treats an indeterminate step as determinate does not fail at once. It fails by growing.
 


### PR DESCRIPTION
#809 리뷰에서 사람 판단으로 넘겼던 것 중 둘을 반영합니다. 종류가 달라 커밋을 나눴습니다.

`origin/main`(`0c73a9dd`)에서 새로 끊었습니다. #810과 형제 관계이고 스택이 아닙니다 — #810은 §2의 두 문장을, 이 PR은 색인과 §3 제목을 건드려 겹치는 줄이 없습니다.

## 하나 — 색인의 두 항목이 한 순간을 겹쳐 쥐던 것 (`42524cb9`)

색인은 문서를 주제가 아니라 **그 문서를 부르는 순간**으로 가리킵니다. 그래서 한 순간이 두 항목에 걸리면, 그 순간에 선 독자가 어디로 갈지 정해지지 않습니다.

#809이 새 항목을 넣을 때 그 앞 절이 `recognition-and-authority` 항목의 셋째 절과 같은 자리를 가리켰습니다. 명세를 쓰는 사람에게는 "판단에 걸린 단계를 명세할 때"와 "이 기준의 답을 미리 정해도 되는지 판정할 때"가 같은 순간이기 때문입니다.

**나누는 선**은 *미리 정해도 되는가*와 *안 된다면 명세가 그럼 무엇을 지고 가는가* 사이에 있습니다. 양쪽을 함께 고쳤습니다.

| | 전 | 후 |
|---|---|---|
| `recognition-and-authority` | …may fix a criterion's answer in advance **or must leave it to resolve at runtime** | …may fix a criterion's answer in advance **at all** |
| `specification-and-judgment` | **when writing or revising a specification for a step whose result depends on a judgment rather than following from its inputs** | **when a criterion has to stay open to the run and the question is what the specification carries in place of the answer** |

앞 항목에서 뺀 "or must leave it to resolve at runtime"이 결정의 두 갈래를 다 품고 있었고, 그중 열어두는 쪽이 새 문서가 맡는 자리입니다. 결정 자체는 그대로 그 항목에 남습니다.

**문서를 접는 길은 택하지 않았습니다.** 문서 수준의 분업은 성립합니다 — *왜 열려 있어야 하는가*와 *그래서 명세가 무엇을 지는가*는 다른 물음이고, 겹친 것은 색인 문구였지 문서가 아니었습니다.

## 둘 — `scaffolding`이 컬렉션 안에서 두 뜻을 갖던 것 (`a80429f7`)

`recognition-and-authority.md`가 이 낱말을 이미 다른 뜻으로 씁니다 — 서 있을 자리가 없는 것(되풀이되는 보일러플레이트, 곁다리 서술, 어떤 결정도 걸리지 않는 잔detail). 그쪽은 그 낱말로 **무엇이 근거가 되지 못하는지를 정의**하고 있어 먼저 자리를 잡았습니다. `premise/`는 부분 채택을 전제하는 표면이라 한 독자가 두 문서를 함께 들고 있을 수 있고, 그때 한 낱말이 두 뜻을 갖습니다. 나중에 온 쪽이 비킵니다.

> `## The Scaffolding Failure` → `## Cases in Place of a Judgment`

새 이름은 절이 실제로 서술하는 것에서 가져왔습니다 — 명세가 답할 수 없는 질문에 답하려다 경우를 쌓는 것. 절 자신의 마지막 문장이 *"The repair is subtraction rather than another case"*로 끝나므로 이름이 그 문장과 같은 낱말로 맞물리고, 색인 항목의 *"cases keep accumulating around one coordinate"*와도 같은 것을 가리킵니다.

저장소 전체에서 옛 이름을 부르는 곳은 이 제목 한 줄뿐이었고 절 본문도 그 낱말을 쓰지 않아, 따라 고칠 참조가 없습니다. 반영 뒤 `premise/`에서 `scaffolding`은 `recognition-and-authority.md:42` 한 곳, 원래 뜻으로만 남습니다.

**tier 라벨은 `(Architectural)` 그대로 뒀습니다.**

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .   → 139 pass / 0 fail / 0 warn
node scripts/package.js --dry-run                        → 정상
node --test scripts/package.test.js …                    → 109 pass / 0 fail
```

## 아직 열린 것

**§3 크기 신호의 서술 강도** — 세 갈래(증거로 낮춤 / 둘째 신호 제거 / 유지)가 아직 판단 대기 중이라 손대지 않았습니다.

`premise/CLAUDE.md`는 `AGENTS.md`의 심링크라 색인은 한 곳만 고쳤습니다.
