### PR TITLE
feat(scripts): install-codex에 codex 프로비저닝 탐침을 넣는다

### DIFF
--- a/scripts/install-codex.sh
+++ b/scripts/install-codex.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Add the Epistemic Protocols marketplace to Codex
-# Idempotent: safe to re-run after the marketplace is already added
+# Provision Codex, then add the Epistemic Protocols marketplace.
+# Installs the Codex CLI when absent and restores a ChatGPT login from
+# CODEX_AUTH_JSON_B64 when no auth.json exists, then adds the marketplace.
+# Idempotent: safe to re-run after the CLI, login, and marketplace are in place.
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/jongwony/epistemic-protocols/main/scripts/install-codex.sh | bash
@@ -11,7 +13,36 @@ REPO="jongwony/epistemic-protocols"
 MANIFEST_URL="https://raw.githubusercontent.com/$REPO/main/.agents/plugins/marketplace.json"
 MARKETPLACE_SOURCE="https://github.com/$REPO.git"
 
-command -v codex >/dev/null 2>&1 || { echo "Error: codex CLI not found. Install Codex first." >&2; exit 1; }
+# --- Codex provisioning probe ---
+# A fresh runtime may have neither the Codex CLI nor a stored login, and
+# environment variables are not set by default. Install the CLI when it is
+# absent, and restore a ChatGPT login from CODEX_AUTH_JSON_B64 only when the
+# machine has no auth.json yet — so an interactive machine already logged in via
+# `codex login` passes through untouched. When there is no login to restore and
+# no credential to restore it from, provisioning cannot produce a usable Codex,
+# so it fails loudly rather than adding a marketplace no protocol run can reach.
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "Codex CLI not found; installing @openai/codex..."
+  command -v npm >/dev/null 2>&1 || { echo "Error: npm not found; cannot install the Codex CLI." >&2; exit 1; }
+  npm install -g @openai/codex
+  command -v codex >/dev/null 2>&1 || { echo "Error: Codex CLI is still not on PATH after install." >&2; exit 1; }
+fi
+
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+if [ ! -f "$CODEX_HOME_DIR/auth.json" ]; then
+  if [ -n "${CODEX_AUTH_JSON_B64:-}" ]; then
+    echo "Restoring Codex login from CODEX_AUTH_JSON_B64..."
+    mkdir -p "$CODEX_HOME_DIR" && chmod 700 "$CODEX_HOME_DIR"
+    printf '%s' "$CODEX_AUTH_JSON_B64" | base64 -d > "$CODEX_HOME_DIR/auth.json"
+    chmod 600 "$CODEX_HOME_DIR/auth.json"
+  else
+    echo "Error: Codex is not logged in and CODEX_AUTH_JSON_B64 is not set." >&2
+    echo "Run 'codex login' interactively, or supply CODEX_AUTH_JSON_B64 to this process." >&2
+    exit 1
+  fi
+fi
+
 command -v curl >/dev/null 2>&1 || { echo "Error: curl not found." >&2; exit 1; }
 
 echo "Adding Codex marketplace..."


### PR DESCRIPTION
## 무엇을

`scripts/install-codex.sh`가 codex가 없으면 "Install Codex first"로 하드 실패만 하던 것을, 마켓플레이스 등록 앞에 프로비저닝 탐침을 넣어 스스로 준비하도록 바꿉니다.

## 왜

새 런타임(클라우드/CI 샌드박스)은 CLI도, 로그인도, 환경변수도 기본으로 없습니다. 그런데 codex를 실제로 부르는 유틸이 넷이고 모두 ChatGPT 구독 모델을 씁니다.

- `goal-research` — `codex exec -m gpt-5.6-sol`
- `gate-check` — advisor로 `codex exec`
- `image-companion` — `codex exec -m gpt-5.5`
- `review-loop` — `codex exec` 소스 어댑터

넷 다 `which codex`로 **존재만 점검**하고, 없거나 미인증이면 raw 에러로 멈춥니다. 프로비저닝은 하지 않으므로 그 자리를 이 설치기가 채웁니다. `-m gpt-5.6-sol` / `gpt-5.5`는 `~/.codex/auth.json`(ChatGPT 로그인)에 의존합니다.

## 어떻게

마켓플레이스 등록 앞에 두 단계를 둡니다.

1. **CLI** — codex가 PATH에 없으면 `npm install -g @openai/codex`. 설치 후에도 없으면 실패.
2. **로그인** — `auth.json`이 없을 때만 `CODEX_AUTH_JSON_B64`를 base64 디코드해 복원(`chmod 700`/`600`). 이미 `codex login`한 대화형 머신은 그대로 통과. 복원할 로그인도 크레덴셜도 없으면 **하드 실패** — 프로토콜 실행이 닿지 못할 마켓플레이스만 등록하고 성공한 척하지 않습니다.

## 경계

`realize` 하니스는 예외입니다. 의도적으로 `CODEX_API_KEY`를 프로세스 범위로만 쓰고 `auth.json`을 남기지 않도록 지어졌으므로, 이 크레덴셜 영속 경로는 **유틸 스킬용**이며 하니스에는 넣지 않았습니다.

## 검증

- `bash -n` · `shellcheck` 통과
- `base64 -d` 왕복 확인(macOS)
- `static-checks.js .` — fail 0 / warn 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5ZjfSDE7bneAWiAt4XMNK
