### PR TITLE
fix(epistemic-cooperative): review-loop 착지 위치 지정을 릴레이 가능하게 한다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.25.6",
+  "version": "4.25.7",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.25.6",
+  "version": "4.25.7",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -15,22 +15,25 @@ What the artifact converges *on* is the project's own stated goal — a mission 
 ## Caller Signature
 
 ```
-/review-loop [source?] [scope?]
+/review-loop [source?] [scope?] [landing?]
 
-source : { codex | code-review }                     -- optional; review source behind the (diff, design-intent) → { findings[], verdict } interface
+source  : { codex | code-review }                    -- optional; review source behind the (diff, design-intent) → { findings[], verdict } interface
                                                      --   absent → Phase 0 asks which source to use (no default; one invokable source relays, zero stops)
-scope  : PR number | (implicit)                      -- optional; PR number, or implicit current-PR / working-tree detection
+scope   : PR number | (implicit)                     -- optional; PR number, or implicit current-PR / working-tree detection
+landing : { head | stacked }                         -- optional; PR scope only — where this invocation's repairs land
+                                                     --   absent → Phase 0 asks; a working-tree scope has nowhere to stack, so it never asks
 ```
 
-The review source is pluggable: any source satisfying the `(diff, design-intent) → { findings[], verdict }` interface can drive the loop. `codex` and `code-review` are the two sources documented in the Source Interface section; both are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 asks which source to use (no preselected default; with exactly one invokable source it relays the designation, with none it stops). When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree).
+The review source is pluggable: any source satisfying the `(diff, design-intent) → { findings[], verdict }` interface can drive the loop. `codex` and `code-review` are the two sources documented in the Source Interface section; both are runtime-selected, not fixed at definition time. When `source` is omitted, Phase 0 asks which source to use (no preselected default; with exactly one invokable source it relays the designation, with none it stops). When `scope` is omitted, Phase 0 detects it (current-branch PR or working tree). When `landing` is omitted on a PR scope, Phase 0 asks that too. All three read the invocation as it arrived rather than only a parsed flag: a designation carried in the request's own words is the ordinary form, and a slot that only matches its own spelling leaves the loop asking a question the user has already answered.
 
 ## Pipeline Overview
 
 ```
 /review-loop [source?] [scope?]
   Phase 0  : source designation (arg → relay | absent → ask, cardinality-guarded) + scope detect (PR diff | working tree)
-                          + landing path, PR scope only (ask: commits on the reviewed head | a layer stacked above it;
-                            settled once per invocation; it moves where repairs land, not the review base)
+                          + landing path, PR scope only (named → relay | absent → ask: commits on the reviewed
+                            head | a layer stacked above it; settled once per invocation; it moves where repairs
+                            land, not the review base)
                           + design-intent harvest (rules/comments for the changed surface → intent bundle,
                             carrying the project's declared order of authority among those surfaces where it declares one)
   Phase 1  : review    — source(diff, intent) → { findings[], verdict, exercised, direction? }
@@ -85,7 +88,7 @@ The loop is the skill's identity; the review source is a parameter behind it. Th
 
 Capture the **resolved base SHA** (the merge-base or PR base commit the diff is taken against; for a working-tree scope, the `HEAD` SHA at capture time) and, for either PR scope (explicit number or detected current-branch PR), the **PR head SHA** (`gh pr view [{N}] --json headRefOid`), plus the changed-files list: this base SHA + head + file list is the **pointer** every source receives — the codex prompt carries it, and the `code-review` call passes it as its scope; the source re-derives the diff locally with its own git (codex: read-only sandbox, no network), so the full diff content is not inlined. PR review runs on a **checkout of that PR head**: when local `HEAD` differs from the PR head SHA (a stale or unrelated checkout), reconcile first — sync or check out the head (a worktree works) — or surface the mismatch and stop; merely fetching the SHA is not enough, because the source reads the artifact and design-intent files from the working tree, and the apply phase must write onto the same head it reviewed. A stacked layer carries a second head, and reaching it takes two more reads than the capture above: the reviewed PR's `baseRefName`, and — where a PR exists on that branch — its `headRefOid`, fetched so the two heads can actually be compared locally. Where no PR sits on the base branch there is no lower layer and nothing further to check. What is being checked is not that the lower head moved: an ordinary advance leaves the cut point an ancestor of it, so the captured base still resolves and the review is unaffected. It is that the lower branch was **rewritten** — the cut point is no longer an ancestor of its head — which leaves this layer standing on a base the layer below no longer has, and which the diff pointer cannot show. That case surfaces and stops, carrying the three values that make it judgeable: the cut point, the lower PR's head as it stands now, and what lies between them. What follows is constituted then rather than fixed here, because whether the layer rebases onto the rewritten base, reviews as it stands, or something else depends on what moved and why — which is what those three show and no rule written here can know. The checkout must also be clean: dirty local edits make the source read content the diff pointer does not address, and the fix commits the re-review requires could fold unrelated same-file edits in — surface dirty state that overlaps the changed surface and stop until it is stowed or adopted. Also capture diff stats for context.
 
-**Where this round's repairs land.** A PR scope gives an apply two places to put its commits: onto the head just reviewed, or onto a branch cut from it that opens its own PR above the first. The difference is not in the code but in what a reader of the PR sees — one grows the unit under review, the other leaves that unit's own commits where they were and stacks the repair above them — and which one fits depends on how the work is being picked up, which the diff does not show. What the second does not do is leave the reviewed PR separately approved: the verdict is formed against the base and the head the round actually ran on, so once repairs sit on a layer the approve covers the two together and neither alone. **Ask**: present both with that difference and let the user constitute it; the loop does not pick on the user's behalf, and silence stops rather than selecting. A working-tree scope has nothing to stack onto, so the gate does not open there.
+**Where this round's repairs land.** A PR scope gives an apply two places to put its commits: onto the head just reviewed, or onto a branch cut from it that opens its own PR above the first. The difference is not in the code but in what a reader of the PR sees — one grows the unit under review, the other leaves that unit's own commits where they were and stacks the repair above them — and which one fits depends on how the work is being picked up, which the diff does not show. What the second does not do is leave the reviewed PR separately approved: the verdict is formed against the base and the head the round actually ran on, so once repairs sit on a layer the approve covers the two together and neither alone. **A landing the invocation already named relays**, exactly as a named source does: the user has decided, and the gate has nothing left for them to constitute. It counts however the invocation carried it — a `landing` argument, or the request's own words naming where the repairs go — because reading it only in the formal slot misses the ordinary case, where someone who says where the work should land says it plainly and does not expect it back as a question. **Otherwise ask**: present both with that difference and let the user constitute it; the loop does not pick on the user's behalf, and silence stops rather than selecting. A working-tree scope has nothing to stack onto, so the gate does not open there whichever way this went.
 
 The answer is taken once per invocation (Rule 15), and it settles **where commits land, not what gets reviewed**. The base captured above stays this invocation's review base whichever way the gate goes: every round types its findings against that base and Phase 5 re-reviews the whole surface it covers, so a finding left unfixed in the reviewed PR keeps returning on every round exactly as it would have. A stacked layer is cut from the head just reviewed and takes the repair commits; the surface beneath it stays in view because the base did not move with it.
 
@@ -523,7 +526,8 @@ The per-round trace is a relay presentation — present it and proceed; it is no
     the gap as a clearance.
 15. **The landing path is settled once and the rounds inherit it** — where a PR scope's
     repairs land, on the head just reviewed or on a layer stacked above it, is constituted at
-    Phase 0 and holds for the whole invocation. It does not move the review base: the Phase 0
+    Phase 0 — by relay where the invocation already named it, by the gate where it did not — and
+    holds for the whole invocation. It does not move the review base: the Phase 0
     capture fixes that, every round types against it (Rule 5), and Phase 5 re-reviews the whole
     surface it covers (Rule 4) whichever way the landing went. What it fixes is where this
     invocation's repairs accumulate, and no round re-opens it, because a mid-loop switch would


### PR DESCRIPTION
`/review-loop`의 Phase 0가 정하는 세 가지 지정 중 **착지 위치만 호출 인자로 받을 수 없었습니다.** 그래서 사용자가 호출 시점에 스택 PR을 지정해도 묶일 곳이 없고, 스킬이 가진 유일한 지시가 "물어라"이므로 이미 답한 질문이 매번 되돌아갔습니다.

## 발견 경위

PR #865를 `/review-loop codex stack pr`로 지시받아 실행하던 중, Phase 0에서 착지 위치를 **다시 물었습니다.** 사용자가 이미 답한 것을요.

원문의 조사 "로" 앞에는 세 토큰이 병렬로 놓여 있었습니다 — `review loop` / `codex` / `stack pr`. Phase 0의 세 지정과 정확히 하나씩 대응합니다. 셋 다 답이 주어져 있었는데 둘만 릴레이됐습니다.

## 결함

| 지정 | 인자 슬롯 | 인자가 주어졌을 때 |
|---|---|---|
| `source` | `[source?]` 있음 | "If a `source` argument is given, use it directly — this is relay" 명시 |
| `scope` | `[scope?]` 있음 | 주어지면 그대로 사용 |
| **착지 위치** | **없음** | **`**Ask**: ... silence stops rather than selecting`만 있음** |

`Rule 15`는 "is constituted at Phase 0"이라고 하는데, 이 한 단어가 *무엇이 정해지는가*와 *어떻게 정해지는가*를 붙여 놓았습니다. 바로 옆 `source` 항목은 같은 둘을 갈라 놓았는데도요.

**슬롯이 없다는 것이 하중을 지는 결함입니다.** `source`를 릴레이하고 `stack pr`을 놓친 이유는 전자에는 매칭될 자리가 있었고 후자에는 없었다는 것뿐입니다 — 값이 갈 곳이 없으면 발화에 담겨 와도 읽히지 않습니다.

## 수리

`.claude/rules/protocol-repair.md`의 *The carriers are already here* 에 따라 어느 기존 carrier가 이 구별을 지는지 먼저 물었습니다. 새 기계를 만들지 않고 **둘을 넓혔습니다** — 호출 서명의 인자 슬롯, 그리고 `source`가 이미 싣고 있는 릴레이 절.

### 1. Caller Signature에 슬롯 추가

```diff
-/review-loop [source?] [scope?]
+/review-loop [source?] [scope?] [landing?]
+
+landing : { head | stacked }    -- optional; PR scope only — where this invocation's repairs land
+                                --   absent → Phase 0 asks; a working-tree scope has nowhere to stack, so it never asks
```

### 2. 서명 산문 — 세 지정 모두 도착한 발화를 읽는다

형식 슬롯에서만 읽으면 일상적인 경우를 놓칩니다. 일이 어디에 얹혀야 하는지 말하는 사람은 자기 말로 말하지 별도 플래그로 말하지 않습니다.

### 3. Phase 0 착지 문단에 릴레이 절

```diff
-**Ask**: present both with that difference and let the user constitute it; ...
+**A landing the invocation already named relays**, exactly as a named source does: the user
+has decided, and the gate has nothing left for them to constitute. It counts however the
+invocation carried it — a `landing` argument, or the request's own words naming where the
+repairs go — ...
+**Otherwise ask**: present both with that difference and let the user constitute it; ...
```

침묵이 선택이 아니라 정지라는 것은 그대로입니다.

### 4. Rule 15 — 구성한다와 묻는다를 가름

```diff
-repairs land, ... is constituted at Phase 0 and holds for the whole invocation.
+repairs land, ... is constituted at Phase 0 — by relay where the invocation already named it,
+by the gate where it did not — and holds for the whole invocation.
```

한 번만 정해지고 라운드가 물려받는다는 규칙 자체는 불변입니다. 바뀐 것은 무엇이 그것을 정하느냐뿐입니다.

### 5. Pipeline Overview 동기화

착지 줄이 `ask:`로 무조건 물음을 주장하고 있어 `named → relay | absent → ask`로 맞췄습니다.

## 손대지 않은 것

- **Phase 5의 "which this phase reads rather than re-opens"**
- **Convergence trace의 `Landing:` 줄**

둘 다 지정이 *어떻게* 이루어졌는지를 주장하지 않으므로 이 변경에 영향받지 않습니다.

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .   # fail 0 / warn 0
```

`epistemic-cooperative` 4.25.6 → 4.25.7 (claude/codex 매니페스트 동시).
