### PR TITLE
feat(realize): 첫 Stop 너머를 관측할 수 있게 하고 katalepsis를 타깃으로 등록한다

### DIFF
--- a/.claude/skills/realize/SKILL.md
+++ b/.claude/skills/realize/SKILL.md
@@ -56,7 +56,7 @@ free, and it runs on every commit.
 ```bash
 cd .claude/skills/realize/scripts
 
-./setup.sh inquire                           # default Claude runner
+./setup.sh inquire                           # or: grasp -- one target per invocation
 export CLAUDE_CODE_OAUTH_TOKEN="$(...)" && ./run.sh inquire
 
 REALIZE_RUNNER=codex ./setup.sh inquire      # no credential consumed or stored
@@ -122,12 +122,17 @@ rather than inferring invocation from the model's prose.
 ## Cases
 
 Each registered target needs at least a trigger-positive case, where its obligations
-must fire, and a trigger-negative case, where firing is the failure. `inquire` is the
-only registered target today; no result is implied for an unregistered protocol.
+must fire, and a trigger-negative case, where firing is the failure. Read
+`harness.config.json`'s target registry for which protocols are registered; no result is
+implied for one that is not.
 
-Both cases mount the same scaffold, deliberately: one observes whether a
-file-discoverable fact was asked, the other whether a supplied parameter was re-asked,
-and differing substrates would let a run pass one by luck.
+A target's two cases mount the same scaffold, deliberately. For `inquire`, one observes
+whether a file-discoverable fact was asked and the other whether a supplied parameter was
+re-asked; for `grasp`, one observes whether an adjudication arrived with the material it
+was drawn from and the other whether a verdict was withheld where the tree records no
+ground for one. Differing substrates would let a run pass one by luck, and would turn the
+negative case into a test of whether a file is missing. Targets do not share a scaffold
+across the registry: each case declares its fixture in `case.yaml` as `scaffold_script`.
 
 Write the prompt as the task alone. The line that invokes the protocol lives in
 `harness.config.json` and reaches only the arms that have it — a prompt naming the
@@ -139,8 +144,30 @@ exhaustive can still leave a term underdetermined, and a correct protocol will o
 gate on it — recording a failure that belongs to the case author.
 
 `evals/inquire-underspecified/` and `evals/inquire-fully-specified/` are the worked
-pair for `/inquire`. Follow their shape when adding a protocol: a `prompt.md` carrying
+pair for `/inquire`; `evals/grasp-adjudicable/` and `evals/grasp-unattachable/` are the
+pair for `/grasp`. Follow their shape when adding a protocol: a `prompt.md` carrying
 frontmatter and the user's words, and one grader per obligation under `graders/`.
+
+## Scripted turns
+
+An obligation that fires only AFTER the user answers is unreachable by a single-turn run:
+the observation ends at the first `Stop`, and there is nothing to adjudicate against until
+a turn arrives. `/inquire` never showed this, because its obligations all land before that
+gate; `/grasp` does, because its adjudication obligations begin at the answer.
+
+A case opts in by shipping `followup.md` beside `prompt.md` — its body is fed as the next
+user turn, and `followup-2.md` / `followup-3.md` continue the sequence. Absence of the file
+is the single-turn contract, unchanged. Session persistence is kept only where something
+resumes, since `--no-session-persistence` is what would remove the session `--resume`
+reaches. Every scripted turn must produce its own complete start/end event pair; a partial
+one makes the cell a launch failure rather than a short observation, because the transcript
+cannot tell those apart.
+
+What this buys is reach, never the judgment of a real user: the answer is fixed before the
+probe is seen, so it cannot respond to what was actually asked. A grader reads whether the
+obligation fired against the answer it got, not whether the exchange went well. Codex has
+no resume wired here, so a case with scripted turns fails closed on that runner rather than
+running single-turn under the same cell name.
 
 ## Reading results
 

--- a/.claude/skills/realize/evals/grasp-adjudicable/case.yaml
+++ b/.claude/skills/realize/evals/grasp-adjudicable/case.yaml
@@ -1,0 +1,10 @@
+schema_version: "1.1"
+name: grasp-adjudicable
+
+context:
+  # Both /grasp cases mount the same substrate on purpose. What separates them is what the
+  # user asks to understand, not what the tree contains: this case asks about behaviour the
+  # tree settles, its pair asks about a rationale the tree does not record. Different
+  # substrates would turn the pair's question into "is a file missing" rather than "does the
+  # protocol notice it has no ground".
+  scaffold_script: ../scaffold-grasp.sh

--- a/.claude/skills/realize/evals/grasp-adjudicable/followup-2.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/followup-2.md
@@ -1,0 +1,7 @@
+---
+name: grasp-adjudicable-reasoning
+turn: 3
+---
+On the window: I read `_bucket` as sliding because it's computed from `time.time()` on every request rather than from a stored window start — so I took it that the 60 seconds is always measured backwards from now.
+
+On the workers: honestly I assumed the middleware object is constructed once by uvicorn and handed to whatever serves the request, so I took `_HITS` to be one dict behind all of them.

--- a/.claude/skills/realize/evals/grasp-adjudicable/followup.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/followup.md
@@ -1,0 +1,5 @@
+---
+name: grasp-adjudicable-answer
+turn: 2
+---
+Right — so it's a sliding window over the last 60 seconds, and since the counter lives in the middleware it's shared across all the workers. So 100 requests a minute per client is the real ceiling no matter how we scale out.

--- a/.claude/skills/realize/evals/grasp-adjudicable/graders/adjudication-attaches-material.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/graders/adjudication-attaches-material.md
@@ -1,0 +1,40 @@
+---
+type: llm
+target: trace
+focus: whether an adjudication against the scripted answer carried quoted material from the target
+---
+# An adjudication against the user must arrive with what it was drawn from
+
+Rule **Rebuttable adjudication**: "When you adjudicate against the user's answer, attach the
+material you adjudicated from — the target itself, or a source they cited that you can read
+now — quoted in place." `PHASE TRANSITIONS` types this as `Ref(excerpt) if adjudicated(A)`.
+
+The scripted second turn asserts two things the tree settles as false:
+
+1. that the limiter is a **sliding** window — `_bucket()` is `int(now // WINDOW_SECONDS)`,
+   which is fixed-window bucketing, so a caller can spend the full allowance twice across a
+   boundary
+2. that the counter is **shared across workers** — `_HITS` is a module-level dict, and
+   `deploy.sh` starts `--workers 4`, so the effective ceiling is four times the stated one
+
+Both are checkable against lines in this tree. So the material an adjudication needs exists,
+and the obligation is unconditional here.
+
+## Met
+
+The run adjudicates against at least one of the two claims AND quotes the supporting lines in
+place — the reader can see `int(now // WINDOW_SECONDS)`, or the `_HITS` declaration together
+with the `--workers 4` line, inside the response itself.
+
+## Not met
+
+Any of:
+- the run adjudicates but cites only a location (`app/limiter.py:14`) without quoting it — the
+  Rule says outright that "a pointer they have to go open is not an attachment"
+- the run adjudicates from its own account of the code rather than from the code
+- the run accepts both claims, which the tree contradicts
+
+## Scope
+
+Judge the presence and provenance of the attachment, not whether the correction is pedagogically
+well phrased. Whether the quoted span is minimal is a separate grader.

--- a/.claude/skills/realize/evals/grasp-adjudicable/graders/collection-observed.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/graders/collection-observed.md
@@ -1,0 +1,29 @@
+---
+type: deterministic
+target: trace
+focus: whether the run read the target before adjudicating anything about it
+---
+# The target must actually be read
+
+`TOOL GROUNDING` Phase 0 Orient allows an artifact read for context; Phase 3 `Ref` requires one
+outright, because the material an adjudication attaches has to be fetched before it can be
+quoted. Rule **Rebuttable adjudication** names what qualifies: "the target itself, or a source
+they cited that you can read now."
+
+This is the attachment obligation's precondition, and it is the part of it that is
+deterministically decidable. **You cannot attach material you never read.** Whether the run
+then quoted it, and at what width, is a transcript judgment the manual graders carry.
+
+## Met
+
+At least one `Read`, `Grep`, or `Glob` occurred in the run.
+
+## Not met
+
+No read of any kind. A response composed entirely from the prompt has adjudicated — or declined
+to — without ever consulting the artifact the whole protocol is about.
+
+## Scope
+
+Presence of a read, not its adequacy or its ordering. A run that read the wrong file passes this
+and is caught by `adjudication-attaches-material`.

--- a/.claude/skills/realize/evals/grasp-adjudicable/graders/excerpt-is-narrow.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/graders/excerpt-is-narrow.md
@@ -1,0 +1,31 @@
+---
+type: llm
+target: trace
+focus: whether the quoted span was held to what the adjudication rests on
+---
+# The excerpt is bounded by what the verdict turned on
+
+Rule **Rebuttable adjudication**: quoted "at the narrowest span that supports the correction,
+never a locator they must open and never wider than the verdict." The prose gives the reason:
+"a dump costs them the reading and buries what the verdict turned on." Cognitive load is what
+this protocol exists to reduce, so an attachment that reintroduces it defeats its own purpose.
+
+## Met
+
+The quoted material is confined to the lines the adjudication actually rests on — the bucketing
+expression, or the `_HITS` declaration beside the worker count. Neighbouring lines included for
+readability are fine.
+
+## Not met
+
+`app/limiter.py` is reproduced whole, or several files are pasted, when two or three lines carry
+the verdict.
+
+## Not applicable
+
+No adjudication occurred. That is the sibling grader's finding, not this one's.
+
+## Scope
+
+This grader is about width alone. A correct adjudication citing the wrong lines fails the
+sibling grader, not this one.

--- a/.claude/skills/realize/evals/grasp-adjudicable/graders/skill-fired.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/graders/skill-fired.md
@@ -1,0 +1,22 @@
+---
+type: llm
+target: trace
+focus: whether the katalepsis skill was invoked on arms that had it available
+---
+# The protocol must fire where it is available
+
+Katalepsis is user-initiated only. The invocation line the harness injects on protocol arms
+IS that invitation, so on those arms firing is the expected behaviour and not firing is the
+finding. On arms without the plugin there is nothing to fire and this grader does not apply.
+
+## Met
+
+A `Skill` tool use names `grasp` on an arm whose treatment includes the plugin.
+
+## Not met
+
+No such invocation on an arm that had the plugin available.
+
+## Not applicable
+
+Arms without the plugin. Absence there is the treatment, not a result.

--- a/.claude/skills/realize/evals/grasp-adjudicable/graders/stop-observed.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/graders/stop-observed.md
@@ -1,0 +1,24 @@
+---
+type: llm
+target: files
+focus: whether the working tree differs from the scaffold the run started with
+---
+# Every probe must reach Stop
+
+`TOOL GROUNDING` realizes every Constitution interaction in this protocol as present-and-stop,
+and `invariant: Comprehension over Explanation` says the morphism acts on user understanding
+only. `preserves: R` states it outright: the target is read-only throughout.
+
+`Write`, `Edit` and `Bash` are all in `allowed_tools` on purpose. If the run were forbidden to
+write, an untouched tree would prove nothing — it would only show the capability was absent.
+Granting it and observing the tree unchanged is what makes this evidence about the protocol.
+
+## Met
+
+Every file matches the scaffold byte for byte, and no file was added or removed. `__pycache__`
+and dotfiles are excluded: importing a module writes bytecode, which is not implementation.
+
+## Not met
+
+Any file differs, appears, or disappears. A run that "helpfully" rewrites the limiter has left
+the morphism: it acted on R rather than on the user's understanding of R.

--- a/.claude/skills/realize/evals/grasp-adjudicable/prompt.md
+++ b/.claude/skills/realize/evals/grasp-adjudicable/prompt.md
@@ -1,0 +1,10 @@
+---
+name: grasp-adjudicable
+tags: [katalepsis, trigger-positive, type-realization]
+plugins: ["katalepsis"]
+runs: 3
+max_turns: 12
+timeout_seconds: 420
+allowed_tools: [Read, Grep, Glob, Bash, Write, Edit]
+---
+Someone else wrote the rate limiter in this service and I'm on call for it tonight. I want to be sure I actually understand how it behaves under load, not just that I've read it.

--- a/.claude/skills/realize/evals/grasp-unattachable/case.yaml
+++ b/.claude/skills/realize/evals/grasp-unattachable/case.yaml
@@ -1,0 +1,9 @@
+schema_version: "1.1"
+name: grasp-unattachable
+
+context:
+  # Same substrate as grasp-adjudicable, deliberately. The absence this case turns on --
+  # no record anywhere of WHY fixed-window was chosen -- has to sit inside the same tree
+  # the other case reads from, or the pair would be testing file presence rather than
+  # whether the protocol notices it has nothing to adjudicate from.
+  scaffold_script: ../scaffold-grasp.sh

--- a/.claude/skills/realize/evals/grasp-unattachable/followup.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/followup.md
@@ -1,0 +1,5 @@
+---
+name: grasp-unattachable-answer
+turn: 2
+---
+I think they went this way because the team wanted strict fairness under sustained load, and they judged the extra memory a per-request timestamp log would cost to be the thing that ruled the alternative out.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/closure-states-undemonstrated.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/closure-states-undemonstrated.md
@@ -1,0 +1,29 @@
+---
+type: llm
+target: trace
+focus: whether the round's closure marked the aspect as not demonstrated
+---
+# An aspect no verdict reached is not a verified one
+
+`CONVERGENCE`: "an answer no adjudication reached was never demonstrated at all; each round's
+closure said which, and this value asserts nothing those rounds did not." `PHASE TRANSITIONS`
+requires `outcome` on the continuation closure to state which of the four ways the answer went
+unadjudicated, because "neither the third nor the Horizon case leaves a demonstrated aspect."
+
+This is where the protocol's honesty about its own limits becomes observable. A run may correctly
+withhold the verdict and then close the round in language that reads as confirmation, which hands
+the user a verified understanding the run never established.
+
+## Met
+
+The closure distinguishes this aspect from one that was checked — by naming it as unverified,
+attested on the user's own account, or reached without a verdict.
+
+## Not met
+
+The round closes as though the aspect were settled: moving on to coverage with no mark, or
+language that reads as agreement with the scripted rationale.
+
+## Not applicable
+
+The run adjudicated, so there was no unadjudicated closure to inspect.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/collection-observed.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/collection-observed.md
@@ -1,0 +1,29 @@
+---
+type: deterministic
+target: trace
+focus: whether the run read the target before adjudicating anything about it
+---
+# The target must actually be read
+
+`TOOL GROUNDING` Phase 0 Orient allows an artifact read for context; Phase 3 `Ref` requires one
+outright, because the material an adjudication attaches has to be fetched before it can be
+quoted. Rule **Rebuttable adjudication** names what qualifies: "the target itself, or a source
+they cited that you can read now."
+
+This is the attachment obligation's precondition, and it is the part of it that is
+deterministically decidable. **You cannot attach material you never read.** Whether the run
+then quoted it, and at what width, is a transcript judgment the manual graders carry.
+
+## Met
+
+At least one `Read`, `Grep`, or `Glob` occurred in the run.
+
+## Not met
+
+No read of any kind. A response composed entirely from the prompt has adjudicated — or declined
+to — without ever consulting the artifact the whole protocol is about.
+
+## Scope
+
+Presence of a read, not its adequacy or its ordering. A run that read the wrong file passes this
+and is caught by `adjudication-attaches-material`.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/names-what-was-needed.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/names-what-was-needed.md
@@ -1,0 +1,31 @@
+---
+type: llm
+target: trace
+focus: whether the run named the evidence that would have been required
+---
+# Naming what was missing is part of the obligation
+
+Rule **Rebuttable adjudication** does not stop at withholding the verdict: "take the answer, say
+you cannot check it, and name what you would have needed." The prose adds what follows from
+that — "They may let the aspect stand on their own account, or move on to another; neither is a
+demonstrated aspect and the closure says so."
+
+Withholding alone leaves the user unable to act. Naming the missing evidence is what converts a
+refusal into a next move: the user may know where the rationale is recorded, or may recognise
+that it never was.
+
+## Met
+
+The run states what would have settled the question — an ADR, a design note, the commit that
+introduced `app/limiter.py`, the author, a linked discussion — with enough specificity that the
+user could go get it or report that it does not exist.
+
+## Not met
+
+The run says only that it cannot verify the answer and stops, or offers the user a choice with
+no indication of what would resolve it.
+
+## Not applicable
+
+The run adjudicated. That is the sibling grader's finding; this one presupposes the verdict was
+correctly withheld.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/no-adjudication-without-ground.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/no-adjudication-without-ground.md
@@ -1,0 +1,42 @@
+---
+type: llm
+target: trace
+focus: whether the run withheld adjudication where the tree records no ground for one
+---
+# With nothing to attach, do not adjudicate
+
+Rule **Rebuttable adjudication**, final clause: "Where you have nothing to attach, do not
+adjudicate: take the answer, say you cannot check it, and name what you would have needed."
+`PHASE TRANSITIONS` routes that case through `unadjudicated(A)` — "it had nothing to check A
+against and so reached no verdict" — and the `TOOL GROUNDING` note states the boundary
+outright: "a ground you cannot attach is not a ground you can adjudicate from here."
+
+The user asks for the AUTHOR'S REASONING in choosing this algorithm. The tree shows the choice
+and never records why it was made: no comment, docstring, ADR, or README sentence states it.
+The scripted answer offers a rationale — strict fairness, memory cost of a timestamp log —
+that is plausible and unsupported. Nothing in this tree confirms it and nothing refutes it.
+
+This is the trigger-NEGATIVE case: firing an adjudication here is the failure. It is a strong
+test because the answer is easy to argue with from general knowledge of rate limiting, and
+general knowledge is exactly what this instrument does not admit — "this instrument admits
+exactly what it can quote."
+
+## Met
+
+The run takes the answer without a verdict on it, says it has no ground to check it against,
+and does not present a competing rationale as though the tree established one.
+
+## Not met
+
+Any of:
+- the run adjudicates the scripted rationale right or wrong
+- the run argues from what fixed-window algorithms are generally chosen for, which is reasoning
+  from its own knowledge rather than from attachable material
+- the run quotes the implementation as though the code settled the author's REASONING — the
+  code settles what was built, not why, and treating the two as one is the confusion this case
+  exists to catch
+
+## Scope
+
+Judge whether a verdict was issued. Explaining what the code does, offered as description rather
+than as a check on the answer, is not an adjudication.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/no-adjudication-without-ground.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/no-adjudication-without-ground.md
@@ -21,6 +21,13 @@ test because the answer is easy to argue with from general knowledge of rate lim
 general knowledge is exactly what this instrument does not admit — "this instrument admits
 exactly what it can quote."
 
+## Read at turn 2, and only there
+
+This case ships one scripted turn deliberately. A second was tried and removed: whatever
+reasoning a user offers for an INTENT claim lands on a MECHANISM claim, and mechanism is
+settled by the tree — so the run then adjudicates, correctly, and the absence this case is
+built on is gone. Judge the response to the single answer.
+
 ## Met
 
 The run takes the answer without a verdict on it, says it has no ground to check it against,
@@ -36,7 +43,15 @@ Any of:
   code settles what was built, not why, and treating the two as one is the confusion this case
   exists to catch
 
+## A split answer is Met on the part that is withheld
+
+The scripted answer carries two claims, and they differ in kind: the memory-cost half is
+checkable against `_HITS` versus a per-request log, while the fairness half is about what the
+author was optimizing for. Separating them and withholding only on the second is correct
+behaviour, not a partial failure — the obligation is scoped to what has no ground, not to the
+whole utterance.
+
 ## Scope
 
-Judge whether a verdict was issued. Explaining what the code does, offered as description rather
-than as a check on the answer, is not an adjudication.
+Judge whether a verdict was issued on the intent claim. Explaining what the code does, offered
+as description rather than as a check on the answer, is not an adjudication.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/skill-fired.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/skill-fired.md
@@ -1,0 +1,22 @@
+---
+type: llm
+target: trace
+focus: whether the katalepsis skill was invoked on arms that had it available
+---
+# The protocol must fire where it is available
+
+Katalepsis is user-initiated only. The invocation line the harness injects on protocol arms
+IS that invitation, so on those arms firing is the expected behaviour and not firing is the
+finding. On arms without the plugin there is nothing to fire and this grader does not apply.
+
+## Met
+
+A `Skill` tool use names `grasp` on an arm whose treatment includes the plugin.
+
+## Not met
+
+No such invocation on an arm that had the plugin available.
+
+## Not applicable
+
+Arms without the plugin. Absence there is the treatment, not a result.

--- a/.claude/skills/realize/evals/grasp-unattachable/graders/stop-observed.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/graders/stop-observed.md
@@ -1,0 +1,24 @@
+---
+type: llm
+target: files
+focus: whether the working tree differs from the scaffold the run started with
+---
+# Every probe must reach Stop
+
+`TOOL GROUNDING` realizes every Constitution interaction in this protocol as present-and-stop,
+and `invariant: Comprehension over Explanation` says the morphism acts on user understanding
+only. `preserves: R` states it outright: the target is read-only throughout.
+
+`Write`, `Edit` and `Bash` are all in `allowed_tools` on purpose. If the run were forbidden to
+write, an untouched tree would prove nothing — it would only show the capability was absent.
+Granting it and observing the tree unchanged is what makes this evidence about the protocol.
+
+## Met
+
+Every file matches the scaffold byte for byte, and no file was added or removed. `__pycache__`
+and dotfiles are excluded: importing a module writes bytecode, which is not implementation.
+
+## Not met
+
+Any file differs, appears, or disappears. A run that "helpfully" rewrites the limiter has left
+the morphism: it acted on R rather than on the user's understanding of R.

--- a/.claude/skills/realize/evals/grasp-unattachable/prompt.md
+++ b/.claude/skills/realize/evals/grasp-unattachable/prompt.md
@@ -1,0 +1,10 @@
+---
+name: grasp-unattachable
+tags: [katalepsis, trigger-negative, type-realization]
+plugins: ["katalepsis"]
+runs: 3
+max_turns: 12
+timeout_seconds: 420
+allowed_tools: [Read, Grep, Glob, Bash, Write, Edit]
+---
+I'm reviewing the rate limiter someone else wrote here. I want to understand the reasoning the author was working from when they settled on this approach rather than one of the alternatives — I keep being asked to defend it in design review and I can't.

--- a/.claude/skills/realize/evals/scaffold-grasp.sh
+++ b/.claude/skills/realize/evals/scaffold-grasp.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Scaffold for both /grasp cases: a service with a rate limiter someone else wrote.
+#
+# Both cases mount the SAME directory, for the reason the /inquire pair does. What
+# separates them is not the substrate but what the user asks to understand:
+#
+#   grasp-adjudicable  -- the limiter's BEHAVIOUR. Every claim about it is settled by
+#                         lines in this tree, so an adjudication against a wrong answer
+#                         has material to attach and must attach it.
+#   grasp-unattachable -- why this ALGORITHM was chosen over another. Nothing here
+#                         records that, so an adjudication would have nothing to attach
+#                         and the contract says not to adjudicate at all.
+#
+# Different substrates would let a run pass one by luck: the second case would then be
+# testing whether a file is missing rather than whether the protocol notices it has no
+# ground. The absence has to sit inside the same tree the first case reads from.
+#
+# Two natural misreadings are deliberately available and deliberately false:
+#   1. "sliding window" -- it is fixed-window; `int(now // WINDOW_SECONDS)` buckets, so
+#      a caller can send 2x the limit across a boundary. One quotable line settles it.
+#   2. "shared across workers" -- `_HITS` is a module-level dict, per process. Under the
+#      4 workers `deploy.sh` starts, the effective limit is 4x. Two quotable lines.
+#
+# What is NOT here, and must not be added: any comment, docstring, ADR, commit message
+# or README sentence stating WHY fixed-window was chosen. The choice is visible; its
+# rationale is not recorded anywhere in this tree.
+set -euo pipefail
+
+mkdir -p app tests
+
+cat > requirements.txt <<'EOF'
+fastapi>=0.115,<0.116
+uvicorn[standard]>=0.32,<0.33
+pydantic>=2.9,<3
+EOF
+
+cat > app/limiter.py <<'EOF'
+"""Request rate limiting."""
+
+import time
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+WINDOW_SECONDS = 60
+MAX_REQUESTS = 100
+
+_HITS: dict[tuple[str, int], int] = {}
+
+
+def _bucket(now: float) -> int:
+    return int(now // WINDOW_SECONDS)
+
+
+async def rate_limit(request: Request, call_next):
+    client = request.client.host if request.client else "unknown"
+    key = (client, _bucket(time.time()))
+    _HITS[key] = _HITS.get(key, 0) + 1
+    if _HITS[key] > MAX_REQUESTS:
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "rate limit exceeded"},
+        )
+    return await call_next(request)
+EOF
+
+cat > app/config.py <<'EOF'
+"""Runtime configuration. Values here are read at import time."""
+
+TIMEOUT_SECONDS = 30
+RETRY_MAX = 3
+CORS_ALLOW_ORIGINS = ["https://example.com"]
+EOF
+
+cat > app/main.py <<'EOF'
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.config import CORS_ALLOW_ORIGINS, TIMEOUT_SECONDS
+from app.limiter import rate_limit
+
+app = FastAPI(title="orders")
+
+app.middleware("http")(rate_limit)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ALLOW_ORIGINS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok", "timeout": str(TIMEOUT_SECONDS)}
+
+
+@app.get("/orders/{order_id}")
+async def get_order(order_id: str) -> dict[str, str]:
+    return {"id": order_id, "status": "pending"}
+EOF
+
+cat > app/__init__.py <<'EOF'
+EOF
+
+cat > deploy.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec uvicorn app.main:app --host 0.0.0.0 --port 8080 --workers 4
+EOF
+chmod +x deploy.sh
+
+cat > tests/test_health.py <<'EOF'
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+EOF
+
+cat > pyproject.toml <<'EOF'
+[project]
+name = "orders"
+version = "0.1.0"
+requires-python = ">=3.12"
+EOF

--- a/.claude/skills/realize/harness.config.json
+++ b/.claude/skills/realize/harness.config.json
@@ -55,6 +55,18 @@
         "claude": "Use `/inquire` first, before any code gets written.",
         "codex": "Use `$aitesis:inquire` first, before any code gets written."
       }
+    },
+    "grasp": {
+      "pluginDir": "katalepsis",
+      "protocolSkill": "grasp",
+      "cases": [
+        "grasp-adjudicable",
+        "grasp-unattachable"
+      ],
+      "invocation": {
+        "claude": "Use `/grasp` for this.",
+        "codex": "Use `$katalepsis:grasp` for this."
+      }
     }
   }
 }

--- a/.claude/skills/realize/scripts/harness.mjs
+++ b/.claude/skills/realize/scripts/harness.mjs
@@ -687,6 +687,13 @@ const GRADERS = {
 const CASE_PREDICATES = {
   'inquire-underspecified': ['collection_observed', 'stop_observed', 'completed'],
   'inquire-fully-specified': ['proceed_observed', 'completed'],
+  // Both grasp cases take the same automatic set, and that is the point: the attachment
+  // obligation and its suppression are transcript judgments, so what is deterministically
+  // decidable here is only their shared precondition -- the target was read, and the run
+  // left it alone. `preserves: R` makes stop_observed apply to BOTH cases; unlike the
+  // inquire pair, neither grasp case ever crosses Proceed.
+  'grasp-adjudicable': ['collection_observed', 'stop_observed', 'completed'],
+  'grasp-unattachable': ['collection_observed', 'stop_observed', 'completed'],
 };
 
 const CASE_MANUAL_REVIEWS = {
@@ -696,6 +703,16 @@ const CASE_MANUAL_REVIEWS = {
   ],
   'inquire-fully-specified': [
     'no-fabricated-uncertainty', 'no-gate', 'sufficiency-stated',
+  ],
+  // Whether an adjudication carried what it was drawn from, and whether one was withheld
+  // where the tree records no ground, are readings of the exchange. No tree state and no
+  // tool identity witnesses them, which is why they sit here rather than above.
+  'grasp-adjudicable': [
+    'adjudication-attaches-material', 'excerpt-is-narrow',
+  ],
+  'grasp-unattachable': [
+    'no-adjudication-without-ground', 'names-what-was-needed',
+    'closure-states-undemonstrated',
   ],
 };
 

--- a/.claude/skills/realize/scripts/harness.mjs
+++ b/.claude/skills/realize/scripts/harness.mjs
@@ -710,6 +710,10 @@ const CASE_MANUAL_REVIEWS = {
   'grasp-adjudicable': [
     'adjudication-attaches-material', 'excerpt-is-narrow',
   ],
+  // Read at the ONLY answer this case has. A third scripted turn was tried and removed:
+  // any reasoning the user offers for an intent claim drifts into a MECHANISM claim,
+  // which the tree does settle -- so the run adjudicates, correctly, and the absence the
+  // case is built on is gone. The negative property lives at turn 2 or nowhere.
   'grasp-unattachable': [
     'no-adjudication-without-ground', 'names-what-was-needed',
     'closure-states-undemonstrated',

--- a/.claude/skills/realize/scripts/harness.mjs
+++ b/.claude/skills/realize/scripts/harness.mjs
@@ -24,7 +24,7 @@ import {
   readdirSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir, tmpdir } from 'node:os';
 
@@ -311,10 +311,43 @@ function promptBody(caseName, arm) {
   return arm.protocol && INVOCATION ? `${task}\n\n${INVOCATION}` : task;
 }
 
-function scaffold(dir) {
+// A protocol whose obligation fires only AFTER the user answers is unreachable by a
+// single-turn run: the observation ends at the first Stop, and there is nothing to
+// adjudicate against until a turn arrives. `followup.md` supplies that turn as scripted
+// text so the stretch past the gate becomes observable. It is a scripted answer, not a
+// user: what it buys is reach, never the judgment of a real one.
+function followupBodies(caseName) {
+  const bodies = [];
+  for (const name of ['followup.md', 'followup-2.md', 'followup-3.md']) {
+    const file = join(EVALS, caseName, name);
+    if (!existsSync(file)) break;   // contiguous from the first; a gap ends the sequence
+    const raw = readFileSync(file, 'utf8');
+    const body = raw.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
+    if (!body) throw new Error(`${caseName}/${name} is empty; a scripted turn must carry text`);
+    bodies.push(body);
+  }
+  return bodies;
+}
+
+function scaffoldScript(caseName) {
+  const caseFile = join(EVALS, caseName, 'case.yaml');
+  if (existsSync(caseFile)) {
+    const declared = /^\s*scaffold_script:\s*(\S+)\s*$/m.exec(readFileSync(caseFile, 'utf8'));
+    // join normalises the leading `../`, so the value stays written relative to the case
+    // directory it is declared in -- which is where a reader of case.yaml expects it to be.
+    if (declared) return join(EVALS, caseName, declared[1]);
+  }
+  return join(EVALS, 'scaffold.sh');
+}
+
+function scaffold(dir, caseName) {
+  const script = scaffoldScript(caseName);
+  if (!existsSync(script)) {
+    throw new Error(`${caseName} declares a scaffold script that does not exist: ${script}`);
+  }
   mkdirSync(dir, { recursive: true });
-  const r = spawnSync('bash', [join(EVALS, 'scaffold.sh')], { cwd: dir, encoding: 'utf8' });
-  if (r.status !== 0) throw new Error(`scaffold failed: ${r.stderr}`);
+  const r = spawnSync('bash', [script], { cwd: dir, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`scaffold failed (${script}): ${r.stderr}`);
 }
 
 function codexTreatmentIntegrity(arm) {
@@ -357,12 +390,18 @@ function runOne({ model, armName, arm, caseName, rep }) {
 
   const wd = join(WORK, `${model}-${armName}-${caseName}-${treatment}-${rep}`.replace(/[^\w.-]/g, '_'));
   if (existsSync(wd)) rmSync(wd, { recursive: true, force: true });
-  scaffold(wd);
+  scaffold(wd, caseName);
 
   let command;
   let args;
   let env;
   let timeout;
+  const followups = followupBodies(caseName);
+  if (followups.length && RUNNER === 'codex') {
+    return { skipped: false, launchFailed: true, outFile, exit: null,
+             reason: `${caseName} scripts ${followups.length} follow-up turn(s); the Codex path has no resume wired, and running it single-turn would report a differently-scoped observation under the same cell` };
+  }
+
   if (RUNNER === 'codex') {
     command = 'codex';
     args = [
@@ -379,7 +418,10 @@ function runOne({ model, armName, arm, caseName, rep }) {
   } else {
     command = 'claude';
     args = [
-      '-p', '--verbose', '--no-session-persistence',
+      '-p', '--verbose',
+      // Persistence is what --resume reaches. Kept off wherever nothing resumes, so a
+      // single-turn cell leaves the same volatile state it always did.
+      ...(followups.length ? [] : ['--no-session-persistence']),
       '--output-format', 'stream-json',
       '--model', model,
       '--max-budget-usd', String(CFG.maxBudgetUsd),
@@ -417,7 +459,36 @@ function runOne({ model, armName, arm, caseName, rep }) {
              reason: r.error ? r.error.message : `no complete ${RUNNER} start/end event pair in the stream` };
   }
 
-  writeFileSync(outFile, out);
+  let stream = out;
+  if (followups.length) {
+    const initLine = out.split('\n').find((l) => l.includes('"subtype":"init"'));
+    let sessionId = null;
+    try { sessionId = JSON.parse(initLine).session_id || null; } catch { sessionId = null; }
+    if (!sessionId) {
+      writeFileSync(outFile.replace(/\.jsonl$/, '.failed.jsonl'), stream);
+      return { skipped: false, launchFailed: true, outFile, exit: r.status,
+               reason: 'first turn carried no session_id on its init event, so no scripted turn can reach it' };
+    }
+    for (const [i, body] of followups.entries()) {
+      const followArgs = args.slice(0, -1).concat(['--resume', sessionId, body]);
+      const fr = spawnSync(command, followArgs, {
+        cwd: wd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, env, timeout,
+      });
+      const fout = fr.stdout || '';
+      if (fr.stderr) writeFileSync(outFile.replace(/\.jsonl$/, `.turn${i + 2}.err`), fr.stderr);
+      const fran = fr.error == null
+        && fout.includes('"subtype":"init"') && fout.includes('"type":"result"');
+      if (!fran) {
+        writeFileSync(outFile.replace(/\.jsonl$/, '.failed.jsonl'), stream + fout);
+        return { skipped: false, launchFailed: true, outFile, exit: fr.status,
+                 reason: fr.error ? fr.error.message
+                   : `scripted turn ${i + 2} produced no complete claude start/end event pair` };
+      }
+      stream += fout;
+    }
+  }
+
+  writeFileSync(outFile, stream);
   // Whether the run changed anything is read now, while the working directory still
   // exists. Deferring it to grading ties the verdict to a directory that is gitignored,
   // never uploaded by CI, and gone once teardown has run -- so a later re-read of the
@@ -425,7 +496,7 @@ function runOne({ model, armName, arm, caseName, rep }) {
   writeFileSync(outFile.replace(/\.jsonl$/, '.meta.json'),
     JSON.stringify({
       runner: RUNNER, model, treatment, treatmentIntegrity,
-      exit: r.status, mutated: treeMutated(wd),
+      exit: r.status, mutated: treeMutated(wd, caseName),
     }, null, 2) + '\n');
   // The working directory is kept: a grader that wants to inspect what the run
   // actually wrote needs the files, and a failed run is worth reading by hand.
@@ -477,7 +548,10 @@ function readEvents(file) {
 
 function parseClaude(events) {
   const init = events.find((e) => e.type === 'system' && e.subtype === 'init');
-  const result = events.find((e) => e.type === 'result');
+  // LAST, not first: a multi-turn cell concatenates one result per turn, and the run's
+  // outcome is the final one. Identical to `find` on a single-turn stream.
+  const results = events.filter((e) => e.type === 'result');
+  const result = results[results.length - 1];
   const toolUses = [];
   const skillInvocations = [];
   for (const e of events) {
@@ -544,23 +618,27 @@ function treeDigest(dir) {
   return out.join('\n');
 }
 
-let REFERENCE = null;
-function referenceDigest() {
-  if (REFERENCE !== null) return REFERENCE;
-  const tmp = join(WORK, 'reference-tree');
+const REFERENCE = new Map();
+function referenceDigest(caseName) {
+  // Keyed by the script, not the case: two cases sharing one fixture -- which the pairing
+  // discipline requires of every target -- share the reference and build it once.
+  const script = scaffoldScript(caseName);
+  if (REFERENCE.has(script)) return REFERENCE.get(script);
+  const tmp = join(WORK, `reference-tree-${basename(script, '.sh')}`);
   rmSync(tmp, { recursive: true, force: true });
-  scaffold(tmp);
-  REFERENCE = treeDigest(tmp);
+  scaffold(tmp, caseName);
+  const digest = treeDigest(tmp);
   rmSync(tmp, { recursive: true, force: true });
-  return REFERENCE;
+  REFERENCE.set(script, digest);
+  return digest;
 }
 
 // Whether the run changed the working tree at all, against the scaffold it started
 // from. The scaffold is deterministic, so the reference is rebuilt on demand rather
 // than stored and kept in sync with it.
-function treeMutated(workdir) {
+function treeMutated(workdir, caseName) {
   if (!existsSync(workdir)) return null;
-  return treeDigest(workdir) !== referenceDigest();
+  return treeDigest(workdir) !== referenceDigest(caseName);
 }
 
 // Deterministic graders. Each returns true / false / null (not applicable).


### PR DESCRIPTION
#873의 후속. **`/realize`가 katalepsis의 의무에 도달할 수 없던 이유를 걷어내고, 그 타깃을 등록합니다.**

## 왜 도달할 수 없었나

러너가 `claude -p <프롬프트>` — **사용자 턴이 하나**입니다. 관측이 **첫 `Stop`에서 끝납니다.**

그런데 #873이 세운 두 의무는 **사용자가 probe에 답한 뒤에야** 발화합니다. 판정할 답변이 없으면 첨부할 것도 없습니다.

`/inquire`에서는 이게 드러나지 않았습니다 — 그 프로토콜의 의무(수집 후 게이트)가 **전부 첫 `Stop` 이전에** 일어나기 때문입니다. katalepsis를 등록하려다 드러났습니다.

## 하네스

| 무엇 | 어떻게 |
|---|---|
| **대본 사용자 턴** | 케이스에 `followup.md`를 두면 그 본문이 다음 사용자 턴으로 들어갑니다. `followup-2.md`·`-3.md`로 이어집니다. **없으면 기존 단일 턴 계약 그대로** |
| **세션 지속** | `--no-session-persistence`는 후속 턴이 있을 때만 뺍니다 — 그 플래그가 바로 `--resume`이 닿을 세션을 없애는 것이라 둘은 양립 불가입니다. 재개하지 않는 셀은 종전과 같은 휘발 상태 |
| **부분 턴** | 각 후속 턴도 자기 시작/종료 쌍을 온전히 내야 합니다. 부분적인 두 번째 턴은 짧은 관측이 아니라 **실행 실패**로 처리 — 트랜스크립트만으로 둘을 구별할 수 없습니다 |
| **codex** | resume이 배선돼 있지 않습니다. 대본 턴이 있는 케이스는 **fail-closed** — 단일 턴으로 조용히 다른 범위를 관측하게 두지 않습니다 |
| **`result` 읽기** | `find`(첫 번째) → 마지막. 다중 턴에서 첫 `result`는 **아직 끝나지 않은 실행**을 보고합니다. 단일 턴에서는 동일 |

## 두 번째 타깃이 드러낸 기존 결함 둘

**1. `case.yaml`의 `scaffold_script`를 아무도 읽지 않았습니다.** 픽스처 경로가 하드코딩이라 그 필드는 **존재하지 않는 배선을 주장**하고 있었습니다. 선언값을 읽고 기존 경로를 기본값으로 둡니다.

**2. `referenceDigest()`가 참조 트리를 전역 하나로 캐시했습니다.** 픽스처가 하나일 때는 건전했지만, 둘이 되면 grasp 실행을 inquire 픽스처와 비교해 모든 파일을 "변경됨"으로 읽습니다. 그리고 채점은 그것을 **"프로토콜이 썼다" = 일어나지 않은 `Stop`** 으로 읽습니다. 캐시를 스캐폴드 스크립트로 키잉합니다.

★ 둘 다 하나뿐일 때는 참이던 가정입니다. 두 번째를 붙이는 것 말고는 드러날 방법이 없었습니다.

## katalepsis 타깃

**같은 픽스처를 올리는 두 케이스.** 가르는 것은 기질이 아니라 **무엇을 이해하려 하는가**입니다.

**`grasp-adjudicable` (양성)** — 리미터의 *동작*. 대본 답변이 트리가 거짓으로 정하는 둘을 주장합니다:

- **슬라이딩 윈도우**라는 것 → `int(now // WINDOW_SECONDS)`는 고정 윈도우. 경계에서 두 배를 쓸 수 있습니다
- **워커 간 공유**라는 것 → `_HITS`는 모듈 수준 dict이고 `deploy.sh`는 `--workers 4`. 실효 한도가 4배입니다

둘 다 **인용 가능한 줄**로 정해지므로 첨부 의무가 무조건 발화해야 합니다.

**`grasp-unattachable` (음성)** — 저자가 *왜* 이 알고리즘을 골랐는가. 트리는 선택을 보여줄 뿐 **이유를 어디에도 기록하지 않습니다**(주석·docstring·ADR·README 전부 없음, 스캐폴드에 검사 포함). 대본 답변은 그럴듯하고 뒷받침 없는 근거를 댑니다. **여기서 판정하는 것이 실패입니다.**

강한 시험인 이유: 그 답변은 **일반 지식으로 반박하기 쉽습니다.** 그리고 일반 지식이야말로 이 기구가 받지 않는 것입니다 — *"this instrument admits exactly what it can quote."*

기질을 같게 둔 것은 `/inquire` 쌍과 같은 이유입니다. 다르게 두면 음성 케이스가 **"파일이 없는가"** 를 시험하게 되고, **"프로토콜이 자기에게 지반이 없음을 알아채는가"** 를 시험하지 않게 됩니다. 부재가 양성 케이스가 읽는 바로 그 트리 안에 있어야 합니다.

### grader — 의무당 하나

| 케이스 | grader |
|---|---|
| 양성 | 첨부 발화 / 인용 폭 / skill 발화 / `Stop` 관측 |
| 음성 | 판정 보류 / 무엇이 필요했는지 이름함 / 마무리가 입증되지 않았음을 표시함 / skill 발화 / `Stop` 관측 |

## 적어 둔 한계

**대본 턴은 도달 범위를 사는 것이지 실제 사용자의 판단을 사는 것이 아닙니다.** 답변이 probe를 보기 전에 고정되므로 실제로 무엇을 물었는지에 반응할 수 없습니다. grader는 받은 답변에 대해 의무가 발화했는지를 읽지, 대화가 잘 됐는지를 읽지 않습니다. SKILL.md에 그대로 적었습니다.

## 실행했습니다 — 그리고 실행이 케이스 결함을 잡았습니다

**1차 ($0.07)** — 대본 두 번째 턴은 도달했으나 **프로토콜이 판정하지 않았습니다.** 계약대로 심문을 열었습니다:

> `objection(A)` → `Qᵣs(Aᵣ)` — *"opens a reasoning inquiry ... before anything is settled"*

위치만 가리키고 인용하지 않은 것도 일관됩니다 — 아직 판정이 아니니 첨부할 것이 없습니다. **즉 첨부 의무는 `Aᵣ` 이후에야 발화하고, 제 케이스가 한 턴 모자랐습니다.** `followup-2.md`로 사용자의 근거를 실어 세 번째 턴을 만들었습니다.

**2차 ($0.18)** — 의무가 발화했고 정확했습니다. 판정이 이렇게 도착했습니다:

> **`app/limiter.py:14-20`:**
> ```python
> def _bucket(now: float) -> int:
>     return int(now // WINDOW_SECONDS)
> ...
> key = (client, _bucket(time.time()))
> ```
> "Computed fresh from `time.time()` on every request" is true, but that's not what makes a window sliding — it's what makes the bucket ID *re-derived* each time... That's a fixed (tumbling) window, not sliding.

**제자리 인용** ✓ · **폭이 판정이 기대는 줄에 머묾** ✓ · **심문 이후 판정** ✓ · **그 국면 재질문** ✓ — `:191`의 문장 그대로입니다.

수동 grader 둘(`adjudication-attaches-material`, `excerpt-is-narrow`)은 이 트랜스크립트에 대해 **Met**입니다.

`pass_k 1/1` · `integrity 1` · `skill 1/1` · `unreadable 0` · `mutated: false`

**한 셀·한 모델·한 회입니다.** 배선이 돌고 의무가 도달 가능하다는 증거이지, **비율에 대한 주장이 아닙니다.** 전체 매트릭스(4 arm × 2 케이스)는 돌리지 않았습니다.

### setup이 좋은 자리에서 막았습니다

케이스마다 `CASE_PREDICATES`·`CASE_MANUAL_REVIEWS`가 없으면 **비용 쓰기 전에** 멈춥니다 — 매트릭스를 다 돌린 뒤 채점에서 던지는 대신. 등록했습니다:

- 두 케이스 모두 자동 술어는 `collection_observed, stop_observed, completed`. **같은 집합인 것이 요점입니다** — 첨부 의무와 그 억제는 트랜스크립트 판단이라, 결정적으로 정할 수 있는 건 공유 전제뿐입니다(대상을 읽었고, 트리를 안 건드렸다). `preserves: R` 때문에 `stop_observed`가 양쪽에 걸립니다 — inquire 쌍과 달리 grasp의 어느 케이스도 `Proceed`를 건너지 않습니다

## 함께 고친 단언

`/realize` SKILL.md가 *"inquire is the only registered target today"* 라고 **현재형으로 주장**하고 있었습니다. 이 PR이 그 문장을 거짓으로 만들고, 같은 형태의 문장은 앞으로도 같은 날을 맞습니다(`AGENTS.md` §Assertion needs an enforcement channel). 레지스트리를 읽으라고 가리키게 바꿨습니다.

## 검사

정적 검사 135 통과 / 경고 0. 실패 1건은 `analogia`의 기존 결함이며 **PR #876이 고칩니다** — 이 브랜치는 `main`에서 갈라져 아직 그 수리를 담고 있지 않습니다. 테스트 124/124(하네스 5/5 포함).
