### PR TITLE
fix(route): 지배적 매치를 판정하고 멈추던 자리를 실제 호출까지 잇는다

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,16 @@ The two layers serve different audiences: the README carries the narrow public c
 
 ### Claude Code
 
-Install all protocols and utilities:
+Install every protocol plus the `epistemic-cooperative` utility plugin:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jongwony/epistemic-protocols/main/scripts/install.sh | bash
+```
+
+`route` is opt-in — it carries a per-prompt hook, so the one-liner leaves it out. Add it on its own:
+
+```bash
+claude plugin install route@epistemic-protocols
 ```
 
 Then run `/onboard` — start with a quick recommendation based on your recent sessions, then optionally continue to guided learning with scenarios, trials, and quizzes.

--- a/README_ko.md
+++ b/README_ko.md
@@ -22,10 +22,16 @@ AI 협업이 방향을 잘못 잡으면, 전부 다시 합니다. 이 프로토�
 
 ### Claude Code
 
-모든 프로토콜과 유틸리티를 설치합니다:
+모든 프로토콜과 `epistemic-cooperative` 유틸리티 플러그인을 설치합니다:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/jongwony/epistemic-protocols/main/scripts/install.sh | bash
+```
+
+`route`는 opt-in입니다 — 매 프롬프트 훅을 동봉하므로 위 한 줄은 이 플러그인을 건너뜁니다. 따로 추가하세요:
+
+```bash
+claude plugin install route@epistemic-protocols
 ```
 
 `/onboard`를 실행하세요 — 최근 세션 기반으로 빠른 추천을 받고, 원하면 시나리오, 실행, 퀴즈를 통한 가이드 학습으로 이어갑니다.

--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "route",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
   "author": {
     "name": "Jongwon Choi",

--- a/route/skills/route/SKILL.md
+++ b/route/skills/route/SKILL.md
@@ -12,27 +12,31 @@ Route the accumulated session context to the core epistemic protocol whose defic
 1. **Read** the loaded core epistemic protocol descriptions — the harness's own loaded-skills listing. Each names the interaction deficit that protocol resolves. Route carries no matching table of its own; a protocol not loaded is not a candidate.
 2. **Match** the accumulated session context against each protocol's deficit. The question per protocol is whether the context, as it stands now, is the situation that description names.
 3. **Decide** by the option-set relay test:
-   - one protocol is the analytically dominant match → **invoke** it through the harness's skill invocation and stop. The invoked protocol's own opening detection and first gate hold the user's judgment.
+   - one protocol is the analytically dominant match → **call the skill-invocation capability** with that protocol's skill identifier, passing a one-sentence deficit-framed statement of the current context as its argument. Issuing that call is what discharges this branch: naming the match belongs to the matching step, and the routing is the call. The invoked protocol's own opening detection and first gate hold the user's judgment.
    - several protocols fit, or the one match is weak → emit one line per fitting protocol, `↗ /command — reason`, and stop.
    - nothing fits → say nothing.
 
 ```
 ── FLOW ──
 Route(C) → Read(loaded protocol descriptions) → Match(C, deficits) → M →
-  |M| = 1 ∧ dominant:  invoke(protocol(M)) → stop            -- the protocol's own Phase 0 and first gate take over
+  |M| = 1 ∧ dominant:  call(skill_invocation, id(protocol(M)), deficit_statement(C)) → stop
   |M| ≥ 2 ∨ weak:      emit(↗ /command — reason) → stop       -- one line per protocol that fits
   |M| = 0:             silence → stop
+-- exactly one branch fires, and its stop ends Route's turn; work on C itself is not a branch
 
 ── TYPES ──
 C  = AccumulatedContext   -- the current session as it stands at this prompt
 M  = Set(Protocol)        -- loaded core protocols whose deficit the context shows
-ProtocolInvocation = Invoke(protocol) | Nudge(List(protocol)) | Silence
+deficit_statement(C) = one sentence naming the deficit the context shows, handed to the invoked protocol
+ProtocolInvocation = Invoke(protocol, deficit_statement) | Nudge(List(protocol)) | Silence
 deficit:  DeficitUnrouted   -- the context shows a deficit no protocol has yet been called for
 preserves: C                -- context is read, never rewritten
+invariant: Routing over Doing
 ```
 
 ## Rules
 
-1. **Loaded descriptions only** — the harness's loaded-skills listing is the sole catalog. Route reads no routing table, no other plugin's file, and no session store.
-2. **Core protocols only** — Route invokes epistemic protocols that resolve a named interaction deficit. It never routes to itself or to another utility skill.
-3. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.
+1. **Routing is the whole turn** — Route ends at exactly one of the three outcomes: the invocation call, the nudge lines, or silence. Reading the descriptions is the matching step, not the deliverable. Where no protocol dominates, the nudge or silence branch is already the complete end. The object-level work the context was asking for belongs to the invoked protocol or to the turn after, never to Route's own; a turn that ends in that work has skipped the routing it was invoked to do.
+2. **Loaded descriptions only** — the harness's loaded-skills listing is the sole catalog. Route reads no routing table, no other plugin's file, and no session store.
+3. **Core protocols only** — Route invokes epistemic protocols that resolve a named interaction deficit. It never routes to itself or to another utility skill.
+4. **No gate of its own** — Route presents no options. The invoked protocol's first gate is where the user judges; a nudge line is a pointer, not a question.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Install all epistemic protocol plugins for Claude Code
+# Install every plugin in the epistemic-protocols marketplace for Claude Code,
+# except the opt-in set named in SKIP_PLUGINS below.
 # Idempotent: safe to re-run when new plugins are added
 #
 # Usage:
@@ -10,6 +11,13 @@ set -eo pipefail
 REPO="jongwony/epistemic-protocols"
 MARKETPLACE="epistemic-protocols"
 MANIFEST_URL="https://raw.githubusercontent.com/$REPO/main/.claude-plugin/marketplace.json"
+
+# Opt-in plugins the default installer leaves out. The plugin list itself is
+# derived from the manifest; this is the one hand-maintained exclusion, guarded
+# by scripts/package.test.js against naming a plugin the manifest no longer has.
+#   route — carries a per-prompt hook; install it deliberately:
+#           claude plugin install route@epistemic-protocols
+SKIP_PLUGINS="route"
 
 command -v claude >/dev/null 2>&1 || { echo "Error: claude CLI not found. Install Claude Code first." >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found." >&2; exit 1; }
@@ -23,8 +31,13 @@ plugins=$(curl -fsSL "$MANIFEST_URL" \
 
 installed=0
 skipped=0
+opted_out=""
 
 for p in $plugins; do
+  if [[ " $SKIP_PLUGINS " == *" $p "* ]]; then
+    opted_out="$opted_out $p"
+    continue
+  fi
   if claude plugin install "$p@$MARKETPLACE" < /dev/null 2>/dev/null; then
     installed=$((installed + 1))
   else
@@ -36,4 +49,7 @@ done
 echo ""
 echo "Installed $installed plugin(s)."
 [[ $skipped -gt 0 ]] && echo "$skipped skipped (already installed or unavailable)."
+for p in $opted_out; do
+  echo "Not installed (opt-in): $p — add it with: claude plugin install $p@$MARKETPLACE"
+done
 echo "Run /onboard to get started."

--- a/scripts/package.test.js
+++ b/scripts/package.test.js
@@ -1417,6 +1417,33 @@ describe('plugin directory registration', () => {
 // agent routing map (generate-routing-map + session-context)
 // ============================================================
 
+describe('default installer skip list', () => {
+  // scripts/install.sh derives its plugin list from the marketplace manifest;
+  // SKIP_PLUGINS is the one hand-maintained exclusion. A name left there after
+  // its plugin leaves the manifest would keep asserting an exclusion of nothing,
+  // so this guard re-runs the claim: every skipped name is a manifest plugin.
+  const installSh = fs.readFileSync(path.resolve(__dirname, 'install.sh'), 'utf8');
+  const manifest = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, '..', '.claude-plugin', 'marketplace.json'), 'utf8')
+  );
+
+  it('every name in SKIP_PLUGINS is a plugin present in the marketplace manifest', () => {
+    const match = installSh.match(/^SKIP_PLUGINS="([^"]*)"$/m);
+    assert.ok(match, 'scripts/install.sh must declare SKIP_PLUGINS="..." on its own line');
+    const skipped = match[1].split(/\s+/).filter(Boolean);
+    const manifestNames = new Set(manifest.plugins.map(p => p.name));
+    for (const name of skipped) {
+      assert.ok(
+        manifestNames.has(name),
+        `SKIP_PLUGINS names "${name}", which is not a plugin in .claude-plugin/marketplace.json — ` +
+        'remove the stale exclusion or restore the plugin'
+      );
+    }
+  });
+});
+
+// ============================================================
+
 describe('agent routing map', () => {
   const REPO_ROOT = path.resolve(__dirname, '..');
   const {


### PR DESCRIPTION
## 무엇을 고치는가

두 가지입니다. `/route`가 지배적 매치를 판정하고도 코어 프로토콜을 실제로 부르지 않고 끝나는 경우를 닫고, 기본 설치기가 `route`를 설치하지 않게 합니다. 둘 다 PR #887로 머지된 플러그인을 실제로 돌려 본 결과입니다.

## 1. 라우팅 사슬 완주

### 관측

스틴트 네 개를 띄워 세 단계를 각각 셌습니다. 브리프에는 `route`·프로토콜·테스트라는 말을 넣지 않았습니다. 그 말이 들어가면 훅이 아니라 브리프가 호출을 일으켰는지 갈라 읽을 수 없기 때문입니다.

| 스틴트 | 요청 성격 | 훅 주입 | `/route` 발화 | 코어 프로토콜 실호출 |
|---|---|---|---|---|
| add-protocol | 좌표 없는 요청 | 1회 | 함 | **`euporia:elicit` 호출됨** (결핍 문장을 인자로 전달) |
| priority | 기준 미정 우선순위 | 1회 | 함 | 없음 |
| install-edit | 즉시 수정·커밋 요구 | 1회 | 안 함 | 해당 없음 |
| count (대조군) | 기계적 조회 | 2회 | 안 함 | 해당 없음 |

- **훅 주입 4/4.** 대조군의 주입이 2회인 것은 세션 간 메시지도 같은 훅 경로를 탄다는 뜻이고, 이번에 처음 확인된 부수 사실입니다.
- **대조군 침묵.** 매 턴 주입되는 지시문이 무해한 요청까지 `/route`로 끌고 가지는 않았습니다.
- **사슬 완주 1/2.** `priority` 세션은 `route:route`를 부르고 프로토콜 description까지 읽은 뒤, 프로토콜을 부르는 대신 `gh`/`git`으로 우선순위 분석을 자기가 했습니다. 사고 블록이 전사에 비어 있어 내부 이유는 복구되지 않습니다.

`install-edit` 건은 테스트 설계 결함이 섞여 있습니다. 전제가 틀린 요청이었고(아래 2절), 이 한 사례로는 발화 누락 여부가 판정되지 않습니다.

### 결함

기존 규칙 셋 — 로드된 description만, 코어 프로토콜만, 자체 게이트 없음 — 은 description을 읽고 나서 대상 작업을 자기가 해버리는 세션도 전부 만족시킵니다. 라우팅 행위가 그 작업을 **대신한다**는 말이 어디에도 없었습니다. 호출 갈래의 "invoke it through the harness's skill invocation"도 판정만으로 이행된 것처럼 읽힙니다. 성공한 한 건이 실제로 한 일은 구체적이었습니다. 스킬 식별자와 결핍 문장을 실어 호출을 발행했습니다.

### 고침 (`7b89270e`)

- **호출 갈래를 명령형으로 좁힙니다.** 스킬 호출 능력을 그 프로토콜의 식별자와 결핍 문장으로 부르고, **그 호출 발행이 갈래를 이행한다**고 적습니다. `AGENTS.md`의 Harness boundary 조항에 따라 도구 이름 대신 능력을 명명합니다.
- **규칙 1로 결과 배타성을 넣습니다.** Route의 턴은 호출·넛지·침묵 중 정확히 하나로 끝납니다. description 읽기는 대조 단계이지 산출물이 아니고, 대상 작업은 호출된 프로토콜이나 다음 턴의 몫입니다.
- **FLOW 블록에도 같은 배타성을 적어** 형식 블록과 산문을 맞춥니다. TYPES에 `deficit_statement`, `invariant: Routing over Doing`.

훅 지시문은 그대로 둡니다. 끊긴 지점이 훅 이후이고, 매 턴 주입되는 세 줄에 스킬 표면의 규칙을 더하면 비용은 매 턴 치르면서 고침은 한 층 아래에서 일어나지 않습니다.

## 2. 기본 설치기 제외 (정정)

### 정정

PR #887 본문과 앞선 커밋 메시지는 `route`가 "기본 설치 집합에 들어 있지 않다"고 적었습니다. **틀린 주장이었습니다.** `scripts/install.sh`에는 목록이 없고 main의 `marketplace.json`을 받아 거기 있는 플러그인을 전부 설치하므로, 등재된 순간 `route`도 기본 설치 대상이었습니다. 루트 README도 그 한 줄을 "모든 프로토콜과 유틸리티 설치"로 광고하고 있었습니다.

처분: 마켓플레이스에는 남기고, 기본 설치기는 설치하지 않습니다.

### 고침 (두 번째 커밋)

- **`install.sh`에 `SKIP_PLUGINS="route"`.** 플러그인 목록은 여전히 매니페스트에서 유도하고, 이 변수가 유일한 손 관리 제외입니다. 끝에 건너뛴 플러그인과 추가 명령을 한 줄로 알립니다.
- **검사 채널.** `package.test.js`의 `default installer skip list`가 `SKIP_PLUGINS` 줄을 파싱해 각 이름이 매니페스트의 플러그인인지 단언합니다. 유령 이름을 넣어 실제로 걸리는 것을 확인했습니다.
- **`install-codex.sh`는 그대로.** 마켓플레이스만 추가하고 아무것도 설치하지 않습니다.
- **루트 README 두 언어**의 설치 절에 `route`가 opt-in이며 자기 설치 명령이 있다고 적습니다.

## 그대로인 것

실험 상태는 계속됩니다. `route/README` 두 언어는 이미 설치 명령을 싣고 있어 손대지 않았습니다.

## 검증

```
static-checks.js .                      FAIL 0 / WARN 0 / PASS 137
node --test (bundle + route)            tests 131 / pass 131 / fail 0
package.js --dry-run                    40 results, route.zip 0.1.4
generate-routing-map.js --check         in sync
```

매니페스트 0.1.3 → 0.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sjcp4x6z8DbvDfairXUBMQ
