### PR TITLE
fix(epistemic-cooperative): 길이가 어느 양에 답하는지를 핀에 올린다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.26.15",
+  "version": "4.26.16",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.26.15",
+  "version": "4.26.16",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/styles/epistemic-ink.md
+++ b/epistemic-cooperative/styles/epistemic-ink.md
@@ -48,15 +48,15 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 
 ## Rendering Judgment
 
-Whether a rendering earns its place, and what form it takes. One shape is pinned, where getting it wrong would make the rendering lie.
+Whether a rendering earns its place, and what form it takes. Two things are pinned, where getting either wrong would make the rendering lie: what a drawn length answers to, and the scale it declares.
 
 **The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape. Pulling out one discrete value is a table's task; taking in a set of relations at once is a picture's; and where the judgment rests on a quantity the reader would have to derive from what is shown — a share of a bound, a ratio between rows — that derived quantity is the finding, and it goes on screen beside its inputs.
 
 **A form the host already renders is not rebuilt here.** Use the harness's tables, lists, and headings. Character count is not display width, so East Asian text, emoji, and many box-drawing characters break columns that looked aligned when written: never pad by counting characters. The Ink elements below are the exception — their literal shapes are fixed under **What This Style Pins**, and are built here by contract rather than chosen.
 
-**A length is answerable to a quantity the work measured in what it was working on.** Bytes, counts, durations — what the work found out, existing whether or not it was drawn. The length asserts that quantity's precision, so the finding is what earns it.
+**A length is answerable to a quantity the work measured in what it was working on.** Pinned. Bytes, counts, durations — what the work found out, existing whether or not it was drawn. The length asserts that quantity's precision, so the finding is what earns it. A request does not reach this: asked for a length over what the work did rather than what it found, give the readout in prose and say in one line why.
 
-**A drawn length declares its scale.** Pinned. A bar with no stated scale reads as a measurement without being one. State the scale beside the drawing in units of one drawn cell (`1 cell ~ 0.8 GB`), and imply no resolution finer than a whole cell. Alignment comes from the harness — put the labels and the lengths in adjacent table columns, so they start from a common left edge without anything being padded by hand.
+**A drawn length declares its scale.** Pinned. State the scale beside the drawing in units of one drawn cell (`1 cell ~ 0.8 GB`), and imply no resolution finer than a whole cell. Alignment comes from the harness — put the labels and the lengths in adjacent table columns, so they start from a common left edge without anything being padded by hand.
 
 ## Ink Elements
 
@@ -140,7 +140,7 @@ A form instruction reaches the wording and not the marking. Asked for a plainer 
 
 ### What This Style Pins
 
-Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers, and the scale a drawn length declares. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
+Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers, what a drawn length answers to, and the scale it declares. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
 
 ## Protocol Recommendations
 

--- a/epistemic-cooperative/styles/proactive-epistemic-ink.md
+++ b/epistemic-cooperative/styles/proactive-epistemic-ink.md
@@ -87,15 +87,15 @@ When the rendered vocabulary would require user Recall at first encounter, optio
 
 ## Rendering Judgment
 
-Whether a rendering earns its place, and what form it takes. One shape is pinned, where getting it wrong would make the rendering lie.
+Whether a rendering earns its place, and what form it takes. Two things are pinned, where getting either wrong would make the rendering lie: what a drawn length answers to, and the scale it declares.
 
 **The reader's task governs; the form follows.** Ask what the reader has to do with what is on screen before choosing a shape. Pulling out one discrete value is a table's task; taking in a set of relations at once is a picture's; and where the judgment rests on a quantity the reader would have to derive from what is shown — a share of a bound, a ratio between rows — that derived quantity is the finding, and it goes on screen beside its inputs.
 
 **A form the host already renders is not rebuilt here.** Use the harness's tables, lists, and headings. Character count is not display width, so East Asian text, emoji, and many box-drawing characters break columns that looked aligned when written: never pad by counting characters. The Ink elements below are the exception — their literal shapes are fixed under **What This Style Pins**, and are built here by contract rather than chosen.
 
-**A length is answerable to a quantity the work measured in what it was working on.** Bytes, counts, durations — what the work found out, existing whether or not it was drawn. The length asserts that quantity's precision, so the finding is what earns it.
+**A length is answerable to a quantity the work measured in what it was working on.** Pinned. Bytes, counts, durations — what the work found out, existing whether or not it was drawn. The length asserts that quantity's precision, so the finding is what earns it. A request does not reach this: asked for a length over what the work did rather than what it found, give the readout in prose and say in one line why.
 
-**A drawn length declares its scale.** Pinned. A bar with no stated scale reads as a measurement without being one. State the scale beside the drawing in units of one drawn cell (`1 cell ~ 0.8 GB`), and imply no resolution finer than a whole cell. Alignment comes from the harness — put the labels and the lengths in adjacent table columns, so they start from a common left edge without anything being padded by hand.
+**A drawn length declares its scale.** Pinned. State the scale beside the drawing in units of one drawn cell (`1 cell ~ 0.8 GB`), and imply no resolution finer than a whole cell. Alignment comes from the harness — put the labels and the lengths in adjacent table columns, so they start from a common left edge without anything being padded by hand.
 
 ## Ink Elements
 
@@ -179,7 +179,7 @@ A form instruction reaches the wording and not the marking. Asked for a plainer 
 
 ### What This Style Pins
 
-Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers, and the scale a drawn length declares. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
+Form feedback names the relation between an instruction and what it does not reach, and leaves the reason to whichever layer fixed each element. These are the elements fixed here, so this is where their reason lives: the marking of a reading's firmness, `Basis:` wherever it is emitted under its own conditions, and the Ink elements themselves — a gate's divider block and its option shape (the numbered options and the summary layer that makes each one recognizable; the rationale line sits outside this pin and is governed by its own emit condition, as `Basis:` is), the convergence lines, the observer markers, what a drawn length answers to, and the scale it declares. Each of them exists so a reader can check a judgment instead of taking it, and a round that reads more smoothly once the check is gone is not the smoother round that was asked for. Asked for a register these sit inside, change the prose around them and say in one line that they stay. This reaches `Basis:` only through its own emit conditions — a protocol that declares the marker intentionally absent has fixed that for reasons of its own, and nothing here reaches past that declaration.
 
 ## Protocol Recommendations
 


### PR DESCRIPTION
## 요약

Rendering Judgment의 길이 판별자("A length is answerable to a quantity the work measured in what it was working on")를 척도 선언과 함께 §What This Style Pins의 고정 목록에 올립니다. 명시 요청이 이 조항에 닿지 않게 되어, 일이 알아낸 양이 아닌 한 일의 기록에 길이를 청하면 산문 readout과 한 줄 사유로 답합니다.

## 근거

개밥먹기 Stint 세션 6c439646 2회차 과제 E에서, 진행률 막대를 명시 요청하자 워커가 "1칸 = 과제 1개" 척도를 선언하고 `█ █ █ █ ░ 4 / 5`를 그렸습니다. 규칙 위반은 아니었습니다. 고정 목록에 척도만 있고 판별자는 없었으므로 Form feedback상 요청이 닿는 열린 조항이었습니다. 척도 핀은 그려진 뒤의 정직함을, 판별자는 그릴지 말지를 정하는 다른 층이라, 사용자가 게이트에서 판별자도 고정하는 쪽을 골랐습니다. 상세는 커밋 메시지에 있습니다.

## 변경

- `epistemic-cooperative/styles/epistemic-ink.md`, `proactive-epistemic-ink.md`: 각 +175자 (ink-body-identity 통과). 서두가 핀 둘을 명명, 판별자에 Pinned 표지와 결과 문장, 고정 목록 확장. 척도 조항에서 서두와 중복된 한 문장 은퇴.
- plugin.json (claude/codex): 4.26.15 → 4.26.16

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — 137 pass / 0 fail
- `node --test scripts/package.test.js` — 85 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157RZRgLo6ysBU6LTCcDP9g
