### PR TITLE
fix(analogia): 인용된 영어 문구로 잠겨 있던 조건 둘을 행위로 다시 쓴다

### DIFF
--- a/analogia/.claude-plugin/plugin.json
+++ b/analogia/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "analogia",
   "description": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
-  "version": "1.10.15",
+  "version": "1.10.16",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/analogia/.codex-plugin/plugin.json
+++ b/analogia/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "analogia",
-  "version": "1.10.15",
+  "version": "1.10.16",
   "description": "Validate structural mapping between domains — /ground (ἀναλογία: a proportion)",
   "author": {
     "name": "Jongwon Choi",

--- a/analogia/skills/ground/SKILL.md
+++ b/analogia/skills/ground/SKILL.md
@@ -239,7 +239,7 @@ Heuristic signals for mapping uncertainty detection (not hard gates):
 |--------|-----------|
 | Abstract framework applied | AI output uses a pattern, model, or analogy without domain-specific validation |
 | Cross-domain transfer | Concept from one domain applied to a structurally different domain |
-| Grounding probe | User requests "concrete example", "how does this apply to my case", "show me in my context" |
+| Grounding probe | User asks for the abstraction to be made concrete — for an instance of it, or for how it lands in their own case |
 | Structural mismatch indicators | Abstract assumptions that may not hold in the concrete domain |
 | Self-grounding (abstraction vs its own instances) | A located/named abstraction is checked against the instances it claims to subsume (wrong-fusion suspicion) — Sₐ = the abstraction, Sₜ = its own members. Distinct from the colimit route-away case (locator absent → /induce); here the abstraction already has a name and is tested for whether it fuses dissimilar instances |
 
@@ -247,7 +247,7 @@ Heuristic signals for mapping uncertainty detection (not hard gates):
 
 **Skip**:
 - Output is already domain-specific with concrete instantiations
-- User explicitly says "I understand the mapping" or "this applies"
+- User explicitly declares the mapping already established
 - Same domain pair was validated in current session (session immunity)
 - Phase 1 domain analysis confirms structural correspondence is trivial
 - No abstract framework is applied (output is purely concrete)


### PR DESCRIPTION
## 무엇을 고치는가

`analogia/skills/ground/SKILL.md`의 두 자리가 조건을 **사용자가 말해야 하는 영어 단어**로 진술하고 있었다.

```
-239  | Grounding probe | User requests "concrete example", "how does this apply to my case", "show me in my context" |
-250  - User explicitly says "I understand the mapping" or "this applies"
```

`premise/recognition-and-authority.md` §Context and Utterance as First-Class Ground가 런타임에 열어 두라고 하는 좌표를 명세가 미리 닫은 자리다. 영어 아닌 언어로 일하는 사용자는 조건을 충족할 수 없고, 영어 사용자도 다른 표현을 쓰면 마찬가지다. 가정이 아니다 — 이 변경을 낳은 세션 자체가 전부 한국어로 진행됐다.

```
+239  | Grounding probe | User asks for the abstraction to be made concrete — for an instance of it, or for how it lands in their own case |
+250  - User explicitly declares the mapping already established
```

## 형제 문구를 이식하지 않았다

`euporia:230` / `aitesis:285` / `horismos:358`의 같은 수리는 전부 "…없이 진행할 것을 명시적으로 요청" 꼴이다. 그런데 analogia의 원문은 **요청이 아니라 선언**이다 — "I understand the mapping"도 "this applies"도 매핑의 상태를 단언하지, 건너뛰기를 요청하지 않는다.

형제 문구를 그대로 옮기면 양쪽으로 조건이 바뀐다. 좁아지는 쪽으로는 선언만 하고 진행을 요청하지 않은 사용자가 탈락하고, 넓어지는 쪽으로는 매핑을 긍정하지 않은 채 진행만 요청한 사용자가 유입된다.

그래서 선언 의미론을 유지하고, 어휘는 계약 자신의 것을 썼다. 활성화 게이트 술어가

```
:215  uncertain(mapping(Sₐ, Sₜ)) ≡ ∃ structure(s, Sₐ) : ¬established(correspondence(s, Sₜ))
```

이고 `:384`의 Gate specificity 행이 같은 것을 게이트로 재진술한다. 이 Skip이 발화하는 자리는 정확히 사용자가 `established(correspondence)`를 선언한 경우이므로, 새 문구는 조건을 단어 목록이 아니라 **활성화를 지배하는 그 술어**에 묶는다.

## 엄격도는 그대로다

Skip 조건은 충족되면 프로토콜이 **돌지 않는다**. 느슨해지면 돌아야 할 때 돌지 않고, 돌지 않은 프로토콜은 출력을 남기지 않으므로 그 실패는 조용하다. 그래서 문구만 풀고 조건은 건드리지 않았다.

- `explicitly` 유지 — 명시적 발화 요건 그대로
- 선언의 **대상** 유지 — 매핑에 관한 선언이어야 한다. 일반적 만족 표현이 아니다
- 선언의 **방향** 유지 — 긍정하는 선언이지 요청이 아니다

쓰지 않은 것: "the user seems to have understood" 류. 그것은 더 약한 **다른** 조건이지 같은 조건의 다시 쓰기가 아니다.

## 판단이 필요했던 두 자리

**두 번째 자리(`:239`) — 포함.** 결함의 종류가 같다(AI가 맞춰 보는 사용자 발화를 영어 문자열로 고정). 결정적 근거는 표 내부 일관성이다 — 같은 표의 다른 네 행은 이미 전부 행위로 명명돼 있고 이 행만 문자열을 세고 있었다. 위험 방향이 Skip과 반대라는 점(휴리스틱이 느슨해지면 시끄럽되 **보인다**)과 표가 스스로 "not hard gates"라고 밝힌다는 점은 실패의 무게를 낮추지만, 결함을 남길 이유는 아니다. 원문이 덮던 두 갈래를 둘 다 남겼다 — "예시를 달라"로 뭉뚱그리면 세부를 묻는 모든 요청에 발화하므로 그것은 넓히기다.

**세 번째 후보(`:124–125`) — 제외.** 같은 종류가 아니다.
1. 블록의 규칙은 바로 위 두 줄(`bind(R) = …`, `Priority: …`)이 전부이고, 네 행이 없어도 완전하다. `:122–123`은 실제 명령 형태라 키지만 `:124–125`는 명령 아닌 호출이 같은 우선순위에 어떻게 얹히는지를 보이는 예시다(`:124`의 말줄임표가 그 표시).
2. 하류에서 이 행들을 키로 읽는 곳이 없다 — Phase 0이 소비하는 것은 `R`이지 호출 문자열이 아니다.
3. `:125`가 예시하는 self-grounding 라우팅은 Trigger Signals의 self-grounding 행과 `:255`의 Skip 절에 이미 독립적으로, 행위로 명명돼 진술돼 있다. 어떤 언어로 물어도 경로에 닿는다.

**후속 건 하나를 명명해 둔다** — 이 블록은 실제 키(`:122–123`)와 표시 없는 예시(`:124–125`)를 같은 화살표 정렬에 섞어 놓아 어느 행이 키인지 구분되지 않는다. 그 수리는 **표시를 다는 것**이지 행위로 다시 쓰는 것이 아니므로, 수리 형태가 다른 변경을 한 PR에 섞지 않았다.

## 다른 프로토콜

같은 종류의 자리는 **남아 있지 않다.** #814·#815 리뷰가 각각 독립적으로 저장소를 훑어 `analogia:250`이 마지막 사례임을 확인했고 이 PR이 그것을 닫는다.

인접하되 종류가 다른 건 하나는 남겨 둔다: `euporia:230` / `aitesis:285` / `horismos:358`이 공유하는 `explicitly`의 **작용역** 모호성 — 진행 지시 자체가 유예인지 유예를 명시적으로 지목해야 하는지가 아티팩트에 고정돼 있지 않다. 문자열 고정이 아니라 범위 미결정이라 다른 종류이고, 네 자리에 걸치므로 이 PR의 건이 아니다.

## 버전 — patch (1.10.15 → 1.10.16, 매니페스트 쌍 동시)

조건 자체는 바뀌지 않았다. 영어 문자열은 언제나 행위였던 조건을 **덜 진술한 것**이었지 더 좁은 조건이 아니었고, 그래서 이것은 조건의 변경이 아니라 진술의 수리다.

정직하게 적어 둘 것 — 명세를 문자 그대로 읽으면 영어 아닌 사용자는 이전에 이 Skip을 충족할 수 없었고 이제 충족한다. 그 사용자에게는 런타임 거동이 실제로 달라진다. 그것이 고치고 있는 결함이지 새로 도입한 조건이 아니다.

선례도 같은 쪽이다 — #815가 같은 종류의 수리를 patch로 올렸다(aitesis 5.3.15→5.3.16, horismos 2.0.46→2.0.48, 내용 커밋 둘이라 +2). 여기는 내용 커밋 하나이므로 +1.

## 의미 폐포 스윕

활성화 표면을 건드렸으므로 조건을 재진술하는 자리를 전부 확인했다.

| 자리 | 결과 |
|---|---|
| Mode Activation §Activation | Skip을 재진술하지 않는다 — 게이트 술어만 싣는다 |
| Mode Deactivation | "User declares the mapping sufficient at any Phase 2"는 이미 행위로 명명돼 있고 조건이 다르다(실행 중 충분성 선언 vs 활성화 전 성립 선언). 이제 둘이 같은 선언 어휘를 공유해 한 계열로 읽힌다 |
| Rules | Skip을 재진술하는 항목 없음 |
| UX Safeguards `:384` | `¬established(correspondence(s, Sₜ))` — 새 Skip 문구가 이 술어와 어휘를 공유하게 됐다 |
| `plugin.json` / `.codex-plugin/plugin.json` description | 활성화 조건을 싣지 않는다 |

## 검증

| 명령 | 결과 |
|---|---|
| `static-checks.js .` | `fail []`, `warn []` (168 텍스트 파일, 16 프로토콜 커버리지) |
| `package.js --dry-run` | 통과 — bundle 101 files / 789695 bytes |
| `node --test` (package + hypomnesis ×2) | tests 109 / pass 109 / **fail 0** |

정적 검사와 나머지 둘을 동시에 돌리지 않았다. 실행 후 작업 트리에 테스트가 남긴 변경이 없음을 확인했다 — 수정 파일은 의도한 셋뿐이다.
