### PR TITLE
fix(epistemic-cooperative): 게이트 옵션 근거줄을 조건부 발화로 내린다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.24.1",
+  "version": "4.25.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.24.1",
+  "version": "4.25.0",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -63,17 +63,17 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 1. **Option** — implication
 ────────────────────────
 
-The implication after each option — the text following the em-dash — is authored in two cognitive layers:
+The implication after each option — the text following the em-dash — carries one required layer and one conditional one:
 
 1. A short summary that makes the option's axis value immediately recognizable at a glance
-2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution)
+2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution) — omit when the consequence is recoverable from the summary and the pre-gate text alone
 
-Applied at live-judgment gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects its consequence.
+Applied at live-judgment gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. Where the rationale is emitted it must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects a consequence the summary left unrecoverable. The condition is what keeps this layer reporting an inference that was actually drawn: a slot that must be filled whether or not the reasoning produced something to put in it gets filled with reconstruction, and reconstruction reads to the user exactly like a projection while carrying none of its evidence.
 
 Rendered shape:
 
 1. **Option** — summary (axis value)
-   → rationale (one of: temporal, branch, side-effect)
+   → rationale, where the consequence is not recoverable from the summary and the pre-gate text
 
 **Channel boundary — text gate vs genuine tool call.** Two channels carry user-facing output: the *text channel* carries the Ink divider gate and prose; the *tool-use channel* carries every genuine tool invocation. Each interaction travels exactly one. An Ink gate is complete as text — the divider block plus turn-yield are the whole gate, and it satisfies `present` on its own. A genuine tool call — AskUserQuestion, or any tool a skill's SKILL.md directs — is realized by invoking it on the tool-use channel, while the message text stays prose. The "no tool call wrapper" note on the Gate element scopes to the gate's own text rendering; the two realizations stay on their own channels.
 
@@ -128,7 +128,7 @@ A form instruction reaches the wording and not the marking. Asked for a plainer 
 
 ### What This Style Pins
 
-Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape, the convergence lines, the observer markers. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
+Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
 
 ## Protocol Recommendations
 

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -102,17 +102,17 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 1. **Option** — implication
 ────────────────────────
 
-The implication after each option — the text following the em-dash — is authored in two cognitive layers:
+The implication after each option — the text following the em-dash — carries one required layer and one conditional one:
 
 1. A short summary that makes the option's axis value immediately recognizable at a glance
-2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution)
+2. A rationale line covering at least one of: *temporal* unfolding (what happens next turn, or N turns out), *branch* consequence (divergent outcomes if a premise holds vs breaks), or *side effect* (parallel cost, downstream resolution) — omit when the consequence is recoverable from the summary and the pre-gate text alone
 
-Applied at live-judgment gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. The rationale must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects its consequence.
+Applied at live-judgment gates where multiple options carry genuinely divergent downstream paths. Comparison matrices, taxonomy enumerations, and convergence traces use the summary layer alone. Where the rationale is emitted it must carry structural information (time, branch, or side effect) — the summary identifies the option, the rationale projects a consequence the summary left unrecoverable. The condition is what keeps this layer reporting an inference that was actually drawn: a slot that must be filled whether or not the reasoning produced something to put in it gets filled with reconstruction, and reconstruction reads to the user exactly like a projection while carrying none of its evidence.
 
 Rendered shape:
 
 1. **Option** — summary (axis value)
-   → rationale (one of: temporal, branch, side-effect)
+   → rationale, where the consequence is not recoverable from the summary and the pre-gate text
 
 **Channel boundary — text gate vs genuine tool call.** Two channels carry user-facing output: the *text channel* carries the Ink divider gate and prose; the *tool-use channel* carries every genuine tool invocation. Each interaction travels exactly one. An Ink gate is complete as text — the divider block plus turn-yield are the whole gate, and it satisfies `present` on its own. A genuine tool call — AskUserQuestion, or any tool a skill's SKILL.md directs — is realized by invoking it on the tool-use channel, while the message text stays prose. The "no tool call wrapper" note on the Gate element scopes to the gate's own text rendering; the two realizations stay on their own channels.
 
@@ -167,7 +167,7 @@ A form instruction reaches the wording and not the marking. Asked for a plainer 
 
 ### What This Style Pins
 
-Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape, the convergence lines, the observer markers. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
+Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
 
 ## Protocol Recommendations
 


### PR DESCRIPTION
## 무엇

게이트 옵션의 근거줄을 **무조건 슬롯에서 조건부 발화로** 내립니다. 요약층은 그대로 유지하고, 근거줄은 "요약과 게이트 앞 텍스트만으로 그 선택지의 결과가 복원되지 않을 때"만 나갑니다. 같은 편집에서 `What This Style Pins`의 "option shape"이 무엇을 덮는지 열거해 모호성을 해소했습니다.

두 스타일 파일 모두에 적용했습니다. `ink-body-identity` 정적 검사가 재생산된 본문의 byte-identity를 강제하므로 한쪽만 고칠 수 없습니다.

## 왜

무조건 슬롯은 추론이 거기 넣을 것을 산출하지 않았을 때도 채워져야 합니다. 그때 채워지는 것은 판단이 아니라 사후 구성물이고, 사용자에게는 진짜 투영과 똑같이 보이면서 근거만 없습니다. 조건은 이 층이 **실제로 그어진 추론만** 보고하게 만드는 장치입니다.

`Basis:`가 이미 같은 문턱을 씁니다 — "would a reader arrive at the same reading from the cited context alone?" 이번 변경은 그 문턱을 옵션 근거줄에 대칭으로 적용한 것입니다.

## 이것은 ablation 시행입니다

`premise/instruction-authoring.md:62`가 정한 형태를 따릅니다.

- **틀 고정** — 게이트, 선택지 수, 게이트 앞 맥락 모두 그대로. 달라지는 것은 근거줄뿐
- **시험 대상** — `:64`가 말하는 "유능한 독자가 매끄럽게 닫아버리는 것을 막는" 역할이 근거줄에 있다면, 근거줄 없이 그게 유지되는지
- **실패의 모양** — 선택지 구분 불가, 선택 후 예상과 다른 상태, 되묻기
- **복원 경로** — 그 실패를 말하면 이 커밋을 되돌립니다 (`:66` 복구가능성 충족)
- **미치는 범위** — 사용자 한 명, 이 두 스타일을 쓰는 세션. `:64` — 발견은 시행이 미친 데까지만

## 기각한 대안

**proactive만 고쳐 base를 대조군으로 남기기.** `ink-body-identity`가 막습니다. 오버레이로 옮기는 안도 검토했으나 본문 요건을 오버레이가 덮는 형태가 되어 `premise:76`의 충돌 모양이 되고, 파일 자신의 "moves only the pacing axis" 선언도 함께 고쳐야 했습니다. 대조군을 잃는 비용을 택했습니다.

## 근거의 출처와 검증 강도

전문성 역전·중복 렌즈, 분할 주의·CLT 렌즈, Concise 조항 대조, codex 교차 자문 — 넷을 격리 실행한 뒤 종합했고, 넷 중 셋이 이 근거줄을 최상위 수정 대상으로 독립 지목했습니다.

- **VERIFIED (독립 재확인)** — Tetzlaff et al. (2025) 메타분석: 고사전지식 독자에게 high-assistance instruction이 `d = -0.428`, 저사전지식 독자에게 `d = 0.505`. pedocs 초록에서 직접 확인
- **MOSTLY (렌즈가 단 강도 그대로, 재확인 안 함)** — Nückles et al. (2010) 영구 프롬프트 기저선 하회, Chandler & Sweller (1991), Oksa et al. (2010), Ginns (2006)
- **가장 약한 고리** — Oksa의 "전문가가 잉여 자료를 억제하지 못한다"는 기제. 제거 논거가 거기 기댑니다

비대칭 단서 하나: 같은 메타분석이 초심자 쪽 이득(`0.505`)이 숙련자 쪽 해(`0.428`)보다 크다고 보고합니다. 요약층을 무조건 유지한 이유입니다.

## 검증

`node .claude/skills/verify/scripts/static-checks.js .` → 138 pass / 0 fail / 0 warn

## 남은 것

- `What This Style Pins`의 "the observer markers"가 어느 마커를 덮는지는 여전히 문면에서 읽히지 않습니다. 이번 범위 밖
- 실제 Martin 라운드 실측은 하지 않았습니다. 라운드 길이의 지배적 원인이 스타일인지 두 에이전트 교환인지는 아직 논증으로만 갈려 있습니다
