### PR TITLE
fix(route): 훅 지시문에 "active"의 정의를 박아 수렴 뒤 남은 스킬 프롬프트를 활성으로 오독하지 않게 한다

### DIFF
--- a/route/.claude-plugin/plugin.json
+++ b/route/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "route",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/route/.codex-plugin/plugin.json
+++ b/route/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "route",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Route the accumulated session context to the core protocol whose deficit it shows — /route (a per-prompt hook directive triggers it)",
   "author": {
     "name": "Jongwon Choi",

--- a/route/scripts/route-prompt.mjs
+++ b/route/scripts/route-prompt.mjs
@@ -7,6 +7,12 @@
  * short directive beside each user prompt carrying the firing conditions:
  * invoke /route when the accumulated context shows a deficit a loaded core
  * protocol resolves, skip while a protocol is active, otherwise stay silent.
+ * "Active" is defined in the directive itself: a protocol invoked this
+ * session that has not yet converged or deactivated. A protocol's skill
+ * prose stays in context after it converges, and without the definition the
+ * agent reads that leftover prose as an active protocol and skips /route for
+ * the rest of the session. /route carries no active-protocol detection of
+ * its own, so the exclusion stays here rather than moving into the skill.
  * The hook decides when; the /route skill decides what.
  *
  * Output shape is the hook wire format both Claude Code and Codex accept for
@@ -25,7 +31,8 @@ import { fileURLToPath } from "node:url";
 // time. It is injected every turn — keep it to a few short lines.
 const DIRECTIVE = [
   "[route] When the accumulated context shows an interaction deficit that a loaded core epistemic protocol resolves, invoke /route.",
-  "Skip while an epistemic protocol is already active.",
+  "Skip while an epistemic protocol is active: invoked this session and not yet converged or deactivated.",
+  "A converged protocol's prose still in context does not make it active.",
   "Otherwise stay silent.",
 ].join("\n");
 

--- a/route/scripts/route-prompt.test.mjs
+++ b/route/scripts/route-prompt.test.mjs
@@ -19,11 +19,13 @@ test("directive carries the three firing conditions and stays short", () => {
   // (a) deficit a loaded core protocol resolves → invoke /route
   assert.match(DIRECTIVE, /accumulated context shows an interaction deficit/);
   assert.match(DIRECTIVE, /loaded core epistemic protocol resolves, invoke \/route/);
-  // (b) active-protocol exclusion
-  assert.match(DIRECTIVE, /Skip while an epistemic protocol is already active/);
+  // (b) active-protocol exclusion, with "active" defined in place: invoked
+  //     and not yet converged/deactivated — leftover skill prose is not active
+  assert.match(DIRECTIVE, /Skip while an epistemic protocol is active: invoked this session and not yet converged or deactivated/);
+  assert.match(DIRECTIVE, /converged protocol's prose still in context does not make it active/);
   // (c) silence otherwise
   assert.match(DIRECTIVE, /Otherwise stay silent/);
-  assert.ok(DIRECTIVE.split("\n").length <= 3);
+  assert.ok(DIRECTIVE.split("\n").length <= 4);
 });
 
 test("parsePayload tolerates empty and malformed stdin", () => {


### PR DESCRIPTION
## 무엇을 고쳤나

`/route` 훅 지시문의 두 번째 줄 "Skip while an epistemic protocol is already active" 가 **"active" 를 정의하지 않은 채 모델에 판정을 맡기고** 있었다. 세션 d74f0603 모니터링에서, `/recollect`·`/ascend` 가 SingleObvious 경로로 첫 턴에 notional 하게 수렴한 뒤에도 스킬 프롬프트가 컨텍스트에 남아 있다는 이유만으로 모델이 이를 활성으로 읽고 이후 모든 턴에서 `/route` 를 건너뛰었다.

지시문이 "active" 를 그 자리에서 정의한다:

```
[route] When the accumulated context shows an interaction deficit that a loaded core epistemic protocol resolves, invoke /route.
Skip while an epistemic protocol is active: invoked this session and not yet converged or deactivated.
A converged protocol's prose still in context does not make it active.
Otherwise stay silent.
```

## 왜 이 경로인가

대안은 skip 조건을 훅에서 빼고 `/route` 에 활성 감지를 맡기는 것이었다. `/route` SKILL.md 는 로드된 설명만 읽고 세션 상태를 읽지 않으므로(Rules #2) 활성 감지가 없고, 그 경로는 프로토콜 도중 `/route` 가 끼어드는 부작용을 낳는다. 배제 조건은 훅에 남기고 정의만 보강했다.

## 변경 파일

- `route/scripts/route-prompt.mjs` — 지시문 4줄로 확장, 헤더 주석에 정의의 이유 기록
- `route/scripts/route-prompt.test.mjs` — 정의 문구 고정, 줄 수 상한 3→4
- `route/.claude-plugin/plugin.json`, `route/.codex-plugin/plugin.json` — 0.1.4 → 0.1.5

## 검증

- `node --test route/scripts/route-prompt.test.mjs` — 6/6 통과
- `node .claude/skills/verify/scripts/static-checks.js .` — fail 0, warn 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EahcFoDRdLGNd8DoHLRWfn
