### PR TITLE
chore(epistemic-cooperative): 5.1.0 → 5.2.0 — #918이 빠뜨린 범프

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols; each utility skill's own SKILL.md carries its contract.",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Utility skills layered on top of the core protocols; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",


### PR DESCRIPTION
## 무엇이 빠졌나

[#918](https://github.com/jongwony/epistemic-protocols/pull/918)은 `review-loop/SKILL.md` §99만 고치고 매니페스트를 그대로 두었다. `.claude/rules/editing-conventions.md`는 변경마다 `plugin.json` 범프를 요구한다 — 값이 움직이지 않으면 마켓플레이스가 새 문장을 배달하지 않으므로, 설치된 쪽에서 §99는 여전히 층을 여는 수단이 없는 상태다.

## minor 인 근거

이 저장소의 이력이 두 갈래를 이미 갈라 놓았다:

| 증분 | 사례 | 성격 |
|---|---|---|
| patch | 4.28.3 → 4.28.4 | 이미 있는 문장을 고쳐 씀 (죽은 보기를 살아 있는 이웃으로) |
| minor | 4.29.0 → 4.30.0 | 공개 표면의 행위가 달라짐 (재도출된 루프를 표면에 맞춤) |

#918은 stacked 랜딩이 **층을 여는 수단을 갖지 못했던 상태**를 메운다. 루프가 그 국면에서 하는 일이 달라지므로 후자다.

## 범위

`.claude-plugin` 과 `.codex-plugin` 둘 다. #917이 그렇게 했고, 갈라지면 어느 쪽 설치인지에 따라 값이 달라진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBNeQRwwWt4yUGR5vgGYj