### PR TITLE
fix(periagoge): 형식 블록 표기 오류 수정 + 제거 시험을 거친 계약 불일치 해소

### DIFF
--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/.claude-plugin/plugin.json
+++ b/periagoge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "periagoge",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/.codex-plugin/plugin.json
+++ b/periagoge/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "periagoge",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Calibrate and crystallize in-process abstraction — /induce (περιαγωγή: turning-around)",
   "author": {
     "name": "Jongwon Choi",

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -13,13 +13,13 @@ Calibrate and crystallize in-process abstraction through AI-proposed candidate p
 
 ```
 ── FLOW ──
-Periagoge(A) → Detect(A) → in_process? →
-  true:  (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K →
+Periagoge(A) → Detect(A) →
+  InProcess(Iᵢ, E, L?): Calibrate(Iᵢ, E, L?, ctx) → K →
          Propose(Iᵢ, E, K, ctx) → (P, G) →
          Qs(P, G, K, framing) → Stop → V → integrate(V, candidate) → candidate' →
          loop until crystallized(Λ) → declare(completion_trace, open_trace) → CrystallizedAbstraction
-         or attempts_exhausted → deactivate
-  false: deactivate
+         or attempts_exhausted(Λ) → deactivate
+  NotInProcess: deactivate
 
 ── MORPHISM ──
 A
@@ -38,7 +38,10 @@ invariant: Calibrative Induction through Dialectical Triangulation over Unilater
 
 ── TYPES ──
 A              = AbstractionSeed (in-process state: instances + essence intuition + optional user concept label)
-Detect         = A → (Bool, Option((Iᵢ, E, L?)))         -- payload is Some(...) exactly when the Bool is true
+Detect         = A → DetectResult
+DetectResult   ∈ {InProcess(Iᵢ, E, L?), NotInProcess}
+                 -- closed: Phase 0's two exits; the payload rides the InProcess branch, so no verdict and payload
+                 -- can disagree, and InProcess is what witnesses requires: in_process(A)
 Iᵢ             = Set(Instance)                             -- instance set observed; cardinality unconstrained (any N ≥ 1 qualifies when essence is sensed; richer sets provide stronger triangulation material)
 Instance       = { content: String, context: String }       -- concrete case observed
 E              = EssenceIntuition                           -- variation-stable core signal from conversation
@@ -51,8 +54,6 @@ K              = CalibrationMap { keeps, sharpens, prunes, open, label_basis }
                  prunes      = overextended or unsupported scope to release
                  open        = residual uncertainty that does not block crystallization
                  label_basis = Option(L) as the user gave it, carried with its provenance
-                               -- the naming ground Propose reads through K; it grounds P.name and P.provenance
-                               -- without determining them, so what the label survives as stays a run-time judgment
 OpenDisposition ∈ {None, Nonblocking, Deferred}
                  None        = no open calibration pressure remains; explicitly declared
                  Nonblocking = open item remains visible but does not block Confirm
@@ -74,6 +75,11 @@ V              = UserMove ∈ {Confirm, Widen(direction), Narrow(specializer), F
                  axis         = orthogonal dimension         -- full redirection
 Qs             = Shaping interaction with candidate + grounding [Tool: Constitution interaction]
 crystallized(Λ) = ∃ step ∈ Λ.history : V(step) = Confirm
+max_attempts   = the triangulation cap LOOP fixes per abstraction seed
+attempts_exhausted(Λ) = |Λ.history| ≥ max_attempts ∧ ¬crystallized(Λ)
+                 -- Λ.history appends exactly one step per triangulation attempt, so |Λ.history| is the attempt count
+                 -- and the cap is read after Phase 3's append; a Confirm on the capped attempt crystallizes rather
+                 -- than exhausting, which is what keeps the two LOOP exits mutually exclusive
 CompletionTrace = List<(A, K, P, V, candidate')>
                  -- derived from Λ.history with A sourced from Λ.A and candidate' computed from each step's post-move candidate state
 CrystallizedAbstraction = P where confirmed(P) via Confirm move ∧ completion_trace_declared(CompletionTrace) ∧ open_disposition_declared(OpenTrace)
@@ -89,7 +95,7 @@ Priority: explicit_arg > recent_instance_cluster > surfaced_essence
 If no essence signal is detectable (neither user sensing language nor AI-inferrable core pattern): pause activation and surface the scan result before Phase 0, inviting the user to either name what feels in-process or withdraw.
 
 ── PHASE TRANSITIONS ──
-Phase 0: A → Detect(A) → in_process?                                       -- detection checkpoint (silent)
+Phase 0: A → Detect(A) → InProcess(Iᵢ, E, L?) | NotInProcess               -- detection checkpoint (silent)
 Phase 1: (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K → Propose(Iᵢ, E, K, ctx) → (P, G); carry (P, G, K)  -- calibration + candidate + grounding construction [Tool]
 Phase 2: (P, G, K) → Qs(P, G, K, framing) → Stop → V                      -- triangulation Constitution interaction [Tool]
 Phase 3: V → integrate(V, candidate) → candidate'                          -- candidate update (track)
@@ -102,14 +108,14 @@ If V = Narrow(specializer): return to Phase 2.
 If V = Fuse(adjacent): return to Phase 1 (grounding recomputed).
 If V = Reorient(axis): return to Phase 1 (full recompute).
 If V = Dismiss: abandon candidate; if essence still sensed, return to Phase 1 with fresh candidate; else deactivate.
-Max 5 triangulation attempts per abstraction seed.
-Continue until: crystallized(Λ) ∨ attempts_exhausted.
+Cap: max_attempts = 5 triangulation attempts per abstraction seed.
+Continue until: crystallized(Λ) ∨ attempts_exhausted(Λ).
 Convergence evidence: At crystallized(Λ), present transformation trace — for each step ∈ history, show (calibration → candidate → user_move → candidate') — plus OpenTrace for K.open. OpenTrace status is None when K.open is empty, Deferred when any open item is routed to later work, and Nonblocking otherwise. Convergence is demonstrated, not asserted.
 
 ── CONVERGENCE ──
 crystallized(Λ): see TYPES (V = Confirm in Λ.history)
-progress(Λ) = |Λ.history| / max_attempts                    -- max_attempts is the LOOP cap; one history step per triangulation attempt
-early_exit = attempts_exhausted
+progress(Λ) = |Λ.history| / max_attempts                    -- both terms per TYPES; LOOP fixes the max_attempts value
+early_exit = attempts_exhausted(Λ)
 
 ── TOOL GROUNDING ──
 -- Realization: Constitution → TextPresent+Stop; Extension → TextPresent+Proceed
@@ -152,6 +158,8 @@ Frame the abstraction currently being shaped rather than a progress fraction. Re
 
 - **Recognition over Recall**: Present structured options with anticipatable post-selection states and yield for the user's shaping move.
 - **Calibration authority**: Treat the candidate as a working hypothesis. The instance-grounded calibration remains open to correction through the same free-response path as candidate shaping.
+- **Label as ground, not verdict**: Read the user's tentative label as the naming ground the proposal works from. It grounds the candidate's name and its provenance without fixing either, so what the label survives as stays a judgment made in the run.
+- **Move-typed shaping**: Apply each shaping move on its own terms — broaden the candidate along the direction given, constrain it along the named dimension, fold in the adjacent abstraction the user named, or redirect onto the named orthogonal axis. Which move arrived, not a generic update, is what determines the shape the next candidate takes.
 - **Personalized grounding**: Pair every candidate with evidence from the user's own domain and keep external provenance visible.
 - **Periagoge boundary**: Form an abstraction around a sensed but unlocated essence. Comparison or validation of an already located abstraction remains outside this operation.
 - **Round composition**: Compose each round in everyday language, keep each judgment beside its evidence and next-move implication, and place analysis before the gate.

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -98,7 +98,7 @@ If no essence signal is detectable (neither user sensing language nor AI-inferra
 Phase 0: A → Detect(A) → InProcess(Iᵢ, E, L?) | NotInProcess               -- detection checkpoint (silent)
 Phase 1: (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K → Propose(Iᵢ, E, K, ctx) → (P, G); carry (P, G, K)  -- calibration + candidate + grounding construction [Tool]
 Phase 2: (P, G, K) → Qs(P, G, K, framing) → Stop → V                      -- triangulation Constitution interaction [Tool]
-Phase 3: V → integrate(V, candidate) → candidate'                          -- candidate update (track)
+Phase 3: V → integrate(V, candidate) → candidate' ; Λ.history := Λ.history ++ [(P, G, K, V)]   -- candidate update + round record (track)
 
 ── LOOP ──
 After Phase 3: evaluate user move.
@@ -159,7 +159,6 @@ Frame the abstraction currently being shaped rather than a progress fraction. Re
 - **Recognition over Recall**: Present structured options with anticipatable post-selection states and yield for the user's shaping move.
 - **Calibration authority**: Treat the candidate as a working hypothesis. The instance-grounded calibration remains open to correction through the same free-response path as candidate shaping.
 - **Label as ground, not verdict**: Read the user's tentative label as the naming ground the proposal works from. It grounds the candidate's name and its provenance without fixing either, so what the label survives as stays a judgment made in the run.
-- **Move-typed shaping**: Apply each shaping move on its own terms — broaden the candidate along the direction given, constrain it along the named dimension, fold in the adjacent abstraction the user named, or redirect onto the named orthogonal axis. Which move arrived, not a generic update, is what determines the shape the next candidate takes.
 - **Personalized grounding**: Pair every candidate with evidence from the user's own domain and keep external provenance visible.
 - **Periagoge boundary**: Form an abstraction around a sensed but unlocated essence. Comparison or validation of an already located abstraction remains outside this operation.
 - **Round composition**: Compose each round in everyday language, keep each judgment beside its evidence and next-move implication, and place analysis before the gate.

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -45,18 +45,22 @@ E              = EssenceIntuition                           -- variation-stable 
 L              = Option(TentativeLabel)                     -- user-provided provisional name or concept, if any
 ctx            = DomainContext                              -- user's domain context gathered via artifact read, artifact search, and a conditional external fetch in Phase 1
 Calibrate      = (Iᵢ, E, L?, ctx) → K
-K              = CalibrationMap { keeps, sharpens, prunes, open }
-                 keeps     = supported core to preserve
-                 sharpens  = under-specified decision-relevant structure
-                 prunes    = overextended or unsupported scope to release
-                 open      = residual uncertainty that does not block crystallization
+K              = CalibrationMap { keeps, sharpens, prunes, open, label_basis }
+                 keeps       = supported core to preserve
+                 sharpens    = under-specified decision-relevant structure
+                 prunes      = overextended or unsupported scope to release
+                 open        = residual uncertainty that does not block crystallization
+                 label_basis = Option(L) as the user gave it, carried with its provenance
+                               -- the naming ground Propose reads through K; it grounds P.name and P.provenance
+                               -- without determining them, so what the label survives as stays a run-time judgment
 OpenDisposition ∈ {None, Nonblocking, Deferred}
                  None        = no open calibration pressure remains; explicitly declared
                  Nonblocking = open item remains visible but does not block Confirm
                  Deferred    = user routes an open item to later work via free response
-OpenItemDisposition ∈ {Nonblocking, Deferred}
+OpenItemDisposition = OpenDisposition \ {None}             -- per-item value space; None is a whole-trace verdict only
 OpenTrace      = { status: OpenDisposition, items: Map(String, OpenItemDisposition) }
                  -- terminal disposition for K.open; empty open sets declare status None
+                 -- invariant: dom(items) = K.open — every open item carries exactly one disposition, which is what makes status(O) total
 status(O)      = None if K.open = ∅; Deferred if ∃ i ∈ dom(O.items) : O.items(i) = Deferred; otherwise Nonblocking
                  -- O is the OpenTrace value (Λ.open_trace); K is the CalibrationMap this trace terminates (Λ.calibration)
 P              = CandidateAbstraction { name, structure, instance_map, provenance }
@@ -93,10 +97,10 @@ Phase 3: V → integrate(V, candidate) → candidate'                          -
 ── LOOP ──
 After Phase 3: evaluate user move.
 If V = Confirm: crystallize(candidate), Λ.completion_trace := derive(Λ.history, Λ.A, candidate'), Λ.open_trace := derive(K.open, V, free_response), declare(Λ.completion_trace, Λ.open_trace), terminate.
-If V = Widen(direction): candidate' = widened(candidate, direction) via Synagoge → return to Phase 2.
-If V = Narrow(specializer): candidate' = narrowed(candidate, specializer) via Diairesis → return to Phase 2.
-If V = Fuse(adjacent): candidate' = fused(candidate, adjacent) via lateral Synagoge → return to Phase 1 (grounding recomputed).
-If V = Reorient(axis): candidate' = orthogonal(axis) → return to Phase 1 (full recompute).
+If V = Widen(direction): return to Phase 2.
+If V = Narrow(specializer): return to Phase 2.
+If V = Fuse(adjacent): return to Phase 1 (grounding recomputed).
+If V = Reorient(axis): return to Phase 1 (full recompute).
 If V = Dismiss: abandon candidate; if essence still sensed, return to Phase 1 with fresh candidate; else deactivate.
 Max 5 triangulation attempts per abstraction seed.
 Continue until: crystallized(Λ) ∨ attempts_exhausted.
@@ -104,7 +108,7 @@ Convergence evidence: At crystallized(Λ), present transformation trace — for 
 
 ── CONVERGENCE ──
 crystallized(Λ): see TYPES (V = Confirm in Λ.history)
-progress(Λ) = |history| / max_attempts
+progress(Λ) = |Λ.history| / max_attempts                    -- max_attempts is the LOOP cap; one history step per triangulation attempt
 early_exit = attempts_exhausted
 
 ── TOOL GROUNDING ──
@@ -119,7 +123,7 @@ seam               (extension)   → TextPresent+Proceed (fires at deactivation/
 ── MODE STATE ──
 Λ = { phase: Phase, A: AbstractionSeed, Iᵢ: Set(Instance), E: EssenceIntuition,
       calibration: Option(K), candidate: Option(P), grounding: Option(G),
-      history: List<(P, G, K, V)>, attempts: Nat, crystallized: Option(P),
+      history: List<(P, G, K, V)>, crystallized: Option(P),
       completion_trace: Option(CompletionTrace),
       open_trace: Option(OpenTrace),
       active: Bool, cause_tag: String }

--- a/periagoge/skills/induce/SKILL.md
+++ b/periagoge/skills/induce/SKILL.md
@@ -17,7 +17,7 @@ Periagoge(A) → Detect(A) → in_process? →
   true:  (Iᵢ, E, L?) → Calibrate(Iᵢ, E, L?, ctx) → K →
          Propose(Iᵢ, E, K, ctx) → (P, G) →
          Qs(P, G, K, framing) → Stop → V → integrate(V, candidate) → candidate' →
-         loop until crystallized(A) → declare(completion_trace, open_trace) → CrystallizedAbstraction
+         loop until crystallized(Λ) → declare(completion_trace, open_trace) → CrystallizedAbstraction
          or attempts_exhausted → deactivate
   false: deactivate
 
@@ -38,7 +38,7 @@ invariant: Calibrative Induction through Dialectical Triangulation over Unilater
 
 ── TYPES ──
 A              = AbstractionSeed (in-process state: instances + essence intuition + optional user concept label)
-Detect         = A → (Bool, (Iᵢ, E, L?) if true)
+Detect         = A → (Bool, Option((Iᵢ, E, L?)))         -- payload is Some(...) exactly when the Bool is true
 Iᵢ             = Set(Instance)                             -- instance set observed; cardinality unconstrained (any N ≥ 1 qualifies when essence is sensed; richer sets provide stronger triangulation material)
 Instance       = { content: String, context: String }       -- concrete case observed
 E              = EssenceIntuition                           -- variation-stable core signal from conversation
@@ -57,7 +57,8 @@ OpenDisposition ∈ {None, Nonblocking, Deferred}
 OpenItemDisposition ∈ {Nonblocking, Deferred}
 OpenTrace      = { status: OpenDisposition, items: Map(String, OpenItemDisposition) }
                  -- terminal disposition for K.open; empty open sets declare status None
-status(OpenTrace) = None if K.open = ∅; Deferred if ∃ item : items(item) = Deferred; otherwise Nonblocking
+status(O)      = None if K.open = ∅; Deferred if ∃ i ∈ dom(O.items) : O.items(i) = Deferred; otherwise Nonblocking
+                 -- O is the OpenTrace value (Λ.open_trace); K is the CalibrationMap this trace terminates (Λ.calibration)
 P              = CandidateAbstraction { name, structure, instance_map, provenance }
 G              = GroundingExample { scenario: String, domain: String, mapping: String }
                                                              -- personalized to user's own domain context
@@ -68,7 +69,7 @@ V              = UserMove ∈ {Confirm, Widen(direction), Narrow(specializer), F
                  adjacent     = neighboring abstraction ref  -- lateral Synagoge with user-named reference (user Production mode)
                  axis         = orthogonal dimension         -- full redirection
 Qs             = Shaping interaction with candidate + grounding [Tool: Constitution interaction]
-crystallized(A) = ∃ step ∈ history : V(step) = Confirm
+crystallized(Λ) = ∃ step ∈ Λ.history : V(step) = Confirm
 CompletionTrace = List<(A, K, P, V, candidate')>
                  -- derived from Λ.history with A sourced from Λ.A and candidate' computed from each step's post-move candidate state
 CrystallizedAbstraction = P where confirmed(P) via Confirm move ∧ completion_trace_declared(CompletionTrace) ∧ open_disposition_declared(OpenTrace)
@@ -98,11 +99,11 @@ If V = Fuse(adjacent): candidate' = fused(candidate, adjacent) via lateral Synag
 If V = Reorient(axis): candidate' = orthogonal(axis) → return to Phase 1 (full recompute).
 If V = Dismiss: abandon candidate; if essence still sensed, return to Phase 1 with fresh candidate; else deactivate.
 Max 5 triangulation attempts per abstraction seed.
-Continue until: crystallized(A) ∨ attempts_exhausted.
-Convergence evidence: At crystallized(A), present transformation trace — for each step ∈ history, show (calibration → candidate → user_move → candidate') — plus OpenTrace for K.open. OpenTrace status is None when K.open is empty, Deferred when any open item is routed to later work, and Nonblocking otherwise. Convergence is demonstrated, not asserted.
+Continue until: crystallized(Λ) ∨ attempts_exhausted.
+Convergence evidence: At crystallized(Λ), present transformation trace — for each step ∈ history, show (calibration → candidate → user_move → candidate') — plus OpenTrace for K.open. OpenTrace status is None when K.open is empty, Deferred when any open item is routed to later work, and Nonblocking otherwise. Convergence is demonstrated, not asserted.
 
 ── CONVERGENCE ──
-crystallized(A): see TYPES (V = Confirm in history)
+crystallized(Λ): see TYPES (V = Confirm in Λ.history)
 progress(Λ) = |history| / max_attempts
 early_exit = attempts_exhausted
 


### PR DESCRIPTION
`periagoge/skills/induce/SKILL.md` 형식 블록의 표기 오류와 계약 불일치를 수리합니다. 커밋 두 개로 나뉩니다.

- `3d042f9e` — 표기 오류 세 건 (house style 판정 후 국소 결함만)
- `325ea647` — 제거 시험을 거친 계약 불일치 해소

## 출처와 먼저 확인한 것

정적 분석 에이전트가 **플러그인 캐시본 하나만** 읽고 여덟 건을 보고했습니다 (`~/.claude/plugins/cache/epistemic-protocols/periagoge/1.0.0/.../SKILL.md`). 소스와 대조된 적도, 형제 프로토콜과 비교된 적도 없는 목록이었습니다.

- **캐시본 vs 소스**: `diff` 결과 바이트 동일.
- **형제 프로토콜 전수 grep**: 지적 8건 중 **2건이 저장소 전체 house style**이었습니다.

---

# 1차 — 표기 오류 세 건 (`3d042f9e`)

### `Detect`의 화살표 타입 안에 들어간 산문 조건절

```diff
-Detect         = A → (Bool, (Iᵢ, E, L?) if true)
+Detect         = A → (Bool, Option((Iᵢ, E, L?)))         -- payload is Some(...) exactly when the Bool is true
```

화살표 타입 안에 산문 `if`를 넣은 사례는 전 저장소에서 이 한 줄뿐입니다. `analogia`는 같은 자리를 `Detect = Mapping uncertainty detection: R → Bool`처럼 전역 화살표로 씁니다.

### `status`의 인자 자리에 값이 아닌 타입 이름

```diff
-status(OpenTrace) = None if K.open = ∅; Deferred if ∃ item : items(item) = Deferred; otherwise Nonblocking
+status(O)      = None if K.open = ∅; Deferred if ∃ i ∈ dom(O.items) : O.items(i) = Deferred; otherwise Nonblocking
+                 -- O is the OpenTrace value (Λ.open_trace); K is the CalibrationMap this trace terminates (Λ.calibration)
```

본문의 `items`가 어디에도 묶여 있지 않았습니다. 자유 변수 `K`는 `merismos` `apportioned(G)`의 방식(주석으로 출처 명시)을 따랐습니다. 함수명/필드명 `status` 충돌은 `syneidesis`가 `status(g) = entry(g).status`로 같은 형태를 쓰므로 고치지 않았습니다.

### `crystallized`의 인자가 본문이 읽는 필드를 담고 있지 않음

```diff
-crystallized(A) = ∃ step ∈ history : V(step) = Confirm
+crystallized(Λ) = ∃ step ∈ Λ.history : V(step) = Confirm
```

`history`는 `Λ`의 필드이고 `A`에서 거기로 가는 경로가 없습니다. 호출부 네 곳을 함께 옮겼습니다. Λ 필드를 읽는 술어가 `Λ`를 받는 건 `proplasma` `converged(Λ)`, `elenchus` `unresolved(Λ)`, `analogia` `affected(Λ)`, `heuresis` `unaddressed(Λ)`의 공통 관습입니다.

### house style로 판정해 고치지 않은 것

- **`Qs = <산문>` + TYPES에 없는 `Stop`**: 게이트 타입을 산문으로 쓰는 프로토콜이 euporia·elenchus·aitesis·katalepsis·epharmoge·horismos·merismos·heuresis로 사실상 전부. `Stop`은 `.claude/skills/realize/SKILL.md`의 실현계층 어휘(`formal branch → Stop | Proceed`)로 어느 프로토콜 TYPES에도 없습니다.
- **`COMPOSITION`의 `*: product — (D₁ × D₂) → (R₁ × R₂)`**: 16개 프로토콜이 한 글자도 다르지 않게 같은 줄을 싣고 있습니다. 이 파일 단독 삭제는 정렬을 깨뜨립니다.

---

# 2차 — 제거 시험 (`325ea647`)

`.claude/rules/protocol-repair.md` §*The morphism is the ablation ground* 에 따라 각 항목에 **먼저 제거 시험**을 돌렸습니다. MORPHISM과 남은 carrier에서 손실 없이 복구되는 절은 사본을 하나 더 동기화하지 않고 제거하고, 재도출 경로가 실제로 닿는 의무만 남겨 수리했습니다.

> 외부 자문(gpt-5.6-sol)은 네 건 모두 "타입을 추가하라"는 방향이었으나, 자문은 이 규칙이 없는 트리를 보고 답한 것입니다. 규칙을 우선했고 **두 건이 추가가 아니라 제거로 뒤집혔습니다.**

## 제거로 뒤집힌 것

### 1. LOOP의 `widened`/`narrowed`/`fused`/`orthogonal` 삭제

```diff
-If V = Widen(direction): candidate' = widened(candidate, direction) via Synagoge → return to Phase 2.
-If V = Narrow(specializer): candidate' = narrowed(candidate, specializer) via Diairesis → return to Phase 2.
-If V = Fuse(adjacent): candidate' = fused(candidate, adjacent) via lateral Synagoge → return to Phase 1 (grounding recomputed).
-If V = Reorient(axis): candidate' = orthogonal(axis) → return to Phase 1 (full recompute).
+If V = Widen(direction): return to Phase 2.
+If V = Narrow(specializer): return to Phase 2.
+If V = Fuse(adjacent): return to Phase 1 (grounding recomputed).
+If V = Reorient(axis): return to Phase 1 (full recompute).
```

자문 자신이 적은 flip condition — *"`integrate(V,P)`가 유일한 실제 변환자이고 이 넷이 설명용 별칭에 불과하다면, 넷을 지우고 `integrate`를 타입 지어라"* — 이 여기서 성립합니다. MORPHISM에 `integrate(V, candidate)`가 있고 Phase 3이 `V → integrate(V, candidate) → candidate'`를 씁니다. 네 이름은 `integrate`를 V 생성자 하나씩에 특수화한 것이고, Synagoge/Diairesis 계열 귀속은 TYPES의 V 주석에 이미 실려 있습니다. LOOP가 독립적으로 지고 있던 의무는 **복귀 지점**과 **재계산 범위**뿐이라 그것만 남겼습니다.

`integrate`를 TYPES에 새로 타입 짓지도 않았습니다 — 서명이 PHASE TRANSITIONS와 TYPES에서 완전히 도출되므로 사본을 하나 더 만드는 일이 됩니다.

**부수 효과**: `orthogonal(axis)`는 candidate를 받지 않아 Phase 3의 `integrate(V, candidate)`와 정면으로 모순했습니다. 삭제로 모순이 사라지고 Phase 3이 지배합니다. 두 블록이 다른 말을 하던 것을 MORPHISM이 뒷받침하는 쪽으로 정리한 것이며 런타임 동작을 새로 정하지는 않습니다.

### 2. MODE STATE의 `attempts: Nat` 삭제

```diff
-      history: List<(P, G, K, V)>, attempts: Nat, crystallized: Option(P),
+      history: List<(P, G, K, V)>, crystallized: Option(P),
```

**이 필드는 선언만 되어 있고 파일 어디에서도 읽히지 않습니다.** 살아 있는 카운터는 `progress`가 쓰는 `|history|` 하나뿐이라, "진행 카운터 두 개" 지적의 실체는 이중화가 아니라 미사용 선언이었습니다. 자문은 `attempts`를 정본으로 삼고 불변식 `Λ.attempts = |Λ.history|`를 세우라고 했지만, 그것은 복구 가능한 양을 위해 사본을 하나 더 동기화하는 일입니다. 미사용 쪽을 지우면 이중 판독 가능성 자체가 사라집니다.

**Dismiss 과금 여부는 새로 정하지 않았습니다** — `history`는 Dismiss 스텝도 append하므로 파일은 이미 과금한다고 말하고 있었고, 삭제는 그것과 어긋날 수 있는 두 번째 판독을 없앨 뿐입니다.

## 추가로 남긴 것 — 제거 시험을 통과한 의무

### 3. `K`에 `label_basis` 필드

MORPHISM은 `calibrate(E, L?, Iᵢ, ctx)` → calibration → `propose(candidate, grounding, calibration)`으로 **이미 `L`을 `K`를 거쳐 propose까지 보내고 있는데**, `K`의 선언된 필드가 그것을 담지 못했습니다 — carrier가 표현할 수 없는 경우입니다. `type-category-convention.md`의 *"a field widened where a case cannot be represented"*가 정확히 이 수리를 지정합니다.

`Propose` 서명을 넓히는 대안은 기각했습니다: MORPHISM이 쓴 경로와 어긋나고, 이름 근거가 두 갈래로 갈려 어느 쪽이 지배하는지 사양이 말하지 못하게 됩니다. 같은 규칙의 openness criterion에 따라 `P.name = L`로 못 박지 않고 **근거로만** 싣습니다.

### 4. `OpenTrace`에 불변식 `dom(items) = K.open`

`status(O)`는 `None` 갈래를 `K.open`으로, 나머지를 `O.items`로 판정하므로 두 집합이 일치해야만 전역 함수가 됩니다. 이 불변식은 어느 carrier도 표현하지 않고 있었습니다.

### 5. `OpenItemDisposition`을 열거에서 파생으로

```diff
-OpenItemDisposition ∈ {Nonblocking, Deferred}
+OpenItemDisposition = OpenDisposition \ {None}             -- per-item value space; None is a whole-trace verdict only
```

추가가 아니라 **통합에 의한 제거**입니다 — 동기화를 요구하는 리터럴 열거 두 개가 하나로 줄어듭니다 (`instruction-authoring.md`: *"unifying it removes surface rather than adding any"*).

---

## 판단이 필요해 남긴 것

동작을 새로 정해야 하므로 단독 처리하지 않았습니다.

1. **`propose`의 인자 수를 두 블록이 다르게 말합니다.** MORPHISM은 `propose(candidate, grounding, calibration)`, TYPES는 `Propose = (Iᵢ, E, K, ctx) → (P, G)`. 이 불일치를 어느 쪽으로 푸느냐가 **Fuse/Reorient가 Phase 1로 복귀할 때 사용자의 조형 수(`candidate'`)가 살아남는지**를 결정합니다.
2. **`attempts_exhausted`가 정의 없이 FLOW/LOOP/CONVERGENCE에서 쓰입니다.** LOOP의 "Max 5 triangulation attempts"에서 도출은 되지만 상한 판정 시점(`≥` vs `>`)이 열려 있습니다. `analogia`는 `attempts_exhausted(Λ)`를 명시 정의하는 선례가 있습니다.

## 상류 재조정

`76ddd821`에서 잘린 워크트리를 `origin/main`(`45c5f84c`)로 rebase했습니다. #864/#866이 periagoge의 산문·frontmatter만 건드렸고 형식 블록은 손대지 않아 이 PR의 수정은 그대로 적용됩니다. 상류 버전이 이미 1.0.2이므로 범프를 **1.0.3**으로 재조정했습니다 (claude/codex 매니페스트 동시).

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .   # fail 0 / warn 0
```
