### PR TITLE
refactor(epistemic-cooperative): 하네스가 이미 싣는 문장을 스타일에서 걷고 인지 층만 남긴다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.26.14",
+  "version": "4.26.15",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.26.14",
+  "version": "4.26.15",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -6,7 +6,7 @@ keep-coding-instructions: true
 
 # Epistemic Ink Output Style
 
-You are an interactive CLI tool that helps users with software engineering tasks. You combine educational insight delivery with visually structured epistemic protocol output.
+You combine educational insight delivery with visually structured epistemic protocol output.
 
 # Epistemic Protocol Formatting
 
@@ -166,9 +166,4 @@ Emit once per distinct pattern per session — subject redefinition, outcome rep
 
 # Tone and Style
 
-- Clear and educational, balancing insight delivery with task completion
 - Exceed typical length only where the request asked for depth. A standing permission to run long sits on the wrong side of the asymmetry named under Form feedback: the error it produces is the one that goes unreported
-- Only use emojis if the user explicitly requests it
-- Respond in the user's language
-
-When working with tool results, write down any important information you might need later in your response, as the original tool result may be cleared later.

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -6,7 +6,7 @@ keep-coding-instructions: true
 
 # Proactive Epistemic Ink Output Style
 
-You are an interactive CLI tool that helps users with software engineering tasks. Execute promptly within established authority while keeping decision-relevant judgments, assumptions, evidence, and verification visible through Epistemic Ink. This style pairs proactive execution pacing with the full Epistemic Ink protocol formatting reproduced below — pacing and visibility are separate axes, and this style moves only the pacing axis while inheriting Ink's visibility rendering unchanged.
+Execute promptly within established authority while keeping decision-relevant judgments, assumptions, evidence, and verification visible through Epistemic Ink. This style pairs proactive execution pacing with the full Epistemic Ink protocol formatting reproduced below — pacing and visibility are separate axes, and this style moves only the pacing axis while inheriting Ink's visibility rendering unchanged.
 
 # Execution Disposition
 
@@ -205,12 +205,7 @@ Emit once per distinct pattern per session — subject redefinition, outcome rep
 
 # Tone and Style
 
-- Clear and educational, balancing insight delivery with task completion
 - Exceed typical length only where the request asked for depth. A standing permission to run long sits on the wrong side of the asymmetry named under Form feedback: the error it produces is the one that goes unreported
-- Only use emojis if the user explicitly requests it
-- Respond in the user's language
-
-When working with tool results, write down any important information you might need later in your response, as the original tool result may be cleared later.
 
 # Per-Turn Reminder
 


### PR DESCRIPTION
## 요약

Fable 5.1 프롬프팅 가이드와 Output Style을 `/ground`로 대조한 뒤, 하네스가 이미 system prompt에 싣는 문장을 스타일에서 걷어 인지 층만 남깁니다. 두 파일 모두 `keep-coding-instructions: true`라 하네스 코딩 지시가 그대로 남으므로 스타일 안의 같은 문장은 진짜 중복이었습니다.

## 걷은 문장

- "You are an interactive CLI tool that helps users with software engineering tasks." (두 파일 머리글)
- "Clear and educational, balancing insight delivery with task completion"
- "Only use emojis if the user explicitly requests it"
- "Respond in the user's language"
- "When working with tool results, write down any important information..."

다섯 줄 모두 최초 커밋(2026-03-21)에서 하네스 기본 프롬프트를 옮겨온 것입니다. 상세는 커밋 메시지에 있습니다.

## 남긴 것

길이 조항("Exceed typical length only where the request asked for depth...")은 하네스 간결성 규칙과 다른 것을 말하는 Form feedback의 따름정리라 남깁니다.

## 후속으로 남긴 것

Drift tracking 문단은 하네스 중복이 아니라 기여자용 유지보수 지시이며 `emit-load-discipline` 검사가 라벨 존재를 강제합니다. 이 PR의 기준 밖이라 손대지 않았습니다.

## 변경

- `epistemic-cooperative/styles/epistemic-ink.md`, `proactive-epistemic-ink.md`: 각 -400자
- plugin.json (claude/codex): 4.26.14 → 4.26.15

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 136 pass / 0 fail
- `node --test scripts/package.test.js` — 84 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157RZRgLo6ysBU6LTCcDP9g
