### PR TITLE
style(realize): harness.mjs의 em-dash 이스케이프를 리터럴로 통일한다

### DIFF
--- a/.claude/skills/realize/scripts/harness.mjs
+++ b/.claude/skills/realize/scripts/harness.mjs
@@ -752,7 +752,7 @@ function report() {
     console.log('\n`pass_k` contains deterministic transition predicates only. Manual transcript review is still required for:');
     for (const item of manualSummary) console.log(`- ${item}`);
     if (evidenceFailures.length) {
-      console.log('\n**Not readable as evidence** \u2014 treatment integrity failed, or a predicate had nothing to read:');
+      console.log('\n**Not readable as evidence** — treatment integrity failed, or a predicate had nothing to read:');
       console.log(line(cols));
       console.log(line(cols.map(() => '---')));
       for (const r of evidenceFailures) console.log(line(cols.map((c) => String(r[c]))));
@@ -771,7 +771,7 @@ function report() {
   console.log('\npass_k contains deterministic transition predicates only. Manual transcript review is still required for:');
   for (const item of manualSummary) console.log(`- ${item}`);
   if (evidenceFailures.length) {
-    console.log('\nNOT READABLE AS EVIDENCE \u2014 treatment integrity failed, or a predicate had nothing to read:');
+    console.log('\nNOT READABLE AS EVIDENCE — treatment integrity failed, or a predicate had nothing to read:');
     console.table(evidenceFailures);
   }
   if (missing.length) {


### PR DESCRIPTION
## 무엇이 불일치였나

`.claude/skills/realize/scripts/harness.mjs`가 같은 문자를 두 가지 표기로 적고 있었습니다. 755행과 774행은 `—` 이스케이프, 나머지 세 곳은 `—` 리터럴입니다. 리뷰에서 지적된 자리입니다.

## 출력은 그대로입니다

JS 소스에서 `'—' === '—'`가 참이므로 두 표기는 같은 문자열로 평가됩니다. 이 PR은 소스 표기의 일관성만 맞춥니다 — 동작 변경이 아닙니다.

## 카운트

| | 리터럴 `—` | 이스케이프 `—` |
|---|---|---|
| 이전 | 3 | 2 |
| 이후 | 5 | 0 |

## 의도적으로 남긴 이스케이프

`.claude/skills/verify/scripts/static-checks.js:560`의 `Ͱ-Ͽ`는 그대로 둡니다. 정규식 문자 클래스 안의 그리스 문자 블록 **범위**라서 load-bearing입니다. 코드포인트 범위는 리터럴 문자로 대체할 수 없습니다. 같은 줄이 단일 문자(`∥`, `ᵣ`, `→`)는 이미 리터럴로 쓰고 있으므로, 이 파일의 표기는 용도별로 갈린 것이지 불일치가 아닙니다.

저장소 본체(`node_modules`와 `.claude/worktrees/` 제외)의 유니코드 이스케이프는 이 두 파일이 전부입니다.

## 버전 범프 없음

`.claude/skills/`는 기여자 표면이며 패키징 대상이 아닙니다. `scripts/package.js`의 `CODEX_FORBIDDEN_SEGMENTS`가 `.claude`를 제외하고, `realize`는 `package.js` 어디에도 나오지 않습니다. 패키지된 런타임 표면이 바뀌지 않았으므로 어느 `plugin.json`도 범프를 지지 않습니다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` — fail 0 / warn 0
- 테스트 125 pass / 0 fail
- 교체 후 바이트 확인: `e2 80 94` (정상 UTF-8 em-dash), 파일 인코딩 UTF-8 유지
- diff는 의도한 두 줄뿐

🤖 Generated with [Claude Code](https://claude.com/claude-code)
