### PR TITLE
fix(install): 설치 후 플러그인을 명시적으로 활성화한다

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,12 @@ for p in $plugins; do
   fi
   if claude plugin install "$p@$MARKETPLACE" < /dev/null 2>/dev/null; then
     installed=$((installed + 1))
+    # Install does not guarantee activation: a plugin that was already
+    # installed and later disabled (via /plugin, or a project-scope
+    # `enabledPlugins: false`) reports "already installed" and stays off.
+    # `enable` auto-detects the scope that disabled it; it exits non-zero
+    # when the plugin is already enabled, which is the common case.
+    claude plugin enable "$p@$MARKETPLACE" < /dev/null 2>/dev/null || true
   else
     echo "  Skipped: $p"
     skipped=$((skipped + 1))


### PR DESCRIPTION
`claude plugin install`은 설치만 보장하고 활성화는 보장하지 않는다. 이미 설치된
플러그인이 `/plugin`에서 꺼졌거나 프로젝트 스코프 `enabledPlugins: false`로
비활성화된 경우, 재설치는 "already installed"만 출력하고 꺼진 상태를 그대로
둔다. 실제 사용자가 설치 스크립트를 재실행했음에도 euporia(/elicit)가 꺼진 채로
남아 있던 사례가 이 경로였다.

설치가 성공(신규 설치 또는 이미 설치됨)한 플러그인마다 `claude plugin enable`을
한 번 더 호출한다. enable은 비활성화된 스코프를 자동 감지해 그 스코프에서 켜고,
이미 켜져 있으면 비영(非零)으로 종료하므로 `|| true`로 흡수한다. 설치가 실패한
플러그인에는 호출하지 않아 설정에 설치되지 않은 항목이 기록되는 일을 피한다.

재현: 프로젝트 `.claude/settings.local.json`에 euporia를 false로 두고 스크립트를
실행하면 패치 전에는 disabled로 남고, 패치 후에는 local 스코프에서 enabled로
바뀐다(Claude Code 2.1.261).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0181rERrPAA1Q9DaYX8gQdc1