### PR TITLE
fix(epistemic-cooperative): 독자의 과제에 파생량을 포함한다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.26.13",
+  "version": "4.26.14",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.26.13",
+  "version": "4.26.14",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -50,7 +50,7 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 
 Whether a rendering earns its place, and what form it takes. One shape is pinned, where getting it wrong would make the rendering lie.
 
-**The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape — pulling out one discrete value is a table's task, taking in a set of relations at once is a picture's.
+**The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape. Pulling out one discrete value is a table's task; taking in a set of relations at once is a picture's; and where the judgment rests on a quantity the reader would have to derive from what is shown — a share of a bound, a ratio between rows — that derived quantity is the finding, and it goes on screen beside its inputs.
 
 **A form the host already renders is not rebuilt here.** Use the harness's tables, lists, and headings. Character count is not display width, so East Asian text, emoji, and many box-drawing characters break columns that looked aligned when written: never pad by counting characters. The Ink elements below are the exception — their literal shapes are fixed under **What This Style Pins**, and are built here by contract rather than chosen.
 

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -89,7 +89,7 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 
 Whether a rendering earns its place, and what form it takes. One shape is pinned, where getting it wrong would make the rendering lie.
 
-**The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape — pulling out one discrete value is a table's task, taking in a set of relations at once is a picture's.
+**The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape. Pulling out one discrete value is a table's task; taking in a set of relations at once is a picture's; and where the judgment rests on a quantity the reader would have to derive from what is shown — a share of a bound, a ratio between rows — that derived quantity is the finding, and it goes on screen beside its inputs.
 
 **A form the host already renders is not rebuilt here.** Use the harness's tables, lists, and headings. Character count is not display width, so East Asian text, emoji, and many box-drawing characters break columns that looked aligned when written: never pad by counting characters. The Ink elements below are the exception — their literal shapes are fixed under **What This Style Pins**, and are built here by contract rather than chosen.
 


### PR DESCRIPTION
## 요약

Rendering Judgment 첫 조항("The reader's task governs")을 독자의 과제 세 항 병렬로 재구성합니다. 값 하나 꺼내기는 표, 관계 한눈에 보기는 그림, 그리고 판정이 파생량(경계 대비 비율 등)에 기대면 그 파생량이 발견이고 입력값 옆에 화면에 올라갑니다.

## 근거

세션 9fca5a14의 마지막 턴에서 비율 질문("파드를 늘려야 하나")에 절대 소진시간 표 세 줄과 "여유롭습니다"로 답해 나눗셈을 독자에게 넘겼습니다. 같은 세션이 구조가 같은 질문 세 곳에서는 산문으로 비율을 올렸으므로, 능력이 아니라 조항의 도달 범위 문제입니다. 상세는 커밋 메시지에 있습니다.

## 변경

- `epistemic-cooperative/styles/epistemic-ink.md`, `proactive-epistemic-ink.md`: 각 +217자 (ink-body-identity 통과)
- plugin.json (claude/codex): 4.26.13 → 4.26.14

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 136 pass / 0 fail
- 새 세션에서 같은 질문을 재현하는 bounded trial은 아직 실행하지 않았습니다. 다음 실제 사용에서 비율이 화면에 오르는지가 시험입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157RZRgLo6ysBU6LTCcDP9g