### PR TITLE
fix(premise): premise 표면의 사족을 걷고 표준 세트를 색인 하나로 낮춘다

### DIFF
--- a/premise/AGENTS.md
+++ b/premise/AGENTS.md
@@ -2,12 +2,6 @@
 
 The cognitive and collaboration premises behind structured human-AI dialogue — stated so they hold on their own, independent of any specific codebase, tool, or harness that happens to implement them.
 
-Where a document depends on a concept from another, it says so and names the file. [`README.md`](README.md) covers adopting these documents and wiring them into a setup.
-
-## Documents
-
-Each entry below names a moment rather than a subject, so what fires it is recognizing that moment in the work at hand — an inference drawn from what is actually happening, not from what the work is nominally about. A document here reaches a conversation about a contract, a summary, or a diagnosis as readily as one about code.
-
 Read [`recognition-and-authority.md`](recognition-and-authority.md) when deciding whether to settle something yourself or put it to the person you are working with, when presenting a set of options for someone to choose from, and when deciding whether a specification may fix a criterion's answer in advance at all.
 
 Read [`interaction-factorization.md`](interaction-factorization.md) when designing the options offered at a checkpoint, and when judging whether those options genuinely diverge or collapse to one dominant answer dressed up as several.

--- a/premise/README.md
+++ b/premise/README.md
@@ -20,12 +20,7 @@ delivery mechanism, and verification check:
 
 **If you are an agent and someone handed you this URL**: identify the host you are running in, read
 this shared procedure and that host's reference before acting, then follow them as one procedure end
-to end. A go-ahead checkpoint before the global write pauses the procedure; once the person gives
-it, resume and complete the approved write. Follow one host reference only.
-
-Both adapters wire the machine the host is running on. A run isolated from its configuration and
-marketplace files cannot follow either path; establish the layer on the instruction surface that
-the isolated run actually receives instead.
+to end. Follow one host reference only.
 
 ## Shared procedure
 

--- a/premise/README.md
+++ b/premise/README.md
@@ -55,10 +55,6 @@ Before writing:
 The checkpoint authorizes the write it previewed. Once approval arrives, perform that write and
 continue to verification rather than treating approval as completion.
 
-The standing layer carries the index plus `recognition-and-authority.md` and
-`approach-verification.md`, the two documents that bear on every turn. The index names when to read
-every other document.
-
 ### 4. Verify in a fresh session
 
 Use the host reference's loading check, then ask the fresh session to reproduce the complete index
@@ -67,8 +63,8 @@ question granularity, and a time or date without a stated zone. Requiring all fo
 depend on the index rather than on a guess from the filename.
 
 A correct response establishes that the index was reached at the configured path in that session.
-It does not establish that the two other standing documents were also read, or that another session
-will behave the same way. Treat a wrong answer as an absent layer.
+It does not establish that another session will behave the same way. Treat a wrong answer as an
+absent layer.
 
 ## Keeping it current
 
@@ -82,11 +78,11 @@ clone as the premise root. The rest of the procedure is unchanged.
 
 ## Adapting
 
-The three standing documents above are one setup's choice, not a required set. A document you adopt
-governs the general principles within the scope you adopted it for; a document you do not adopt
-governs nothing. A project may bind a narrower or wider set on its own instruction surface without
-changing the global layer. Where a host instruction and an adopted document disagree on a general
-principle, the document is the one to reason from.
+The standing set above is one setup's choice, not a required set. A document you adopt governs the
+general principles within the scope you adopted it for; a document you do not adopt governs nothing.
+A project may bind a narrower or wider set on its own instruction surface without changing the
+global layer. Where a host instruction and an adopted document disagree on a general principle, the
+document is the one to reason from.
 
 Your own instructions supply what an adopted document deliberately leaves open — the concrete
 surface a principle binds to, the value your project has settled on — rather than restating the

--- a/premise/references/claude-code.md
+++ b/premise/references/claude-code.md
@@ -50,23 +50,7 @@ Create that file with this content after applying the shared procedure's preview
 ```markdown
 # Premise Layer
 
-The general principles behind your operating rules live outside this directory, at
-`<PREMISE_PATH>` — a git clone the plugin manager keeps in sync.
-Read from it freely; never write to it.
-
-The split: your own rules — this directory and the rest of your configuration — carry the
-operational side: when a principle fires here, what threshold applies, which tool or path it binds
-to, what this setup has settled on. The principle itself lives in `premise/`. When one of your rules
-names a premise document, read that document before acting on a case its operational wording does
-not already settle.
-
-The index loads below. It names each document and the moment that calls for it, so the moment is
-recognized rather than recalled. The two documents that bear on every turn load with it; the rest
-are read on demand when their trigger fires.
-
 @<PREMISE_PATH>/AGENTS.md
-@<PREMISE_PATH>/recognition-and-authority.md
-@<PREMISE_PATH>/approach-verification.md
 ```
 
 An existing `rules/premise.md` is an existing wiring decision. Show the proposed integration and
@@ -74,6 +58,6 @@ let the person decide how it joins that file; do not replace it as though it wer
 
 ### Verification
 
-Start a fresh session and run `/context`. The target rules file and its three imports should appear
-under **Memory files**. Then run the shared procedure's complete-entry question for
+Start a fresh session and run `/context`. The target rules file and the index it imports should
+appear under **Memory files**. Then run the shared procedure's complete-entry question for
 `matching-the-request.md`.

--- a/premise/references/codex.md
+++ b/premise/references/codex.md
@@ -61,21 +61,9 @@ the section the same heading level as the target file's other top-level sections
 ```markdown
 # Premise Layer
 
-The general principles behind the rules in this file live at
-`<PREMISE_PATH>` — a git clone Codex's plugin manager keeps in sync.
-Read from it freely; never write to it.
-
 `<PREMISE_PATH>/AGENTS.md` is the index: it names each document and the moment that calls for it.
 Read it at the start of a session, before the first substantive action, so those moments are
-recognized rather than recalled. Read `<PREMISE_PATH>/recognition-and-authority.md` and
-`<PREMISE_PATH>/approach-verification.md` alongside it — those two bear on every turn. Read any
-other document at the moment the index names for it.
-
-The split: the rest of this file and the rest of your configuration carry the operational side —
-when a principle fires here, what threshold applies, which tool or path it binds to, what this setup
-has settled on. The principle itself lives in the premise documents. When one of your rules names a
-premise document, read that document before acting on a case its operational wording does not
-already settle.
+recognized rather than recalled. Read any other document at the moment the index names for it.
 ```
 
 ### Verification


### PR DESCRIPTION
premise/ 표면에서 두 가지를 정리한다. 축이 달라 커밋으로 갈랐다.

## 1. 다른 표면이 이미 말하고 있는 문장 셋 (`d6a1beb`)

- `AGENTS.md` — `## Documents` 헤딩, "각 항목은 주제가 아니라 순간을 부른다" 문단(README가 이미 색인을 그렇게 소개한다), 문서 간 참조 관례 문장(재실행되는 검사 채널이 없다), README 링크.
- `README.md` — 에이전트 문단의 체크포인트 예고(3단계가 실제로 구속되는 자리에서 다시 말한다), 격리 실행 문단(두 호스트 참조가 각자 Scope에서 말한다).

## 2. 표준 세트 3 → 1 (`9d27c9b`)

문서는 `AGENTS.md` + `recognition-and-authority.md` + `approach-verification.md` 셋을 상시 로드하라고 했는데, 실제 설정은 색인 하나만 import한다. 문서를 돌고 있는 쪽에 맞췄다.

색인 항목 자체가 이미 그 순간을 부른다 — `approach-verification.md`의 항목은 "before deciding what to do with a request"이고 매 턴이다. `README.md` §Adapting도 애초에 이 세트를 "one setup's choice, not a required set"으로 열어두고 있었다.

함께 움직인 자리: `README.md`(표준 레이어 문단, 검증 범위 문장, §Adapting의 개수 표현 → 개수 없는 문장), `references/claude-code.md`(import 3줄 → 1줄, 검증 문구), `references/codex.md`(두 문서 포인터).

템플릿 산문도 걷었다. 대가는 명시해 둔다: 쓰기 금지(`never write to it`)는 저장소 전체에서 두 호스트 템플릿에만 있었고, 지우면 `premise/`를 실수로 편집하는 것을 막던 유일한 런타임 문장이 사라진다. Codex 쪽 산문은 남는다 — import 지시어를 확장하지 않아 포인터 산문 자체가 전달 기제다.

## 확인

`node .claude/skills/verify/scripts/static-checks.js .` — fail 0, warn 0. 저장소 밖에서 이 세트를 박아둔 곳 없음(`ONBOARDING.md`는 기여자 읽기 순서로 같은 파일명을 부르지만 import 세트가 아니다). `premise/` 는 플러그인이 아니라 버전 범프 대상 없음.

기각한 대안과 근거는 각 커밋 메시지에 있다.