### PR TITLE
feat(epistemic-cooperative): goal-research와 review-loop의 Codex 위임 모델을 gpt-6-astra로 올린다

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
-  "version": "4.28.2",
+  "version": "4.29.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "4.28.2",
+  "version": "4.29.0",
   "description": "Utility skills layered on top of the core protocols. /catalog browses the protocol handbook; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/skills/goal-research/SKILL.md
+++ b/epistemic-cooperative/skills/goal-research/SKILL.md
@@ -59,7 +59,7 @@ disabled.`), so every extraction below filters to lines starting with `{` before
 parsing. Select `{effort}` per run by the research question's depth and breadth, floored at `high` (never below) — a narrow, single-fact question runs at `high`, a multi-branch or deep-synthesis question at `xhigh`, and the most demanding research may escalate to `max` (the top of this model's ladder — it consumes usage limits faster, so reserve it for genuinely heavy questions):
 
 ```bash
-codex exec --ephemeral --json --color never --skip-git-repo-check -m gpt-5.6-sol \
+codex exec --ephemeral --json --color never --skip-git-repo-check -m gpt-6-astra \
   --config model_reasoning_effort="{effort}" \
   < /tmp/goal_research_${SUFFIX}.txt > /tmp/goal_research_events_${SUFFIX}.jsonl 2>/tmp/goal_research_warn_${SUFFIX}.txt
 ```

--- a/epistemic-cooperative/skills/review-loop/references/source-adapter-codex.md
+++ b/epistemic-cooperative/skills/review-loop/references/source-adapter-codex.md
@@ -43,7 +43,7 @@ The contract this adapter answers to — what it accepts, what it yields, and th
 
    ```bash
    codex exec --ephemeral --json --color never --skip-git-repo-check --cd "{repo_root}" \
-     -m gpt-5.6-sol {effort_flag} --sandbox read-only \
+     -m gpt-6-astra {effort_flag} --sandbox read-only \
      < /tmp/review_loop_codex_${SUFFIX}.txt \
      > /tmp/review_loop_codex_events_${SUFFIX}.jsonl \
      2>/tmp/review_loop_codex_warn_${SUFFIX}.txt &


### PR DESCRIPTION
두 스킬은 Codex CLI를 외부 자문 채널로 쓴다. review-loop의 codex source는
변경 파일 전체의 계약 닫힘과 EXERCISED 도달 보고를 매 라운드 요구하고,
goal-research는 Tavily 검증 리서치를 백그라운드로 위임한다. GPT-6 Astra는
cross-file 리뷰 커버리지에서 Sol 대비 격차가 크고, 시스템 카드 기준으로
검색 도구 고장 시 한계 인정 실패와 수행 내용 허위 보고가 각각 10배·4배
적어 두 스킬이 경계하는 실패 형태에 직접 닿는다.

effort 사다리(high 바닥, xhigh 가변, max 예외)는 그대로 둔다. OpenAI
마이그레이션 가이드가 기존 effort 유지를 권하고, reasoning 가이드의
high/xhigh 용도 정의가 두 스킬의 작업 형태와 이미 맞물린다. Codex 문서의
medium 기본값은 대화형 일상 작업 기준이라 이 위임 채널에는 적용하지 않는다.

image-companion(gpt-5.5 구조적 고정), anamnesis 추출 워커와 realize
하네스(gpt-5.6-luna, 비용 민감 배경 작업)는 이번 범위에서 제외한다.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ks8udfficSkg6Ex6zT5CtJ