### PR TITLE
fix(verify): 워크트리에서 죽어 있던 version-staleness 충돌 가드를 되살린다

### DIFF
--- a/.claude/skills/verify/scripts/static-checks.js
+++ b/.claude/skills/verify/scripts/static-checks.js
@@ -712,9 +712,28 @@ function checkVersionStaleness() {
     return;
   }
 
-  // Skip version staleness check during conflict states (diff output unreliable)
+  // Skip version staleness check during conflict states (diff output unreliable).
+  // Resolve the git dir rather than assuming a layout: in a worktree `.git` is a file
+  // holding a gitdir: pointer, so a `<root>/.git/<head>` path can never exist there.
+  // `--git-dir` and not `--git-common-dir` — the conflict heads are per-worktree and
+  // are absent from the shared dir the latter reports.
+  let gitDir;
+  try {
+    // `--git-dir` may answer relative to the git process's cwd, which is projectRoot
+    const gitDirOutput = execFileSync('git', ['rev-parse', '--git-dir'], { cwd: projectRoot, encoding: 'utf8' }).trim();
+    gitDir = path.resolve(projectRoot, gitDirOutput);
+  } catch (e) {
+    // Conflict state is now unknown, which is precisely when diff output cannot be
+    // trusted — skip visibly rather than let the guard fall silently open again.
+    results.warn.push({
+      check: 'version-staleness',
+      file: 'working tree',
+      message: `Git command failed (rev-parse --git-dir) — version staleness check skipped: ${e.message}`
+    });
+    return;
+  }
   const conflictHeads = ['MERGE_HEAD', 'REBASE_HEAD', 'CHERRY_PICK_HEAD'];
-  const activeConflict = conflictHeads.find(h => fs.existsSync(path.join(projectRoot, '.git', h)));
+  const activeConflict = conflictHeads.find(h => fs.existsSync(path.join(gitDir, h)));
   if (activeConflict) {
     results.pass.push({
       check: 'version-staleness',

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -47,6 +47,19 @@ function writeFixtureFile(root, relativePath, content = 'fixture\n') {
   fs.writeFileSync(target, content);
 }
 
+// The pre-commit hook runs this suite with GIT_DIR, GIT_INDEX_FILE and the rest
+// of git's environment exported. Inherited by a subprocess, those override cwd
+// and silently redirect a fixture's git calls at the real repository — where
+// `git init` rewrites the shared config rather than building a fixture. Strip
+// the whole namespace so a temp-dir fixture is determined by its cwd alone.
+function envWithoutGitVars() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_')) delete env[key];
+  }
+  return env;
+}
+
 function makeCodexFixture() {
   const root = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'codex-submit-fixture-'));
   const plugin = { dir: 'fixture-plugin', skill: 'fixture' };
@@ -411,15 +424,21 @@ describe('language-purity worktree prune', () => {
 // concurrently with a static protocol verification run (see CLAUDE.md
 // Verification note); run them sequentially.
 
-function runStaticChecksSubprocess() {
+function runStaticChecksSubprocess(projectRoot) {
   const REPO_ROOT = path.join(__dirname, '..');
+  // Defaults to this repo; a caller may pass a throwaway fixture root instead.
+  const targetRoot = projectRoot || REPO_ROOT;
   const scriptPath = path.join(
     REPO_ROOT, '.claude', 'skills', 'verify', 'scripts', 'static-checks.js'
   );
   try {
-    const stdout = execFileSync(process.execPath, [scriptPath, REPO_ROOT], {
+    const stdout = execFileSync(process.execPath, [scriptPath, targetRoot], {
       encoding: 'utf8',
       maxBuffer: 32 * 1024 * 1024,
+      // static-checks.js shells out to git itself, so it needs the same
+      // scrubbing: an inherited GIT_DIR would aim it at the real repository
+      // no matter which root it was handed.
+      env: envWithoutGitVars(),
     });
     return JSON.parse(stdout);
   } catch (err) {
@@ -553,6 +572,128 @@ describe('enforcement-check detector liveness', () => {
       );
     } finally {
       restoreOrDie(SIBLING_STYLE_MD, backup, 'proactive-epistemic-ink.md');
+    }
+  });
+});
+
+// ============================================================
+// version-staleness conflict guard (worktree git-dir resolution)
+// ============================================================
+// Unlike the liveness tests above, this builds a throwaway repository under
+// the OS temp dir and mutates nothing live, so it carries no sequencing
+// constraint. Both checkout shapes are asserted because they differ exactly
+// where this guard once broke: `.git` is a directory in a primary checkout
+// but a gitdir: pointer file in a worktree, and the conflict heads live in
+// the per-worktree git dir rather than the shared one.
+
+function gitFixture(cwd, args, { allowFailure = false } = {}) {
+  try {
+    return execFileSync('git', args, {
+      cwd, encoding: 'utf8', stdio: 'pipe', env: envWithoutGitVars(),
+    });
+  } catch (err) {
+    if (allowFailure) return err.stdout || '';
+    throw err;
+  }
+}
+
+// Builds: a primary checkout on `trunk`, two divergent branches editing the
+// same line, and a worktree on one of them. Returns both checkout roots.
+function makeConflictFixture() {
+  const root = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'staleness-guard-'));
+  const primary = path.join(root, 'primary');
+  fs.mkdirSync(primary, { recursive: true });
+  gitFixture(primary, ['init', '-q', '-b', 'trunk', '.']);
+  gitFixture(primary, ['config', 'user.email', 'fixture@example.invalid']);
+  gitFixture(primary, ['config', 'user.name', 'fixture']);
+  writeFixtureFile(primary, '.claude-plugin/plugin.json', '{\n  "name": "fixture",\n  "version": "1.0.0"\n}\n');
+  writeFixtureFile(primary, 'skills/x/SKILL.md', 'base\n');
+  gitFixture(primary, ['add', '-A']);
+  gitFixture(primary, ['commit', '-qm', 'base']);
+  for (const [branch, body] of [['sideA', 'from A\n'], ['sideB', 'from B\n']]) {
+    gitFixture(primary, ['checkout', '-q', 'trunk']);
+    gitFixture(primary, ['checkout', '-q', '-b', branch]);
+    writeFixtureFile(primary, 'skills/x/SKILL.md', body);
+    gitFixture(primary, ['commit', '-qam', branch]);
+  }
+  gitFixture(primary, ['checkout', '-q', 'sideA']);
+  const worktree = path.join(root, 'wt');
+  gitFixture(primary, ['worktree', 'add', '-q', worktree, 'sideB']);
+  // Assert the isolation rather than trusting it: an inherited GIT_* variable
+  // would aim these calls at the real repository regardless of cwd, which is
+  // how a fixture can rewrite the shared config instead of building its own.
+  const realRoot = fs.realpathSync(root);
+  for (const checkout of [primary, worktree]) {
+    const resolved = gitFixture(checkout, ['rev-parse', '--absolute-git-dir']).trim();
+    assert.ok(
+      resolved.startsWith(realRoot),
+      `fixture escaped its temp root: rev-parse in ${checkout} resolved to ${resolved}`
+    );
+  }
+  return { root, primary, worktree };
+}
+
+function stalenessMessages(results) {
+  return [...results.pass, ...results.warn, ...results.fail]
+    .filter(r => r.check === 'version-staleness')
+    .map(r => r.message);
+}
+
+const SKIPPED_ON_CONFLICT = /MERGE_HEAD detected/;
+
+describe('version-staleness conflict guard', () => {
+  it('trips in a worktree, where .git is a pointer file', () => {
+    const { root, worktree } = makeConflictFixture();
+    try {
+      // Sanity-check the premise: a worktree really does carry a `.git` file,
+      // so a `<root>/.git/MERGE_HEAD` path could never have existed here.
+      assert.ok(
+        fs.statSync(path.join(worktree, '.git')).isFile(),
+        'fixture premise broken: worktree .git should be a file'
+      );
+      gitFixture(worktree, ['merge', 'sideA'], { allowFailure: true });
+      const messages = stalenessMessages(runStaticChecksSubprocess(worktree));
+      assert.ok(
+        messages.some(m => SKIPPED_ON_CONFLICT.test(m)),
+        `guard did not trip in worktree. version-staleness said: ${JSON.stringify(messages)}`
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('trips in a primary checkout, where .git is a directory', () => {
+    const { root, primary } = makeConflictFixture();
+    try {
+      gitFixture(primary, ['checkout', '-q', 'sideA']);
+      gitFixture(primary, ['merge', 'sideB'], { allowFailure: true });
+      const messages = stalenessMessages(runStaticChecksSubprocess(primary));
+      assert.ok(
+        messages.some(m => SKIPPED_ON_CONFLICT.test(m)),
+        `guard did not trip in primary checkout. version-staleness said: ${JSON.stringify(messages)}`
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stays out of the way when there is no conflict', () => {
+    const { root, worktree } = makeConflictFixture();
+    try {
+      // An ordinary uncommitted edit — the staleness check should evaluate it
+      // rather than skip, or the fix would have disabled the check outright.
+      writeFixtureFile(worktree, 'skills/x/SKILL.md', 'edited, uncommitted\n');
+      const messages = stalenessMessages(runStaticChecksSubprocess(worktree));
+      assert.ok(
+        !messages.some(m => SKIPPED_ON_CONFLICT.test(m)),
+        `guard tripped without a conflict. version-staleness said: ${JSON.stringify(messages)}`
+      );
+      assert.ok(
+        messages.some(m => /no version bump/.test(m)),
+        `staleness check did not evaluate the edit. version-staleness said: ${JSON.stringify(messages)}`
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## 무엇이 문제였나

`version-staleness` 검사에는 충돌 상태에서 검사를 건너뛰는 가드가 있습니다. 충돌 중에는 diff 출력을 신뢰할 수 없기 때문입니다. 그 가드가 충돌 헤드를 찾던 경로가 이렇습니다:

```js
fs.existsSync(path.join(projectRoot, '.git', h))
```

`.git`이 디렉터리라는 전제입니다. **워크트리에서 `.git`은 디렉터리가 아니라 `gitdir:` 포인터를 담은 파일입니다.** 따라서 `<root>/.git/MERGE_HEAD`는 존재할 수 없는 경로였고, `activeConflict`는 언제나 `undefined`였습니다. 가드는 아무 소리 없이 열려 있었습니다.

하필 이 저장소의 관례상 에이전트가 수행하는 편집은 **전부 워크트리에서** 일어납니다. 가드는 정확히 자신이 필요한 환경에서만 죽어 있었고, 주 체크아웃에서만 동작했습니다.

## 어떻게 고쳤나

레이아웃을 가정하지 않고 실제 git 디렉터리를 물어봅니다.

```js
const gitDirOutput = execFileSync('git', ['rev-parse', '--git-dir'], { cwd: projectRoot, encoding: 'utf8' }).trim();
gitDir = path.resolve(projectRoot, gitDirOutput);
```

**`--git-common-dir`이 아니라 `--git-dir`입니다.** 실측으로 확인했습니다 — 충돌 중인 워크트리에서 공유 `.git/MERGE_HEAD`는 없고 `.git/worktrees/<name>/MERGE_HEAD`만 있습니다. 공유 쪽을 봤다면 가드는 여전히 죽은 채였을 것입니다.

`--git-dir`은 주 체크아웃에서 상대 경로 `.git`을, 워크트리에서 절대 경로를 돌려줍니다. 같은 함수의 다른 git 호출과 동일하게 `cwd: projectRoot`로 실행하므로 상대 응답은 `path.resolve(projectRoot, ...)`로 받습니다.

### 판단이 필요했던 두 가지

**해석 실패 시** — 기존 "Git commands failed" 경로에 합류시키되 메시지로 어떤 명령이 실패했는지 구별했습니다(warn + skip + return). 이 방향이 안전 실패인 이유: 충돌 여부를 모른다는 것은 diff 출력을 믿을 수 없다는 가드의 전제 그 자체이므로 건너뛰는 쪽이 보수적이고, warn이므로 이번 결함의 실패 양상이었던 **침묵**으로 되돌아가지 않습니다.

**한 번 해석해 재사용할지** — 하지 않았습니다. 소비자가 한 곳뿐이고, 끌어올리면 지금 독립적인 두 가지가 엮입니다. 특히 앞의 `rev-parse --is-inside-work-tree` 탐침을 `--git-dir`로 대체하면 베어 저장소에서도 통과하게 되는데, 작업 트리가 없는 곳에서 staleness 검사는 의미가 없으므로 현재의 올바른 skip이 깨집니다.

## 증거 — 읽기가 아니라 실행입니다

임시 저장소와 그 워크트리를 만들어 병합 충돌을 구성하고 검사기를 직접 돌렸습니다.

| 환경 | 충돌 | 수정 전 | 수정 후 |
|---|---|---|---|
| 워크트리 | MERGE_HEAD | `Plugin "root" has content changes but no version bump` **(오탐)** | `MERGE_HEAD detected — skipping` |
| 워크트리 | 없음 | — | staleness 정상 평가 |
| 주 체크아웃 | MERGE_HEAD | (원래 동작) | `MERGE_HEAD detected — skipping` |
| 주 체크아웃 | 없음 | — | staleness 정상 평가 |

## 테스트

넣었습니다. 이 결함이 살아남은 경로가 곧 가드에 테스트가 없었다는 것이고, **정적 검사는 수정 전후 모두 통과하므로 이 결함을 잡지 못합니다.**

테스트 세 개가 판별력을 갖는지 확인했습니다 — 수정 전 코드에 대고 돌리면 **워크트리 테스트만 실패(1 fail)** 하고 주 체크아웃·무충돌 테스트는 통과합니다. 뒤의 둘이 통과하는 것이 과잉 수정(가드를 아예 꺼버리는 식)을 배제합니다.

## 함께 처리한 사고 — 경로 격리는 환경 격리를 함의하지 않는다

테스트를 처음 넣었을 때 사고가 났고, **그 자체가 이 PR이 고치는 것과 같은 종류의 결함**이라 함께 기록합니다.

`.husky/pre-commit`은 이 스위트를 돌립니다. 훅 환경에는 git이 `GIT_DIR`·`GIT_INDEX_FILE` 등을 export해 둡니다. 픽스처의 `execFileSync('git', ...)`가 그것을 상속하면서, **경로상으로는 임시 디렉터리에 있던 `git init`이 실제 공유 저장소를 대상으로 실행**됐습니다. 공유 `.git/config`에 `core.bare = true`가 쓰여 주 체크아웃과 모든 형제 워크트리의 git이 죽었습니다. 사용자 승인 아래 복구했고, 오염된 커밋은 없습니다.

격리의 근거로 삼았던 것은 **경로**였는데 유출은 **환경**으로 났습니다. 이것은 이 PR이 고치는 결함(`.git`이 디렉터리라는 가정)과 같은 부류입니다 — 둘 다 *git이 어디를 대상으로 삼는지를 무엇이 결정하는가*에 대한 잘못된 가정이고, 둘 다 조용히 틀립니다.

그래서 픽스처는 `GIT_`로 시작하는 환경변수를 **통째로** 걸러 낸 환경에서 git과 static-checks 하위 프로세스를 돌립니다(개별 unset은 목록이 새면 다시 뚫립니다). 나아가 픽스처가 자기 격리를 스스로 단언합니다 — 생성 직후 `rev-parse --absolute-git-dir`가 임시 루트 아래를 가리키는지 확인하고, 아니면 실패합니다.

수용 검증: 공유 config의 sha256을 대조해 (1) 직접 실행 (2) `GIT_*` 7개를 실제 값으로 export한 훅 유사 환경 (3) **실제 커밋 훅 경로** 모두에서 동일함을 확인했습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `static-checks.js .` | **139 pass / 0 fail / 0 warn** (origin/main 기준선과 동일) |
| `package.js --dry-run` | exit 0 |
| 테스트 | **112/112 통과** (기준선 109 + 신규 3) |

## 범위

저장소 전체를 훑어 `.git`을 디렉터리로 가정하는 다른 지점을 확인했고 **이 한 곳뿐**이었습니다. `static-checks.js:2062`와 `language-purity.js`의 `SKIP_DIRS`는 디렉터리 순회 필터라 `.git`이 파일이어도 확장자·타입 필터에서 걸러지므로 영향이 없습니다.

프로토콜 `SKILL.md`은 건드리지 않았습니다.
