### PR TITLE
fix(anamnesis): 전송 봉투로 중계된 사람의 발화를 사람의 발화로 읽는다

### DIFF
--- a/anamnesis/.claude-plugin/plugin.json
+++ b/anamnesis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "anamnesis",
   "description": "Resolve vague recall into recognized context — one session, or a line of work, topic, or settled concept across several — /recollect (ἀνάμνησις: a recollecting)",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/anamnesis/.codex-plugin/plugin.json
+++ b/anamnesis/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anamnesis",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Resolve vague recall into recognized context — one session, or a line of work, topic, or settled concept across several — /recollect (ἀνάμνησις: a recollecting)",
   "author": {
     "name": "Jongwon Choi",

--- a/anamnesis/skills/recollect/references/claude.md
+++ b/anamnesis/skills/recollect/references/claude.md
@@ -29,7 +29,7 @@ Per record, bind:
 - `bridgeSessionId` when a `{"type":"bridge-session"}` line is present;
 - the topic from the first human turn, under the filter below.
 
-**Human-turn filter.** A turn is the session's own human when `type` is `user`, `isMeta` and `isCompactSummary` are both absent, and the text neither opens with `<` nor is a bare control marker such as `[Request interrupted by user]`. Hook injections and cross-session envelopes arrive in that same `user` stream while being written by something other than the person; without the filter the spine attributes machine text to them, and the candidate presented for recognition is one the user never said.
+**Human-turn filter.** A turn is the session's own human when `type` is `user`, `isMeta` and `isCompactSummary` are both absent, and the text neither opens with `<` nor is a bare control marker such as `[Request interrupted by user]`. Hook injections and cross-session envelopes arrive in that same `user` stream while being written by something other than the person; without the filter the spine attributes machine text to them, and the candidate presented for recognition is one the user never said. One turn is the person's despite failing that test: a **relayed turn**, where `origin.kind` is `channel`. A transport carrying the person's words into the session wraps them and marks the record `isMeta`, because the envelope is machine-written even though its contents are not — so the `isMeta` rejection above discards it unread. Admit it on that field rather than on its text: `origin.server` merely names which transport carried it, so keying on `origin.kind` admits every transport without enumerating any. The utterance is what remains once the envelope and the machine-written context blocks nested inside it are set aside, and that remainder is what the spine takes as the topic and what Ground takes as the excerpt span.
 
 **Bridge handle.** `cse_…` and `session_…` are one identifier in two spellings. A recorded `bridgeSessionId` therefore yields the session's web address by prefix substitution:
 
@@ -50,11 +50,13 @@ grep -m1 '"type":"bridge-session"' "<record>"
 head -n 400 "<record>" | jq -rs '
   [ .[]?
     | select(.type=="user")
-    | select((.isMeta // false) | not)
     | select((.isCompactSummary // false) | not)
+    | select((.origin.kind == "channel") or ((.isMeta // false) | not))
+    | (.origin.kind == "channel") as $relayed
     | ( .message.content
         | if type=="string" then . else ([ .[]? | select(.type=="text") | .text ] | join(" ")) end )
-    | select(type=="string" and (startswith("<") | not))
+    | select(type=="string" and ($relayed or (startswith("<") | not)))
+    | select(length > 0)
   ] | .[0] // ""'
 ```
 


### PR DESCRIPTION
## 무엇이 문제였나

교차 세션 회상을 실제 저장소에 돌려보다 발견했습니다. 단서는 "Agents SDK 빌링을 조사한 세션"이었고, 회상 단위를 line 으로 올리자 네 구성원이 세 파티션에 걸쳐 조립됐습니다. 그중 사용자의 질문에 실제로 답하는 유일한 구성원 — `125f9b59-335d-4a5a-8b4c-d7f07eb35aac` — 에서 발췌가 하나도 나오지 않았습니다.

그 기록의 사용자 발화는 전송 봉투 안에 들어 있습니다. `origin.kind == "channel"`, `origin.server == "telegram"`, 그리고 **`isMeta: true`**. `claude.md` 의 사람-발화 필터는 `isMeta` 를 거부하므로, 무엇이 들어 있는지 읽어보기도 전에 기록을 버립니다.

## 재현

| 필터 | 비어 있지 않은 사람의 발화 |
|---|---|
| 고치기 전 | **0** |
| 고친 뒤 | **4** |

첫 건 안에 그 발화가 있습니다.

> gpt5.5 pro api 를 oauth 로 사용하는 방법을 리서치하여 cc-plugin 에 이식해 보려고 합니다. codex가 아닙니다 인증을 하나의 요금으로 하는 방법이 중요합니다

파일에 실린 jq 프로그램을 그대로 떼어 실행해 확인했습니다.

## 진단 정정

`startswith("<")` 한 절만의 문제가 아닙니다. 중계된 턴은 `isMeta: true` 로도 표시되므로 두 절이 함께 거부합니다. `<` 절만 고쳤다면 발췌는 여전히 복구되지 않았습니다.

## 고친 방식

텍스트를 문자열로 넘겨짚는 대신 기록 자신의 필드를 봅니다. `origin.kind == "channel"` 이 판별자이고 `<channel …>` 은 그 필드의 텍스트 형태입니다. `origin.server` 는 어떤 전송이었는지를 이름할 뿐이라 검사하지 않습니다 — 그래서 전송을 열거하지 않고 모든 전송을 받습니다. 채널 턴에는 `startswith("<")` 거부를 적용하지 않습니다.

## 봉투를 벗기는 일은 싣지 않는다

참조가 나르는 것은 모델이 스스로 알 수 없는 **저장소의 사실**이고, 기록을 연 뒤에 무엇이 사람의 말이고 무엇이 기계가 쓴 맥락 블록인지는 읽어서 압니다.

초안은 `<open-branches>` 와 `<reply-to …>` 를 이름으로 열거해 `gsub` 넷으로 벗겼습니다. 그것은 전송을 열거하지 않겠다는 같은 원칙을 한 층 아래에서 어기는 것이고, 새 블록이 하나 생기는 날 깨집니다. 산문 한 절로 남깁니다. 같은 이유로 `test("^\[.*\]$")` 절도 싣지 않습니다 — `[Request interrupted by user]` 를 topic 으로 제시할 모델은 없고, 산문은 이미 그것을 거른다고 적고 있습니다.

결과적으로 참조 표면의 diff 는 **한 문단에 세 문장, jq 에 세 줄**입니다.

## 왜 지금 문제가 되는가

재도출(`97884461`) 이전에는 서사가 INDEX 요지로 물러설 수 있었으므로, 필터가 발췌를 지워도 제시할 이야기는 남았습니다. 재도출이 서사를 발췌에서만 짓게 만들면서 같은 필터가 이제 **침묵**을 만듭니다. 전 대화가 전송으로 들어온 세션은 모든 턴이 버려지고, 기록은 발췌를 내지 못하며, 발췌로만 조립되는 recognizable 은 주장할 것이 남지 않습니다. ablation 자체는 옳았고, 그 결과로 이 필터에 요구되는 정확도가 올라갔는데 아무도 그것을 다시 보지 않았습니다.

## 번지지 않는 범위

이 필터는 저장소 전체에서 `claude.md` 한 곳에만 있습니다 (`SKILL.md`·hypomnesis 작성기 어디에도 같은 논리가 없습니다). codex 쪽은 최근 롤아웃 40 건을 훑어 `response_item`/`user` 위치의 channel 봉투가 0 건이라 손대지 않았습니다 — 그쪽의 대응물은 `SYNTHETIC_USER_TEXT_PREFIXES` 접두사 목록이고 전송 중계와 다른 문제입니다.

## 검증

- 회귀: `c806572a`·`ebedd95c`·`8be4caa6` 세 기록에서 topic 첫 발화 불변, 건수도 불변(9·9·11)
- `node .claude/skills/verify/scripts/static-checks.js .` — fail 0 / warn 0
- 테스트 128 pass / 0 fail
- anamnesis 2.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
