### PR TITLE
feat(repo): morphism에서 복구되는 수리 중복을 걷는다

### DIFF
--- a/.claude/rules/protocol-repair.md
+++ b/.claude/rules/protocol-repair.md
@@ -30,6 +30,17 @@ moved when a neighboring block changed. The semantic-closure sweep `AGENTS.md` a
 is the walk that finds this, so run it to site the repair and not only to check one already
 chosen.
 
+**The morphism is the ablation ground.** When coupled blocks disagree, first read each affected
+clause against the declared deficit-to-resolution path and the block's own structural role. A
+clause carries an independent obligation when its removal would leave an execution order,
+judgment boundary, state transition, termination path, grounding, or invariant that the morphism
+and the remaining carriers do not represent. Keep and repair only those clauses whose obligations
+the re-derived path actually reaches. Content recoverable without loss from the written morphism
+and remaining carriers is redundant; remove it rather than synchronizing another copy. Treat that
+removal as the ablation in
+`premise/instruction-authoring.md` §Subtraction at Revision Time: exercise the obligations in a
+bounded, recoverable trial and restore only what failed.
+
 **The carriers are already here.** Before an entry is added, ask which existing carrier holds
 the distinction: a field widened where a case cannot be represented, a rule's subject moved
 where the morphism's unit of presentation changed, an option set indexed on one further axis


### PR DESCRIPTION
## 배경

타입과 morphism 사이의 불일치를 발견했을 때 semantic closure를 모든 관련 블록의 동기화로 읽으면, 결핍에서 해소로 향하는 경로가 이미 운반하는 의미까지 사본으로 남습니다. Euporia 분기에서 확정한 의도는 morphism에서 다시 이끌어낼 수 있는 내용은 굳이 병존시키지 않고 ablation하는 편집 방향입니다.

## 변경

- `protocol-repair.md`에 morphism을 ablation 근거로 읽는 판정을 추가했습니다.
- 조항 제거가 실행 순서, 판단 경계, 상태 전이, 종료 경로, grounding, 불변식 가운데 독립 의무를 잃는지 확인합니다.
- 작성된 morphism과 남은 carrier에서 손실 없이 복구되는 내용은 동기화하지 않고 제거합니다.
- 제거는 bounded·recoverable trial로 검증하고 실패한 의무만 복원합니다.

새 규칙 파일이나 `AGENTS.md` 항목은 추가하지 않았습니다. 이 판정은 계약 표면의 불일치를 수리하는 순간에 발동하므로 기존 `protocol-repair.md`가 소유하며, 현재 경로 규칙과 `AGENTS.md` 도달 경로가 이미 전달합니다. 프로토콜 `SKILL.md` 변경이 없어 plugin 버전은 올리지 않았습니다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 136 pass / 0 fail / 0 warn
- `node --test scripts/package.test.js anamnesis/scripts/hypomnesis-write.test.mjs anamnesis/scripts/hypomnesis-codex-write.test.mjs .claude/skills/realize/scripts/harness.test.mjs` — 124 pass / 0 fail
  - 기존 SKILL.md 길이 guideline 경고 2건만 출력되며 이번 변경과 무관합니다.
