### PR TITLE
feat(route): 쌓인 컨텍스트를 코어 프로토콜 결핍으로 라우팅하는 플러그인

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -161,6 +161,18 @@
       "category": "Productivity"
     },
     {
+      "name": "route",
+      "source": {
+        "source": "local",
+        "path": "./route"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
       "name": "anagoge",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "route",
       "source": "./route",
-      "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (per-prompt hook directive; opt-in)"
+      "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (per-prompt hook directive)"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -89,6 +89,11 @@
       "name": "heuresis",
       "source": "./heuresis",
       "description": "Widen an underexpanded candidate field through frame-parallel divergent generation — /ideate (εὕρεσις: finding/invention)"
+    },
+    {
+      "name": "route",
+      "source": "./route",
+      "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (per-prompt hook directive; opt-in)"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -89,12 +89,17 @@ Concern clusters: Planning (`/inquire`, `/elicit`, `/ideate`, `/preview`) · Ana
 | Plugin | Command | Purpose |
 |--------|---------|---------|
 | [Epistemic Cooperative](./epistemic-cooperative) | `/onboard`, `/probe`, `/catalog`, `/report`, `/dashboard`, `/steer`, `/realign`, `/misuse`, `/triage`, `/forge`, `/reduced-space-test`, `/gate-check` | Protocol learning, deficit recognition fit review, handbook reference, usage analysis, coverage dashboard, project profile recalibration, project guide direction-line fusion, retrospective contract violation detection, work-unit triage, reference-grounded prompt-artifact formation, scoped empirical validation, and advisor-checked decision gates |
+| [Route](./route) (experimental, opt-in) | `/route` | Context-driven protocol routing — a per-prompt hook directive has the agent invoke the one core protocol whose deficit the accumulated context shows |
 
 **Three discovery modes coexist** (none replaces the others):
 
 - `/catalog` — passive reference handbook (browse / lookup; you already know the question)
 - `/onboard` — pattern-based recommendation + optional trial (session-history-driven; you want to learn what fits your patterns)
 - `/probe` — active AI-hypothesized deficit recognition (multi-hypothesis fit review when you feel something is off but cannot yet name which deficit fits)
+
+**Context-driven routing** (experimental; separate opt-in plugin):
+
+- `/route` — the plugin's `UserPromptSubmit` hook places a short directive beside each prompt; when the accumulated context shows a deficit exactly one loaded core protocol resolves, the agent invokes that protocol (its own first gate holds the user's judgment), nudges when several fit, and stays silent when none. Candidate replacement for `/probe`; not in the default install set
 
 **Retrospective audit** (separate category from the discovery trio above):
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Concern clusters: Planning (`/inquire`, `/elicit`, `/ideate`, `/preview`) · Ana
 | Plugin | Command | Purpose |
 |--------|---------|---------|
 | [Epistemic Cooperative](./epistemic-cooperative) | `/onboard`, `/probe`, `/catalog`, `/report`, `/dashboard`, `/steer`, `/realign`, `/misuse`, `/triage`, `/forge`, `/reduced-space-test`, `/gate-check` | Protocol learning, deficit recognition fit review, handbook reference, usage analysis, coverage dashboard, project profile recalibration, project guide direction-line fusion, retrospective contract violation detection, work-unit triage, reference-grounded prompt-artifact formation, scoped empirical validation, and advisor-checked decision gates |
-| [Route](./route) (experimental, opt-in) | `/route` | Context-driven protocol routing — a per-prompt hook directive has the agent invoke the one core protocol whose deficit the accumulated context shows |
+| [Route](./route) | `/route` | Context-driven protocol routing — a per-prompt hook directive has the agent invoke the one core protocol whose deficit the accumulated context shows |
 
 **Three discovery modes coexist** (none replaces the others):
 
@@ -97,9 +97,9 @@ Concern clusters: Planning (`/inquire`, `/elicit`, `/ideate`, `/preview`) · Ana
 - `/onboard` — pattern-based recommendation + optional trial (session-history-driven; you want to learn what fits your patterns)
 - `/probe` — active AI-hypothesized deficit recognition (multi-hypothesis fit review when you feel something is off but cannot yet name which deficit fits)
 
-**Context-driven routing** (experimental; separate opt-in plugin):
+**Context-driven routing** (separate plugin):
 
-- `/route` — the plugin's `UserPromptSubmit` hook places a short directive beside each prompt; when the accumulated context shows a deficit exactly one loaded core protocol resolves, the agent invokes that protocol (its own first gate holds the user's judgment), nudges when several fit, and stays silent when none. Candidate replacement for `/probe`; not in the default install set
+- `/route` — the plugin's `UserPromptSubmit` hook places a short directive beside each prompt; when the accumulated context shows a deficit exactly one loaded core protocol resolves, the agent invokes that protocol (its own first gate holds the user's judgment), nudges when several fit, and stays silent when none
 
 **Retrospective audit** (separate category from the discovery trio above):
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -89,12 +89,17 @@ Codex marketplace는 Claude Code와 같은 플러그인 경계를 유지합니�
 | 플러그인 | 명령어 | 용도 |
 |----------|--------|------|
 | [Epistemic Cooperative](./epistemic-cooperative) | `/onboard`, `/probe`, `/catalog`, `/report`, `/dashboard`, `/steer`, `/realign`, `/misuse`, `/triage`, `/forge`, `/reduced-space-test`, `/gate-check` | 프로토콜 학습, 결핍 인식 fit review, 핸드북 레퍼런스, 사용 분석, 커버리지 대시보드, 프로젝트 프로필 재조정, 프로젝트 가이드 direction line 지평융합, 소급적 계약 위반 감지, work-unit triage, 레퍼런스-grounded prompt-artifact 형성, scoped 실증 검증, 그리고 자문 검증 결정 게이트 |
+| [Route](./route) (실험적, opt-in) | `/route` | 컨텍스트 기반 프로토콜 라우팅 — 매 프롬프트 훅 지시문이 에이전트로 하여금 쌓인 컨텍스트가 드러내는 결핍에 맞는 코어 프로토콜 하나를 호출하게 함 |
 
 **세 가지 발견 모드 공존** (서로 대체하지 않음):
 
 - `/catalog` — 패시브 레퍼런스 핸드북 (브라우징 / 룩업; 이미 질문을 알고 있을 때)
 - `/onboard` — 패턴 기반 추천 + 선택적 trial (세션 히스토리 기반; 자신의 패턴에 맞는 프로토콜을 학습하고 싶을 때)
 - `/probe` — AI 가설 기반 결핍 인식 (어떤 결핍이 맞는지 아직 명명하지 못할 때 multi-hypothesis fit review)
+
+**컨텍스트 기반 라우팅** (실험적; 별도 opt-in 플러그인):
+
+- `/route` — 플러그인의 `UserPromptSubmit` 훅이 매 프롬프트 옆에 짧은 지시문을 놓고, 쌓인 컨텍스트가 로드된 코어 프로토콜 정확히 하나가 해소하는 결핍을 보이면 에이전트가 그 프로토콜을 호출(첫 게이트는 그 프로토콜 자신이 쥠), 여럿이 맞으면 넛지, 없으면 침묵. `/probe`의 대체 후보; 기본 설치 세트에는 포함되지 않음
 
 **소급적 감사** (위 발견 트리오와 별도 카테고리):
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -89,7 +89,7 @@ Codex marketplace는 Claude Code와 같은 플러그인 경계를 유지합니�
 | 플러그인 | 명령어 | 용도 |
 |----------|--------|------|
 | [Epistemic Cooperative](./epistemic-cooperative) | `/onboard`, `/probe`, `/catalog`, `/report`, `/dashboard`, `/steer`, `/realign`, `/misuse`, `/triage`, `/forge`, `/reduced-space-test`, `/gate-check` | 프로토콜 학습, 결핍 인식 fit review, 핸드북 레퍼런스, 사용 분석, 커버리지 대시보드, 프로젝트 프로필 재조정, 프로젝트 가이드 direction line 지평융합, 소급적 계약 위반 감지, work-unit triage, 레퍼런스-grounded prompt-artifact 형성, scoped 실증 검증, 그리고 자문 검증 결정 게이트 |
-| [Route](./route) (실험적, opt-in) | `/route` | 컨텍스트 기반 프로토콜 라우팅 — 매 프롬프트 훅 지시문이 에이전트로 하여금 쌓인 컨텍스트가 드러내는 결핍에 맞는 코어 프로토콜 하나를 호출하게 함 |
+| [Route](./route) | `/route` | 컨텍스트 기반 프로토콜 라우팅 — 매 프롬프트 훅 지시문이 에이전트로 하여금 쌓인 컨텍스트가 드러내는 결핍에 맞는 코어 프로토콜 하나를 호출하게 함 |
 
 **세 가지 발견 모드 공존** (서로 대체하지 않음):
 
@@ -97,9 +97,9 @@ Codex marketplace는 Claude Code와 같은 플러그인 경계를 유지합니�
 - `/onboard` — 패턴 기반 추천 + 선택적 trial (세션 히스토리 기반; 자신의 패턴에 맞는 프로토콜을 학습하고 싶을 때)
 - `/probe` — AI 가설 기반 결핍 인식 (어떤 결핍이 맞는지 아직 명명하지 못할 때 multi-hypothesis fit review)
 
-**컨텍스트 기반 라우팅** (실험적; 별도 opt-in 플러그인):
+**컨텍스트 기반 라우팅** (별도 플러그인):
 
-- `/route` — 플러그인의 `UserPromptSubmit` 훅이 매 프롬프트 옆에 짧은 지시문을 놓고, 쌓인 컨텍스트가 로드된 코어 프로토콜 정확히 하나가 해소하는 결핍을 보이면 에이전트가 그 프로토콜을 호출(첫 게이트는 그 프로토콜 자신이 쥠), 여럿이 맞으면 넛지, 없으면 침묵. `/probe`의 대체 후보; 기본 설치 세트에는 포함되지 않음
+- `/route` — 플러그인의 `UserPromptSubmit` 훅이 매 프롬프트 옆에 짧은 지시문을 놓고, 쌓인 컨텍스트가 로드된 코어 프로토콜 정확히 하나가 해소하는 결핍을 보이면 에이전트가 그 프로토콜을 호출(첫 게이트는 그 프로토콜 자신이 쥠), 여럿이 맞으면 넛지, 없으면 침묵
 
 **소급적 감사** (위 발견 트리오와 별도 카테고리):
 

--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — /recollect (ἀνάμνησις: a recollecting)",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anamnesis",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Resolve vague recall into recognized context — /recollect (ἀνάμνησις: a recollecting)",
   "author": {
     "name": "Jongwon Choi",

--- a/anamnesis/scripts/hypomnesis-write.mjs
+++ b/anamnesis/scripts/hypomnesis-write.mjs
@@ -94,6 +94,7 @@ const protocolMap = {
   "/grasp": ["grasp", "katalepsis"], "/apportion": ["apportion", "merismos"],
   "/induce": ["induce", "periagoge"], "/preview": ["preview", "proplasma"],
   "/frame": ["frame", "prothesis"], "/gap": ["gap", "syneidesis"],
+  "/route": ["route", "route"],
   "/clarify": ["clarify", null], "/goal": ["goal", null],
   "/reflect": ["reflect", null], "/write": ["write", null],
   "/verify": ["verify", null],

--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
-  "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
-  "version": "0.1.0",
+  "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
+  "version": "0.1.1",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "route",
+  "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
+  "version": "0.1.0",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  }
+}

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "route",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
   "author": {
     "name": "Jongwon Choi",

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
-  "version": "0.1.0",
-  "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
+  "version": "0.1.1",
+  "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
@@ -17,8 +17,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Route",
-    "shortDescription": "Experimental — route accumulated context to the matching core protocol — /route",
-    "longDescription": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
+    "shortDescription": "Route accumulated context to the matching core protocol — /route",
+    "longDescription": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
     "developerName": "Jongwon Choi",
     "category": "Productivity",
     "capabilities": [

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "route",
+  "version": "0.1.0",
+  "description": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
+  "author": {
+    "name": "Jongwon Choi",
+    "url": "https://github.com/jongwony"
+  },
+  "homepage": "https://github.com/jongwony/epistemic-protocols",
+  "repository": "https://github.com/jongwony/epistemic-protocols",
+  "license": "MIT",
+  "keywords": [
+    "epistemic-protocols",
+    "skills",
+    "route"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Route",
+    "shortDescription": "Experimental — route accumulated context to the matching core protocol — /route",
+    "longDescription": "Experimental — route the accumulated session context to the core protocol whose deficit it shows: /route (a per-prompt hook directive triggers it; install is opt-in)",
+    "developerName": "Jongwon Choi",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read"
+    ],
+    "websiteURL": "https://github.com/jongwony/epistemic-protocols",
+    "defaultPrompt": [
+      "Use route to invoke the epistemic protocol this context calls for"
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "route",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
   "author": {
     "name": "Jongwon Choi",

--- a/route/README.md
+++ b/route/README.md
@@ -1,0 +1,74 @@
+# Route — /route (experimental)
+
+Route the accumulated session context to the core epistemic protocol whose deficit it shows, and invoke it.
+
+> [한국어](./README_ko.md)
+
+**Status: experimental.** This plugin is opt-in — it is not part of the default install set — and its contract may change or be retired. It is the candidate replacement for `/probe`: if routing from context alone holds up in use, `/probe` is the skill it retires.
+
+## What is Route?
+
+The agent on the loop already holds every loaded epistemic protocol's description, and each description names the interaction deficit that protocol resolves. What is missing is the moment: a passive description does not make the agent stop and check whether the context has drifted into one of those deficits.
+
+Route supplies the moment. Its `UserPromptSubmit` hook places a short directive beside each prompt — *if the accumulated context now shows an interaction deficit that one loaded protocol resolves, invoke `/route`; stay silent otherwise; skip while a protocol is active.* The `/route` skill then reads the loaded descriptions against the context and, when exactly one protocol's deficit is what the context shows, invokes that protocol. The invoked protocol's own opening detection and first gate remain where the user's judgment lives; Route adds no gate of its own.
+
+| Outcome | When |
+|---------|------|
+| Invoke the protocol | One loaded protocol is the dominant match |
+| One nudge line per protocol (`↗ /command — reason`) | Several fit, or the one match is weak |
+| Silence | Nothing fits — the common case |
+
+### Difference from the other routing surfaces
+
+| Surface | When it acts | What it does |
+|---------|--------------|--------------|
+| `/catalog` session-start routing map | Session start | Injects a static deficit → protocol directive once |
+| `/probe` | User invokes, or AI offers on deficit-ambiguity | Two or more hypotheses; the user's recognition constitutes the route |
+| `/route` | Every prompt via the hook, or on `/route` | Invokes the one dominant protocol, nudges when several fit, stays silent when none |
+
+## What the hook injects
+
+`hooks/hooks.json` registers one `UserPromptSubmit` command hook, `scripts/route-prompt.mjs`. On every prompt it writes the directive above as `hookSpecificOutput.additionalContext` — the hook wire shape both Claude Code and Codex accept for this event — and exits 0. The hook payload on stdin is read but not required; an empty or malformed payload still yields the directive. No file is written, no network is touched, and no session content leaves the process.
+
+### Codex
+
+Codex reads the same `hooks/hooks.json` and supports the `UserPromptSubmit` event with the same `additionalContext` output field. The residual: this was verified against the Codex source, not exercised in a live Codex session during this plugin's first cut. Codex also skips a plugin-bundled hook until its current definition is trusted (see Install).
+
+## Install
+
+Claude Code:
+
+```
+claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
+claude plugin install route@epistemic-protocols
+```
+
+Codex:
+
+```
+codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
+codex plugin add route@epistemic-protocols
+```
+
+Then review and trust the plugin's hooks — installing a plugin does not trust
+them, and Codex skips a plugin-bundled hook until its current definition is
+trusted, so the per-prompt directive stays off until this step is done:
+
+```
+/hooks
+```
+
+Codex records trust against the hook definition's hash, so this recurs whenever
+the plugin's hooks change.
+
+## Usage
+
+The hook does the work; nothing needs to be typed. To run the same pass by hand over the context as it stands:
+
+```
+/route
+```
+
+## Author
+
+Jongwon Choi (https://github.com/jongwony)

--- a/route/README.md
+++ b/route/README.md
@@ -8,7 +8,7 @@ Route the accumulated session context to the core epistemic protocol whose defic
 
 The agent on the loop already holds every loaded epistemic protocol's description, and each description names the interaction deficit that protocol resolves. What is missing is the moment: a passive description does not make the agent stop and check whether the context has drifted into one of those deficits.
 
-Route supplies the moment. Its `UserPromptSubmit` hook places a short directive beside each prompt — *if the accumulated context now shows an interaction deficit that one loaded protocol resolves, invoke `/route`; stay silent otherwise; skip while a protocol is active.* The `/route` skill then reads the loaded descriptions against the context and, when exactly one protocol's deficit is what the context shows, invokes that protocol. The invoked protocol's own opening detection and first gate remain where the user's judgment lives; Route adds no gate of its own.
+Route supplies the moment, split in two: **the hook decides when, the skill decides what.** The `UserPromptSubmit` hook places a short directive beside each prompt carrying the firing conditions. The `/route` skill, once invoked, reads the loaded core protocol descriptions against the accumulated context and, when exactly one protocol's deficit is what the context shows, invokes that protocol. The invoked protocol's own opening detection and first gate remain where the user's judgment lives; Route adds no gate of its own.
 
 | Outcome | When |
 |---------|------|
@@ -18,7 +18,7 @@ Route supplies the moment. Its `UserPromptSubmit` hook places a short directive 
 
 ## What the hook injects
 
-`hooks/hooks.json` registers one `UserPromptSubmit` command hook, `scripts/route-prompt.mjs`. On every prompt it writes the directive above as `hookSpecificOutput.additionalContext` — the hook wire shape both Claude Code and Codex accept for this event — and exits 0. The hook payload on stdin is read but not required; an empty or malformed payload still yields the directive. No file is written, no network is touched, and no session content leaves the process.
+`hooks/hooks.json` registers one `UserPromptSubmit` command hook, `scripts/route-prompt.mjs`. On every prompt it writes the firing conditions (the directive text lives in that script) as `hookSpecificOutput.additionalContext` — the hook wire shape both Claude Code and Codex accept for this event — and exits 0. The hook payload on stdin is read but not required; an empty or malformed payload still yields the directive. No file is written, no network is touched, and no session content leaves the process.
 
 Codex reads the same `hooks/hooks.json` and supports the `UserPromptSubmit` event with the same `additionalContext` output field. Codex skips a plugin-bundled hook until its current definition is trusted (see Install).
 

--- a/route/README.md
+++ b/route/README.md
@@ -1,10 +1,8 @@
-# Route — /route (experimental)
+# Route — /route
 
 Route the accumulated session context to the core epistemic protocol whose deficit it shows, and invoke it.
 
 > [한국어](./README_ko.md)
-
-**Status: experimental.** This plugin is opt-in — it is not part of the default install set — and its contract may change or be retired. It is the candidate replacement for `/probe`: if routing from context alone holds up in use, `/probe` is the skill it retires.
 
 ## What is Route?
 
@@ -18,21 +16,11 @@ Route supplies the moment. Its `UserPromptSubmit` hook places a short directive 
 | One nudge line per protocol (`↗ /command — reason`) | Several fit, or the one match is weak |
 | Silence | Nothing fits — the common case |
 
-### Difference from the other routing surfaces
-
-| Surface | When it acts | What it does |
-|---------|--------------|--------------|
-| `/catalog` session-start routing map | Session start | Injects a static deficit → protocol directive once |
-| `/probe` | User invokes, or AI offers on deficit-ambiguity | Two or more hypotheses; the user's recognition constitutes the route |
-| `/route` | Every prompt via the hook, or on `/route` | Invokes the one dominant protocol, nudges when several fit, stays silent when none |
-
 ## What the hook injects
 
 `hooks/hooks.json` registers one `UserPromptSubmit` command hook, `scripts/route-prompt.mjs`. On every prompt it writes the directive above as `hookSpecificOutput.additionalContext` — the hook wire shape both Claude Code and Codex accept for this event — and exits 0. The hook payload on stdin is read but not required; an empty or malformed payload still yields the directive. No file is written, no network is touched, and no session content leaves the process.
 
-### Codex
-
-Codex reads the same `hooks/hooks.json` and supports the `UserPromptSubmit` event with the same `additionalContext` output field. The residual: this was verified against the Codex source, not exercised in a live Codex session during this plugin's first cut. Codex also skips a plugin-bundled hook until its current definition is trusted (see Install).
+Codex reads the same `hooks/hooks.json` and supports the `UserPromptSubmit` event with the same `additionalContext` output field. Codex skips a plugin-bundled hook until its current definition is trusted (see Install).
 
 ## Install
 

--- a/route/README_ko.md
+++ b/route/README_ko.md
@@ -8,7 +8,7 @@
 
 루프 위의 에이전트는 이미 로드된 모든 epistemic 프로토콜의 description을 들고 있고, 각 description은 그 프로토콜이 해소하는 상호작용 결핍을 명명합니다. 빠져 있는 것은 계기입니다 — 수동적인 description은 에이전트가 멈춰서 컨텍스트가 그 결핍 중 하나로 흘러갔는지 확인하게 만들지 못합니다.
 
-Route가 그 계기를 공급합니다. `UserPromptSubmit` 훅이 매 프롬프트 옆에 짧은 지시문을 놓습니다 — *쌓인 컨텍스트가 로드된 프로토콜 하나가 해소하는 상호작용 결핍을 보이면 `/route`를 호출하라; 아니면 침묵하라; 프로토콜이 이미 활성 상태면 건너뛰라.* 그러면 `/route` 스킬이 로드된 description을 컨텍스트에 대조하고, 정확히 하나의 프로토콜 결핍이 컨텍스트가 보여주는 것일 때 그 프로토콜을 호출합니다. 호출된 프로토콜 자신의 Phase 0 감지와 첫 게이트가 사용자 판단의 자리로 남고, Route는 자기 게이트를 추가하지 않습니다.
+Route가 그 계기를 둘로 나눠 공급합니다: **언제는 훅이 정하고, 무엇은 스킬이 정합니다.** `UserPromptSubmit` 훅이 매 프롬프트 옆에 발동 조건을 담은 짧은 지시문을 놓습니다. `/route` 스킬은 호출되고 나면 로드된 코어 프로토콜 description을 쌓인 컨텍스트에 대조하고, 정확히 하나의 프로토콜 결핍이 컨텍스트가 보여주는 것일 때 그 프로토콜을 호출합니다. 호출된 프로토콜 자신의 Phase 0 감지와 첫 게이트가 사용자 판단의 자리로 남고, Route는 자기 게이트를 추가하지 않습니다.
 
 | 결과 | 조건 |
 |------|------|
@@ -18,7 +18,7 @@ Route가 그 계기를 공급합니다. `UserPromptSubmit` 훅이 매 프롬프�
 
 ## 훅이 주입하는 것
 
-`hooks/hooks.json`은 `UserPromptSubmit` command 훅 하나, `scripts/route-prompt.mjs`를 등록합니다. 매 프롬프트마다 위 지시문을 `hookSpecificOutput.additionalContext`로 씁니다 — Claude Code와 Codex가 이 이벤트에 공통으로 받는 훅 wire 형태 — 그리고 0으로 종료합니다. stdin의 훅 payload는 읽지만 필수가 아닙니다; 비어 있거나 잘못된 payload여도 지시문은 나옵니다. 파일을 쓰지 않고, 네트워크를 건드리지 않으며, 세션 내용이 프로세스 밖으로 나가지 않습니다.
+`hooks/hooks.json`은 `UserPromptSubmit` command 훅 하나, `scripts/route-prompt.mjs`를 등록합니다. 매 프롬프트마다 발동 조건(지시문 본문은 그 스크립트에 있습니다)을 `hookSpecificOutput.additionalContext`로 씁니다 — Claude Code와 Codex가 이 이벤트에 공통으로 받는 훅 wire 형태 — 그리고 0으로 종료합니다. stdin의 훅 payload는 읽지만 필수가 아닙니다; 비어 있거나 잘못된 payload여도 지시문은 나옵니다. 파일을 쓰지 않고, 네트워크를 건드리지 않으며, 세션 내용이 프로세스 밖으로 나가지 않습니다.
 
 Codex는 같은 `hooks/hooks.json`을 읽고, `UserPromptSubmit` 이벤트와 같은 `additionalContext` 출력 필드를 지원합니다. Codex는 플러그인 동봉 훅을 현재 정의가 신뢰될 때까지 건너뜁니다 (설치 참조).
 

--- a/route/README_ko.md
+++ b/route/README_ko.md
@@ -1,0 +1,71 @@
+# Route — /route (실험적)
+
+쌓인 세션 컨텍스트가 드러내는 결핍에 맞는 코어 epistemic 프로토콜로 라우팅하고, 그 프로토콜을 호출합니다.
+
+> [English](./README.md)
+
+**상태: 실험적.** 이 플러그인은 opt-in입니다 — 기본 설치 세트에 포함되지 않으며, 계약이 바뀌거나 폐기될 수 있습니다. `/probe`의 대체 후보입니다: 컨텍스트만으로 라우팅하는 방식이 실제 사용에서 유지되면, `/probe`가 이 스킬로 대체됩니다.
+
+## Route란?
+
+루프 위의 에이전트는 이미 로드된 모든 epistemic 프로토콜의 description을 들고 있고, 각 description은 그 프로토콜이 해소하는 상호작용 결핍을 명명합니다. 빠져 있는 것은 계기입니다 — 수동적인 description은 에이전트가 멈춰서 컨텍스트가 그 결핍 중 하나로 흘러갔는지 확인하게 만들지 못합니다.
+
+Route가 그 계기를 공급합니다. `UserPromptSubmit` 훅이 매 프롬프트 옆에 짧은 지시문을 놓습니다 — *쌓인 컨텍스트가 로드된 프로토콜 하나가 해소하는 상호작용 결핍을 보이면 `/route`를 호출하라; 아니면 침묵하라; 프로토콜이 이미 활성 상태면 건너뛰라.* 그러면 `/route` 스킬이 로드된 description을 컨텍스트에 대조하고, 정확히 하나의 프로토콜 결핍이 컨텍스트가 보여주는 것일 때 그 프로토콜을 호출합니다. 호출된 프로토콜 자신의 Phase 0 감지와 첫 게이트가 사용자 판단의 자리로 남고, Route는 자기 게이트를 추가하지 않습니다.
+
+| 결과 | 조건 |
+|------|------|
+| 프로토콜 호출 | 로드된 프로토콜 하나가 지배적으로 맞을 때 |
+| 프로토콜별 넛지 한 줄 (`↗ /command — reason`) | 여럿이 맞거나, 하나뿐인 매치가 약할 때 |
+| 침묵 | 아무것도 맞지 않을 때 — 가장 흔한 경우 |
+
+### 다른 라우팅 표면과의 차이
+
+| 표면 | 발동 시점 | 하는 일 |
+|------|-----------|---------|
+| `/catalog` 세션 시작 routing map | 세션 시작 | 정적 결핍 → 프로토콜 지시문을 한 번 주입 |
+| `/probe` | 사용자 호출, 또는 결핍 모호성 감지 시 AI 제안 | 가설 둘 이상 제시; 사용자 인식이 라우팅을 구성 |
+| `/route` | 훅으로 매 프롬프트, 또는 `/route` | 지배적 프로토콜 하나를 호출, 여럿이면 넛지, 없으면 침묵 |
+
+## 훅이 주입하는 것
+
+`hooks/hooks.json`은 `UserPromptSubmit` command 훅 하나, `scripts/route-prompt.mjs`를 등록합니다. 매 프롬프트마다 위 지시문을 `hookSpecificOutput.additionalContext`로 씁니다 — Claude Code와 Codex가 이 이벤트에 공통으로 받는 훅 wire 형태 — 그리고 0으로 종료합니다. stdin의 훅 payload는 읽지만 필수가 아닙니다; 비어 있거나 잘못된 payload여도 지시문은 나옵니다. 파일을 쓰지 않고, 네트워크를 건드리지 않으며, 세션 내용이 프로세스 밖으로 나가지 않습니다.
+
+### Codex
+
+Codex는 같은 `hooks/hooks.json`을 읽고, `UserPromptSubmit` 이벤트와 같은 `additionalContext` 출력 필드를 지원합니다. 잔여: 이 첫 cut에서는 Codex 소스에 대조해 확인했고, 실제 Codex 세션에서 실행해 보지는 않았습니다. Codex는 또한 플러그인 동봉 훅을 현재 정의가 신뢰될 때까지 건너뜁니다 (설치 참조).
+
+## 설치
+
+Claude Code:
+
+```
+claude plugin marketplace add https://github.com/jongwony/epistemic-protocols
+claude plugin install route@epistemic-protocols
+```
+
+Codex:
+
+```
+codex plugin marketplace add https://github.com/jongwony/epistemic-protocols.git
+codex plugin add route@epistemic-protocols
+```
+
+그 다음 플러그인의 훅을 검토하고 신뢰하세요 — 플러그인 설치가 훅을 신뢰하는 것은 아니며, Codex는 플러그인 동봉 훅을 현재 정의가 신뢰될 때까지 건너뛰므로, 이 단계 전까지 매 프롬프트 지시문은 꺼져 있습니다:
+
+```
+/hooks
+```
+
+Codex는 훅 정의의 해시에 대해 신뢰를 기록하므로, 플러그인의 훅이 바뀔 때마다 이 단계가 반복됩니다.
+
+## 사용법
+
+훅이 일을 하므로 입력할 것은 없습니다. 현재 컨텍스트에 대해 같은 패스를 수동으로 돌리려면:
+
+```
+/route
+```
+
+## 저자
+
+Jongwon Choi (https://github.com/jongwony)

--- a/route/README_ko.md
+++ b/route/README_ko.md
@@ -1,10 +1,8 @@
-# Route — /route (실험적)
+# Route — /route
 
 쌓인 세션 컨텍스트가 드러내는 결핍에 맞는 코어 epistemic 프로토콜로 라우팅하고, 그 프로토콜을 호출합니다.
 
 > [English](./README.md)
-
-**상태: 실험적.** 이 플러그인은 opt-in입니다 — 기본 설치 세트에 포함되지 않으며, 계약이 바뀌거나 폐기될 수 있습니다. `/probe`의 대체 후보입니다: 컨텍스트만으로 라우팅하는 방식이 실제 사용에서 유지되면, `/probe`가 이 스킬로 대체됩니다.
 
 ## Route란?
 
@@ -18,21 +16,11 @@ Route가 그 계기를 공급합니다. `UserPromptSubmit` 훅이 매 프롬프�
 | 프로토콜별 넛지 한 줄 (`↗ /command — reason`) | 여럿이 맞거나, 하나뿐인 매치가 약할 때 |
 | 침묵 | 아무것도 맞지 않을 때 — 가장 흔한 경우 |
 
-### 다른 라우팅 표면과의 차이
-
-| 표면 | 발동 시점 | 하는 일 |
-|------|-----------|---------|
-| `/catalog` 세션 시작 routing map | 세션 시작 | 정적 결핍 → 프로토콜 지시문을 한 번 주입 |
-| `/probe` | 사용자 호출, 또는 결핍 모호성 감지 시 AI 제안 | 가설 둘 이상 제시; 사용자 인식이 라우팅을 구성 |
-| `/route` | 훅으로 매 프롬프트, 또는 `/route` | 지배적 프로토콜 하나를 호출, 여럿이면 넛지, 없으면 침묵 |
-
 ## 훅이 주입하는 것
 
 `hooks/hooks.json`은 `UserPromptSubmit` command 훅 하나, `scripts/route-prompt.mjs`를 등록합니다. 매 프롬프트마다 위 지시문을 `hookSpecificOutput.additionalContext`로 씁니다 — Claude Code와 Codex가 이 이벤트에 공통으로 받는 훅 wire 형태 — 그리고 0으로 종료합니다. stdin의 훅 payload는 읽지만 필수가 아닙니다; 비어 있거나 잘못된 payload여도 지시문은 나옵니다. 파일을 쓰지 않고, 네트워크를 건드리지 않으며, 세션 내용이 프로세스 밖으로 나가지 않습니다.
 
-### Codex
-
-Codex는 같은 `hooks/hooks.json`을 읽고, `UserPromptSubmit` 이벤트와 같은 `additionalContext` 출력 필드를 지원합니다. 잔여: 이 첫 cut에서는 Codex 소스에 대조해 확인했고, 실제 Codex 세션에서 실행해 보지는 않았습니다. Codex는 또한 플러그인 동봉 훅을 현재 정의가 신뢰될 때까지 건너뜁니다 (설치 참조).
+Codex는 같은 `hooks/hooks.json`을 읽고, `UserPromptSubmit` 이벤트와 같은 `additionalContext` 출력 필드를 지원합니다. Codex는 플러그인 동봉 훅을 현재 정의가 신뢰될 때까지 건너뜁니다 (설치 참조).
 
 ## 설치
 

--- a/route/hooks/hooks.json
+++ b/route/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Per-prompt routing directive — tells the agent on the loop to invoke /route when the accumulated context shows a deficit a loaded epistemic protocol resolves.",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/route-prompt.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/route/hooks/hooks.json
+++ b/route/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Per-prompt routing directive — tells the agent on the loop to invoke /route when the accumulated context shows a deficit a loaded epistemic protocol resolves.",
+  "description": "Per-prompt routing directive — carries the firing conditions for /route; the directive text lives in scripts/route-prompt.mjs.",
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/route/scripts/route-prompt.mjs
+++ b/route/scripts/route-prompt.mjs
@@ -4,8 +4,10 @@
  *
  * The agent on the loop already holds every loaded protocol's description,
  * yet a passive description does not trigger invocation. This hook puts one
- * short directive beside each user prompt so the agent checks the accumulated
- * context for a deficit and invokes /route when one protocol resolves it.
+ * short directive beside each user prompt carrying the firing conditions:
+ * invoke /route when the accumulated context shows a deficit a loaded core
+ * protocol resolves, skip while a protocol is active, otherwise stay silent.
+ * The hook decides when; the /route skill decides what.
  *
  * Output shape is the hook wire format both Claude Code and Codex accept for
  * UserPromptSubmit: hookSpecificOutput.additionalContext. The payload on
@@ -18,9 +20,13 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
+// The firing conditions live here and nowhere else: SKILL.md loads only after
+// the skill is invoked, so this directive is the surface present at decision
+// time. It is injected every turn — keep it to a few short lines.
 const DIRECTIVE = [
-  "[route] If the accumulated context now shows an interaction deficit that one loaded epistemic protocol resolves, invoke /route.",
-  "Stay silent otherwise. Skip while an epistemic protocol is already active.",
+  "[route] When the accumulated context shows an interaction deficit that a loaded core epistemic protocol resolves, invoke /route.",
+  "Skip while an epistemic protocol is already active.",
+  "Otherwise stay silent.",
 ].join("\n");
 
 function parsePayload(raw) {

--- a/route/scripts/route-prompt.mjs
+++ b/route/scripts/route-prompt.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * UserPromptSubmit hook — emit the per-prompt routing directive.
+ *
+ * The agent on the loop already holds every loaded protocol's description,
+ * yet a passive description does not trigger invocation. This hook puts one
+ * short directive beside each user prompt so the agent checks the accumulated
+ * context for a deficit and invokes /route when one protocol resolves it.
+ *
+ * Output shape is the hook wire format both Claude Code and Codex accept for
+ * UserPromptSubmit: hookSpecificOutput.additionalContext. The payload on
+ * stdin is read but not required — an empty or malformed payload still
+ * yields the directive, because the directive does not depend on it.
+ *
+ * Zero external dependencies: Node.js standard library only.
+ */
+
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const DIRECTIVE = [
+  "[route] If the accumulated context now shows an interaction deficit that one loaded epistemic protocol resolves, invoke /route.",
+  "Stay silent otherwise. Skip while an epistemic protocol is already active.",
+].join("\n");
+
+function parsePayload(raw) {
+  try {
+    const parsed = JSON.parse(String(raw ?? "").trim());
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function render(raw) {
+  const payload = parsePayload(raw);
+  const eventName = typeof payload.hook_event_name === "string"
+    ? payload.hook_event_name
+    : "UserPromptSubmit";
+  return JSON.stringify({
+    suppressOutput: true,
+    hookSpecificOutput: {
+      hookEventName: eventName,
+      additionalContext: DIRECTIVE,
+    },
+  });
+}
+
+export { DIRECTIVE, parsePayload, render };
+
+let isMain = true;
+try {
+  isMain = !!process.argv[1]
+    && fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
+} catch { isMain = true; }
+
+if (isMain) {
+  let raw = "";
+  try { raw = fs.readFileSync(0, "utf8"); } catch {}
+  process.stdout.write(render(raw) + "\n");
+  process.exit(0);
+}

--- a/route/scripts/route-prompt.test.mjs
+++ b/route/scripts/route-prompt.test.mjs
@@ -1,0 +1,64 @@
+// Tests for route-prompt.mjs — the UserPromptSubmit routing directive.
+// Run with: node --test
+// Repo precedent: anamnesis/scripts/hypomnesis-write.test.mjs (node:test + node:assert).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { DIRECTIVE, parsePayload, render } from "./route-prompt.mjs";
+
+const SCRIPT = path.join(path.dirname(fileURLToPath(import.meta.url)), "route-prompt.mjs");
+
+function runHook(input) {
+  return spawnSync(process.execPath, [SCRIPT], { input, encoding: "utf8" });
+}
+
+test("directive names /route and stays short", () => {
+  assert.ok(DIRECTIVE.includes("/route"));
+  assert.ok(DIRECTIVE.split("\n").length <= 3);
+});
+
+test("parsePayload tolerates empty and malformed stdin", () => {
+  assert.deepEqual(parsePayload(""), {});
+  assert.deepEqual(parsePayload("not json"), {});
+  assert.deepEqual(parsePayload(undefined), {});
+  assert.deepEqual(parsePayload("[1,2]"), [1, 2]);
+});
+
+test("render carries the directive as UserPromptSubmit additionalContext", () => {
+  const out = JSON.parse(render(JSON.stringify({
+    hook_event_name: "UserPromptSubmit",
+    prompt: "hello",
+  })));
+  assert.equal(out.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.equal(out.hookSpecificOutput.additionalContext, DIRECTIVE);
+  assert.equal(out.suppressOutput, true);
+});
+
+test("render on empty stdin still yields the directive", () => {
+  const out = JSON.parse(render(""));
+  assert.equal(out.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.ok(out.hookSpecificOutput.additionalContext.includes("/route"));
+});
+
+test("hook process exits 0 with the directive on empty stdin", () => {
+  const result = runHook("");
+  assert.equal(result.status, 0);
+  const out = JSON.parse(result.stdout);
+  assert.ok(out.hookSpecificOutput.additionalContext.includes("/route"));
+});
+
+test("hook process exits 0 with the directive on a valid payload", () => {
+  const result = runHook(JSON.stringify({
+    session_id: "s",
+    transcript_path: "/tmp/t.jsonl",
+    hook_event_name: "UserPromptSubmit",
+    prompt: "what next?",
+  }));
+  assert.equal(result.status, 0);
+  const out = JSON.parse(result.stdout);
+  assert.equal(out.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.ok(out.hookSpecificOutput.additionalContext.includes("/route"));
+});

--- a/route/scripts/route-prompt.test.mjs
+++ b/route/scripts/route-prompt.test.mjs
@@ -15,8 +15,14 @@ function runHook(input) {
   return spawnSync(process.execPath, [SCRIPT], { input, encoding: "utf8" });
 }
 
-test("directive names /route and stays short", () => {
-  assert.ok(DIRECTIVE.includes("/route"));
+test("directive carries the three firing conditions and stays short", () => {
+  // (a) deficit a loaded core protocol resolves → invoke /route
+  assert.match(DIRECTIVE, /accumulated context shows an interaction deficit/);
+  assert.match(DIRECTIVE, /loaded core epistemic protocol resolves, invoke \/route/);
+  // (b) active-protocol exclusion
+  assert.match(DIRECTIVE, /Skip while an epistemic protocol is already active/);
+  // (c) silence otherwise
+  assert.match(DIRECTIVE, /Otherwise stay silent/);
   assert.ok(DIRECTIVE.split("\n").length <= 3);
 });
 

--- a/route/skills/route/SKILL.md
+++ b/route/skills/route/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: route
-description: "Experimental. Read the loaded protocol descriptions, match the accumulated session context to the one deficit it shows, and invoke that protocol; nudge when several fit, stay silent when none."
+description: "Fires when the accumulated session context shows a deficit a loaded core protocol resolves: reads loaded descriptions, invokes the one dominant match, nudges when several fit, silent when none."
 user_invocable: true
 ---
 
@@ -8,68 +8,41 @@ user_invocable: true
 
 Route the accumulated session context to the core epistemic protocol whose deficit it shows, and invoke that protocol. Type: `(DeficitUnrouted, AI, ROUTE, AccumulatedContext) → ProtocolInvocation`.
 
-This skill is **experimental**. It is the candidate replacement for `/probe`: where `/probe` puts two or more deficit hypotheses to the user and lets recognition constitute the route, `/route` acts only when the context has already collapsed the choice to one protocol, and steps aside otherwise. Whether that collapse can be read reliably enough from context alone is the experiment; if it holds up in use, `/probe` is the skill it retires.
+## What fires it
 
-## Definition
+- **Hook directive** — the plugin's `UserPromptSubmit` hook places one short directive beside each prompt: if the accumulated context now shows an interaction deficit that one loaded epistemic protocol resolves, invoke `/route`; stay silent otherwise; skip while a protocol is active. The agent on the loop reads that directive and calls this skill.
+- **Direct** — `/route` invoked by the user runs the same pass over the context as it stands.
 
-**Route**: a relay act. The agent already holds every loaded epistemic protocol's description — each names the interaction deficit it resolves. Route reads those descriptions against what the session has accumulated, and when exactly one protocol's deficit is what the context shows, hands the turn to that protocol. The invoked protocol's own opening detection and first gate remain where the user's judgment lives; Route adds no gate of its own.
+The trigger is the deficit, not the topic: a turn fires this skill when what the session has accumulated is the situation one loaded protocol's description names.
+
+## How it matches
+
+1. **Read** the loaded epistemic protocol descriptions — the harness's own loaded-skills listing. Each names the interaction deficit that protocol resolves. Route carries no matching table of its own; a protocol not loaded is not a candidate.
+2. **Match** the accumulated session context against each protocol's deficit. The question per protocol is whether the context, as it stands now, is the situation that description names.
+3. **Decide** by the option-set relay test:
+   - one protocol is the analytically dominant match → **invoke** it through the harness's skill invocation and stop. The invoked protocol's own opening detection and first gate hold the user's judgment.
+   - several protocols fit, or the one match is weak → emit one line per fitting protocol, `↗ /command — reason`, and stop.
+   - nothing fits → say nothing.
 
 ```
 ── FLOW ──
 Route(C) → Read(loaded protocol descriptions) → Match(C, deficits) → M →
-  |M| = 1 ∧ dominant:  invoke(protocol(M)) → stop            -- relay: the protocol's own Phase 0 and first gate take over
-  |M| ≥ 2 ∨ weak:      emit(↗ /command — reason) → stop       -- one line per protocol that fits, no gate
+  |M| = 1 ∧ dominant:  invoke(protocol(M)) → stop            -- the protocol's own Phase 0 and first gate take over
+  |M| ≥ 2 ∨ weak:      emit(↗ /command — reason) → stop       -- one line per protocol that fits
   |M| = 0:             silence → stop
-
-── MORPHISM ──
-AccumulatedContext
-  → read(descriptions)        -- the harness's loaded-skills listing; never a file of another plugin
-  → match(deficits)           -- which loaded protocol's deficit the context now shows
-  → decide(relay | nudge | silence)   -- option-set relay test: one dominant match relays; several keep the choice open
-  → invoke(protocol) | nudge | silence
-  → ProtocolInvocation
-requires: ¬protocol_active(session)   -- Route never fires inside a running protocol
-deficit:  DeficitUnrouted             -- the context shows a deficit no protocol has yet been called for
-preserves: C                          -- context is read, never rewritten
 
 ── TYPES ──
 C  = AccumulatedContext   -- the current session as it stands at this prompt
 M  = Set(Protocol)        -- loaded core protocols whose deficit the context shows
 ProtocolInvocation = Invoke(protocol) | Nudge(List(protocol)) | Silence
+requires: ¬protocol_active(session)
+deficit:  DeficitUnrouted   -- the context shows a deficit no protocol has yet been called for
+preserves: C                -- context is read, never rewritten
 ```
-
-## Activation
-
-Two entries, one behavior:
-
-- **Hook directive** — the plugin's `UserPromptSubmit` hook places a short directive beside each prompt: invoke `/route` when the accumulated context shows a deficit a loaded protocol resolves; stay silent otherwise; skip while a protocol is active. The agent on the loop reads that directive and calls this skill.
-- **Direct** — `/route` invoked by the user runs the same read → match → decide pass over the context as it stands.
-
-## Protocol
-
-1. **Read** the loaded epistemic protocol descriptions. Route carries no matching table of its own; the descriptions the harness loaded are the whole catalog, so a protocol not loaded is not a candidate.
-2. **Match** the accumulated session context against each protocol's deficit. The question per protocol is whether the context, as it stands now, is the situation that protocol's description names.
-3. **Decide** by the option-set relay test:
-   - one protocol is the analytically dominant match → **invoke** it through the harness's skill invocation and stop. The invoked protocol's own detection and first gate hold the user's judgment; Route neither confirms nor summarizes ahead of it.
-   - several protocols fit, or the one match is weak → emit one line per fitting protocol, `↗ /command — reason`, and stop. No gate; the user picks by invoking one or moving on.
-   - nothing fits → say nothing.
-
-## Distinction
-
-| Surface | When it acts | What it does |
-|---------|--------------|--------------|
-| `/catalog` session-start routing map | Session start | Injects a static deficit → protocol directive once; the agent routes from it on its own |
-| `/probe` | User invokes, or AI offers on deficit-ambiguity | Presents two or more deficit hypotheses; the user's recognition constitutes the route |
-| `/route` | Every prompt via the hook directive, or on `/route` | Reads loaded descriptions against accumulated context; invokes the one dominant protocol, nudges when several fit, stays silent when none |
-
-The three coexist during the experiment. `/route` is the only one that invokes rather than offers, and the only one triggered per prompt.
 
 ## Rules
 
 1. **Loaded descriptions only** — the harness's loaded-skills listing is the sole catalog. Route reads no routing table, no other plugin's file, and no session store.
 2. **Core protocols only** — Route invokes epistemic protocols that resolve a named interaction deficit. It never routes to itself or to another utility skill.
-3. **Skip inside an active protocol** — when an epistemic protocol is already running, Route does nothing; the running protocol's own nudges cover other deficits.
+3. **Skip inside an active protocol** — when an epistemic protocol is already running, Route does nothing.
 4. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.
-5. **Option-set relay test governs** — a single dominant match is a relay and is invoked; a set with more than one live member keeps the choice with the user, as a nudge. Route never scores or ranks protocols to force a single match.
-6. **Silence is a valid outcome** — when no loaded protocol's deficit fits, Route emits nothing. A turn with no deficit is the common case.
-7. **Experimental** — this skill's contract may change or be retired; it exists to test whether context alone can carry the route `/probe` currently asks the user to constitute.

--- a/route/skills/route/SKILL.md
+++ b/route/skills/route/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: route
 description: "Route the accumulated session context to the loaded core protocol whose deficit it shows — /route. Invokes the one dominant match, nudges when several fit, stays silent when none."
-user_invocable: true
 ---
 
 # Route Skill

--- a/route/skills/route/SKILL.md
+++ b/route/skills/route/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: route
-description: "Fires when the accumulated session context shows a deficit a loaded core protocol resolves: reads loaded descriptions, invokes the one dominant match, nudges when several fit, silent when none."
+description: "Route the accumulated session context to the loaded core protocol whose deficit it shows — /route. Invokes the one dominant match, nudges when several fit, stays silent when none."
 user_invocable: true
 ---
 
@@ -8,16 +8,9 @@ user_invocable: true
 
 Route the accumulated session context to the core epistemic protocol whose deficit it shows, and invoke that protocol. Type: `(DeficitUnrouted, AI, ROUTE, AccumulatedContext) → ProtocolInvocation`.
 
-## What fires it
+## What it does
 
-- **Hook directive** — the plugin's `UserPromptSubmit` hook places one short directive beside each prompt: if the accumulated context now shows an interaction deficit that one loaded epistemic protocol resolves, invoke `/route`; stay silent otherwise; skip while a protocol is active. The agent on the loop reads that directive and calls this skill.
-- **Direct** — `/route` invoked by the user runs the same pass over the context as it stands.
-
-The trigger is the deficit, not the topic: a turn fires this skill when what the session has accumulated is the situation one loaded protocol's description names.
-
-## How it matches
-
-1. **Read** the loaded epistemic protocol descriptions — the harness's own loaded-skills listing. Each names the interaction deficit that protocol resolves. Route carries no matching table of its own; a protocol not loaded is not a candidate.
+1. **Read** the loaded core epistemic protocol descriptions — the harness's own loaded-skills listing. Each names the interaction deficit that protocol resolves. Route carries no matching table of its own; a protocol not loaded is not a candidate.
 2. **Match** the accumulated session context against each protocol's deficit. The question per protocol is whether the context, as it stands now, is the situation that description names.
 3. **Decide** by the option-set relay test:
    - one protocol is the analytically dominant match → **invoke** it through the harness's skill invocation and stop. The invoked protocol's own opening detection and first gate hold the user's judgment.
@@ -35,7 +28,6 @@ Route(C) → Read(loaded protocol descriptions) → Match(C, deficits) → M →
 C  = AccumulatedContext   -- the current session as it stands at this prompt
 M  = Set(Protocol)        -- loaded core protocols whose deficit the context shows
 ProtocolInvocation = Invoke(protocol) | Nudge(List(protocol)) | Silence
-requires: ¬protocol_active(session)
 deficit:  DeficitUnrouted   -- the context shows a deficit no protocol has yet been called for
 preserves: C                -- context is read, never rewritten
 ```
@@ -44,5 +36,4 @@ preserves: C                -- context is read, never rewritten
 
 1. **Loaded descriptions only** — the harness's loaded-skills listing is the sole catalog. Route reads no routing table, no other plugin's file, and no session store.
 2. **Core protocols only** — Route invokes epistemic protocols that resolve a named interaction deficit. It never routes to itself or to another utility skill.
-3. **Skip inside an active protocol** — when an epistemic protocol is already running, Route does nothing.
-4. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.
+3. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.

--- a/route/skills/route/SKILL.md
+++ b/route/skills/route/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: route
+description: "Experimental. Read the loaded protocol descriptions, match the accumulated session context to the one deficit it shows, and invoke that protocol; nudge when several fit, stay silent when none."
+user_invocable: true
+---
+
+# Route Skill
+
+Route the accumulated session context to the core epistemic protocol whose deficit it shows, and invoke that protocol. Type: `(DeficitUnrouted, AI, ROUTE, AccumulatedContext) → ProtocolInvocation`.
+
+This skill is **experimental**. It is the candidate replacement for `/probe`: where `/probe` puts two or more deficit hypotheses to the user and lets recognition constitute the route, `/route` acts only when the context has already collapsed the choice to one protocol, and steps aside otherwise. Whether that collapse can be read reliably enough from context alone is the experiment; if it holds up in use, `/probe` is the skill it retires.
+
+## Definition
+
+**Route**: a relay act. The agent already holds every loaded epistemic protocol's description — each names the interaction deficit it resolves. Route reads those descriptions against what the session has accumulated, and when exactly one protocol's deficit is what the context shows, hands the turn to that protocol. The invoked protocol's own opening detection and first gate remain where the user's judgment lives; Route adds no gate of its own.
+
+```
+── FLOW ──
+Route(C) → Read(loaded protocol descriptions) → Match(C, deficits) → M →
+  |M| = 1 ∧ dominant:  invoke(protocol(M)) → stop            -- relay: the protocol's own Phase 0 and first gate take over
+  |M| ≥ 2 ∨ weak:      emit(↗ /command — reason) → stop       -- one line per protocol that fits, no gate
+  |M| = 0:             silence → stop
+
+── MORPHISM ──
+AccumulatedContext
+  → read(descriptions)        -- the harness's loaded-skills listing; never a file of another plugin
+  → match(deficits)           -- which loaded protocol's deficit the context now shows
+  → decide(relay | nudge | silence)   -- option-set relay test: one dominant match relays; several keep the choice open
+  → invoke(protocol) | nudge | silence
+  → ProtocolInvocation
+requires: ¬protocol_active(session)   -- Route never fires inside a running protocol
+deficit:  DeficitUnrouted             -- the context shows a deficit no protocol has yet been called for
+preserves: C                          -- context is read, never rewritten
+
+── TYPES ──
+C  = AccumulatedContext   -- the current session as it stands at this prompt
+M  = Set(Protocol)        -- loaded core protocols whose deficit the context shows
+ProtocolInvocation = Invoke(protocol) | Nudge(List(protocol)) | Silence
+```
+
+## Activation
+
+Two entries, one behavior:
+
+- **Hook directive** — the plugin's `UserPromptSubmit` hook places a short directive beside each prompt: invoke `/route` when the accumulated context shows a deficit a loaded protocol resolves; stay silent otherwise; skip while a protocol is active. The agent on the loop reads that directive and calls this skill.
+- **Direct** — `/route` invoked by the user runs the same read → match → decide pass over the context as it stands.
+
+## Protocol
+
+1. **Read** the loaded epistemic protocol descriptions. Route carries no matching table of its own; the descriptions the harness loaded are the whole catalog, so a protocol not loaded is not a candidate.
+2. **Match** the accumulated session context against each protocol's deficit. The question per protocol is whether the context, as it stands now, is the situation that protocol's description names.
+3. **Decide** by the option-set relay test:
+   - one protocol is the analytically dominant match → **invoke** it through the harness's skill invocation and stop. The invoked protocol's own detection and first gate hold the user's judgment; Route neither confirms nor summarizes ahead of it.
+   - several protocols fit, or the one match is weak → emit one line per fitting protocol, `↗ /command — reason`, and stop. No gate; the user picks by invoking one or moving on.
+   - nothing fits → say nothing.
+
+## Distinction
+
+| Surface | When it acts | What it does |
+|---------|--------------|--------------|
+| `/catalog` session-start routing map | Session start | Injects a static deficit → protocol directive once; the agent routes from it on its own |
+| `/probe` | User invokes, or AI offers on deficit-ambiguity | Presents two or more deficit hypotheses; the user's recognition constitutes the route |
+| `/route` | Every prompt via the hook directive, or on `/route` | Reads loaded descriptions against accumulated context; invokes the one dominant protocol, nudges when several fit, stays silent when none |
+
+The three coexist during the experiment. `/route` is the only one that invokes rather than offers, and the only one triggered per prompt.
+
+## Rules
+
+1. **Loaded descriptions only** — the harness's loaded-skills listing is the sole catalog. Route reads no routing table, no other plugin's file, and no session store.
+2. **Core protocols only** — Route invokes epistemic protocols that resolve a named interaction deficit. It never routes to itself or to another utility skill.
+3. **Skip inside an active protocol** — when an epistemic protocol is already running, Route does nothing; the running protocol's own nudges cover other deficits.
+4. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.
+5. **Option-set relay test governs** — a single dominant match is a relay and is invoked; a set with more than one live member keeps the choice with the user, as a nudge. Route never scores or ranks protocols to force a single match.
+6. **Silence is a valid outcome** — when no loaded protocol's deficit fits, Route emits nothing. A turn with no deficit is the common case.
+7. **Experimental** — this skill's contract may change or be retired; it exists to test whether context alone can carry the route `/probe` currently asks the user to constitute.

--- a/route/skills/route/agents/openai.yaml
+++ b/route/skills/route/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Route"
-  short_description: "Route accumulated context to the matching epistemic protocol (experimental)"
+  short_description: "Route accumulated context to the matching epistemic protocol"
   default_prompt: "Use $route to invoke the epistemic protocol this context calls for."

--- a/route/skills/route/agents/openai.yaml
+++ b/route/skills/route/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Route"
+  short_description: "Route accumulated context to the matching epistemic protocol (experimental)"
+  default_prompt: "Use $route to invoke the epistemic protocol this context calls for."

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -1337,6 +1337,7 @@ describe('package.js CLI', () => {
         'reduced-space-test.zip',
         'report.zip',
         'review-loop.zip',
+        'route.zip',
         'sophia.zip',
         'steer.zip',
         'sublate.zip',
@@ -1393,7 +1394,7 @@ describe('plugin directory registration', () => {
   // the removal direction (a registered name whose directory is gone) and is
   // blind to the addition direction. This guard reads the filesystem inventory
   // instead of the registry, so neither direction can hide behind the filter.
-  const KNOWN_UTILITY_DIRS = ['epistemic-cooperative'];
+  const KNOWN_UTILITY_DIRS = ['epistemic-cooperative', 'route'];
 
   it('every plugin directory on disk is registered as a protocol or a utility', () => {
     const dirs = [...new Set(


### PR DESCRIPTION
## 요약

쌓인 세션 컨텍스트를 코어 프로토콜의 결핍 타입으로 라우팅하는 독립 플러그인 **`route/`**를 추가합니다. `anamnesis`와 같은 모양이며, 두 층으로 나뉩니다 — **언제는 훅이 정하고, 무엇은 스킬이 정합니다.** `UserPromptSubmit` 훅(`scripts/route-prompt.mjs`)이 매 프롬프트 옆에 발동 조건을 담은 짧은 지시문을 `hookSpecificOutput.additionalContext`로 놓고, `/route` 스킬은 호출되고 나면 로드된 코어 프로토콜 description을 컨텍스트에 대조해 지배적 매치가 하나면 그 프로토콜을 호출하고(첫 게이트는 호출된 프로토콜 자신이 쥡니다), 여럿이 맞거나 약하면 `↗ /command — reason` 넛지 한 줄씩, 없으면 침묵합니다. 타입: `(DeficitUnrouted, AI, ROUTE, AccumulatedContext) → ProtocolInvocation`.

## 훅 지시문 (매 턴 주입되는 전문)

```
[route] When the accumulated context shows an interaction deficit that a loaded core epistemic protocol resolves, invoke /route.
Skip while an epistemic protocol is already active.
Otherwise stay silent.
```

SKILL.md 본문은 스킬이 호출된 뒤에야 로드되므로, "언제 부르는가"는 결정 시점에 있는 유일한 표면인 이 지시문에만 둡니다. `route-prompt.test.mjs`가 세 조건이 지시문에 있음을 단언합니다.

## SKILL.md의 범위

호출 뒤 하는 일만 담습니다: 로드된 코어 프로토콜 description 읽기, 쌓인 컨텍스트를 각 결핍에 대조, 옵션 집합 relay 테스트로 세 갈래(호출 / 넛지 / 침묵) 결정, 그리고 세 규칙(로드된 description만, 코어 프로토콜만, 자기 게이트 없음). frontmatter description은 `/route`를 이름하는 짧은 라우팅 cue입니다.

## 설계 결정

- **독립 플러그인**: 훅을 `epistemic-cooperative`에 넣으면 유틸리티를 쓰는 모두에게 매 턴 주입이 강제되므로 별개 플러그인으로 둡니다. `scripts/install.sh` / `install-codex.sh`의 기본 설치 세트에는 넣지 않았고, marketplace 두 매니페스트에 등록되어 `claude plugin install route@epistemic-protocols`로 설치합니다.
- **자기완결**: `/route`는 `/catalog`의 SessionStart `routing-map.md`를 읽지 않습니다. 다른 플러그인 파일을 런타임에 읽으면 self-containment가 깨지므로, 하네스가 로드한 스킬 description 목록을 유일한 카탈로그로 씁니다.
- **지위 기록 위치**: 이 플러그인의 실험적 지위와 `/probe`와의 관계는 사용자 대면 표면에 두지 않고 커밋 메시지(원장)에만 기록합니다.

## Codex 실현과 잔여

- `hooks/hooks.json`은 Claude Code와 Codex가 공유합니다. Codex 소스(`codex-rs/hooks/src/events/user_prompt_submit.rs`, `schema/generated/user-prompt-submit.command.output.schema.json`)에서 `UserPromptSubmit` 이벤트와 `hookSpecificOutput.additionalContext` 출력 필드를 지원함을 확인했고, 출력 형식을 그 wire shape에 맞췄습니다. `agents/openai.yaml`로 Codex 스킬 discovery 메타데이터도 둡니다.
- **잔여 1**: 실제 Codex 세션에서 훅을 실행해 보지는 않았습니다(소스 대조까지). 플러그인 동봉 훅은 `/hooks`로 신뢰해야 켜지며, README에 절차를 적었습니다.
- **잔여 2**: Codex 소스는 로컬 클론(`~/github/oss/codex`)을 읽었고, 이 세션의 sandbox가 worktree 밖 `git pull`을 막아 최신으로 갱신하지 못했습니다.

## 함께 움직인 것

- `anamnesis/scripts/hypomnesis-write.mjs` `protocolMap`에 `/route` 추가 — `hypomnesis-write.test.mjs`가 디스크의 모든 플러그인 스킬 명령을 map이 덮기를 요구합니다. 양쪽 매니페스트 1.0.2 → 1.0.3 (별도 커밋).
- `scripts/package.test.js`: `KNOWN_UTILITY_DIRS`에 `route`, release-ZIP 목록에 `route.zip`.
- 루트 `README.md` / `README_ko.md` 유틸리티 표와 "컨텍스트 기반 라우팅" 항목, `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`.
- route 매니페스트 0.1.0 → 0.1.1 → 0.1.2 (표면 정리, 발동 조건 이동 커밋).

## 검증

```
node .claude/skills/verify/scripts/static-checks.js .
# FAIL 0 / WARN 0 / PASS 137

node --test scripts/package.test.js anamnesis/scripts/hypomnesis-write.test.mjs \
  anamnesis/scripts/hypomnesis-codex-write.test.mjs \
  .claude/skills/realize/scripts/harness.test.mjs route/scripts/route-prompt.test.mjs
# tests 130 / pass 130 / fail 0

node scripts/package.js --dry-run
# results 40 (route.zip 포함, version 0.1.2, files 2, 1504 bytes)

node scripts/generate-routing-map.js --check
# routing-map.md is in sync with canonical sources
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjcp4x6z8DbvDfairXUBMQ
