### PR TITLE
fix(premise): 환경 변화의 Constitution 분류와 방향 정정의 재확인을 걷는다 — 묻는지는 가역성 축이 정한다

### DIFF
--- a/premise/recognition-and-authority.md
+++ b/premise/recognition-and-authority.md
@@ -19,7 +19,7 @@ An AI system detects conditions (gaps, uncertainties, mismatches, risks) and pre
 The detection/authority distinction operationalizes at the level of individual actions. Every AI act in a dialogue is a move with one of two modes:
 
 - **Extension (relay mode)**: the AI exercises zero epistemic authority — it mechanically transmits environmental facts with a cited basis. Auto-resolution is legitimate when the action is relay.
-- **Constitution (gated mode)**: the AI exercises epistemic authority through selection, interpretation, scope expansion, or environment mutation. User confirmation is required.
+- **Constitution (gated mode)**: the AI exercises epistemic authority through selection, interpretation, or scope expansion. User confirmation is required.
 
 Single test: "Is the AI acting as a relay, or exercising authority?" Three indicators derive from this test — all are natural consequences of zero epistemic authority:
 
@@ -29,7 +29,7 @@ Single test: "Is the AI acting as a relay, or exercising authority?" Three indic
 | Cited | An external source is the basis, visible at the point of use | AI inference is the basis, and it is opaque |
 | Within boundary | Action stays within the current scope | Action crosses the current scope's boundary |
 
-**Dynamic observation scope**: non-destructive observation of a live system (including a test run with cleanup) is relay. Environment mutation (installation, a persistent state change) is constitution. Operational constraint: observation must not modify existing artifacts, and anything it creates must be cleaned up afterward.
+**Dynamic observation scope**: non-destructive observation of a live system (including a test run with cleanup) is relay. Whether a change to the environment proceeds is tiered by reversibility under Decision Tiering below, not settled on this axis. Operational constraint: observation must not modify existing artifacts, and anything it creates must be cleaned up afterward.
 
 **Visibility principle**: what determines sufficiency is that the resolution's basis is cited somewhere — timing (immediate or deferred) is immaterial. A convergence trace, a summary, or a post-hoc report all satisfy visibility when the basis is cited. A progress-count-only display with no cited basis forces recall instead of recognition.
 
@@ -54,7 +54,7 @@ A companion codification of Detection with Authority's split, framed by reversib
 - Reversible + Clear: execute, then summarize
 - Reversible + Ambiguous: ask
 - Irreversible: ask, await approval (`boundaries-and-safety.md` carries the general reversible/irreversible classification)
-- Settled direction collapses the ask (Reversible only): treat a reversible fork as "Clear" when the project's stated goals, an established convention (a sibling artifact's settled pattern), or a declared decision calibration already determines its direction — proceed/relay rather than ask. An irreversible or environment-mutating action stays "ask, await approval" however settled its direction.
+- Settled direction collapses the ask (Reversible only): treat a reversible fork as "Clear" when the project's stated goals, an established convention (a sibling artifact's settled pattern), or a declared decision calibration already determines its direction — proceed/relay rather than ask. An irreversible action stays "ask, await approval" however settled its direction.
 - Tier each follow-up separately (bundling re-gates a settled item): when one checkpoint surfaces several follow-ups, tier each on its own. Pairing a settled reversible item with a genuine fork in a single question promotes the settled one back to undecided — execute the settled ones, then ask only about the fork, stating what was already done.
-- Delegation default (who-executes, not whether-to-proceed): once an action is authorized, the assistant executes or delegates it rather than asking who performs it; when the user states they will do it themselves, the action is theirs. Whether to proceed with an irreversible or environment-mutating action still follows its tier above.
+- Delegation default (who-executes, not whether-to-proceed): once an action is authorized, the assistant executes or delegates it rather than asking who performs it; when the user states they will do it themselves, the action is theirs. Whether to proceed with an irreversible action still follows its tier above.
 - On silence: proceed if reversible+clear; wait otherwise

--- a/premise/session-and-handoff.md
+++ b/premise/session-and-handoff.md
@@ -12,7 +12,7 @@ This rests on the memory-for-goals account of task resumption: when people antic
 
 A user interruption during in-progress work indicates one of three things:
 - **Context provision**: the user supplies a value directly → incorporate immediately
-- **Direction change**: the user corrects the approach → pause, re-confirm before resuming
+- **Direction change**: the user corrects the approach → resume under the correction at once, then relay what changed and what it displaced, so the approach it replaced stays recoverable; the correction is the user's own settled direction, and re-confirming it would gate what they just decided
 - **State declaration**: the user declares a completed state → when relevant to the current task context, treat as an implicit turn yield; when ambiguous or cross-context, confirm before proceeding
 
 ## Protecting an In-Progress Task from Unnecessary Switching


### PR DESCRIPTION
## 무엇을

두 프리미스 절을 걷습니다. 둘 다 이미 정해진 것을 다시 게이트하던 절입니다.

**1. `premise/recognition-and-authority.md`** — "환경 변화·지속적 상태 변화"를 Constitution으로 분류하던 네 구절.

| 위치 | 변경 |
|---|---|
| §Operational refinement, Constitution 정의 | "or environment mutation" 삭제. Constitution은 선택·해석·범위 확장이라는 인식적 권위로만 정의됩니다. |
| §Dynamic observation scope | "Environment mutation (installation, a persistent state change) is constitution"을 "환경 변화가 진행되는지는 아래 Decision Tiering의 가역성으로 tier한다"로 대체. 관찰의 조작적 제약은 그대로입니다. |
| Decision Tiering, Settled direction collapses the ask | "or environment-mutating" 삭제. 비가역 행동만 방향이 정해져도 승인을 기다립니다. |
| Decision Tiering, Delegation default | 같은 삭제. |

**2. `premise/session-and-handoff.md` §Interruption Handling** — Direction change 항목. "pause, re-confirm before resuming"을 "정정 아래서 즉시 재개하고, 무엇이 바뀌었고 무엇을 밀어냈는지 중계해 대체된 접근이 복구 가능하게 남긴다"로 바꿉니다. State declaration의 "ambiguous면 confirm"은 그대로입니다.

## 왜

**1.** 이 문서는 두 축을 나란히 둡니다. Extension/Constitution은 인식적 권위의 축이고, Decision Tiering은 스스로 "가역성으로 짜인 동반 규약"이라 말합니다. 그런데 위 네 구절은 환경 변화를 인식적 권위 축에 실었습니다. git이 추적하는 파일 편집도 지속적 상태 변화이므로, 문자 그대로 읽는 모델은 모든 편집 앞에서 멈추게 되고 "Reversible + Clear: execute, then summarize"는 쓰기에 대해 공허해집니다. 비가역의 일반 분류는 `boundaries-and-safety.md`가 이미 가지고 있습니다. 발견된 곳은 한 줄이었지만 같은 분류를 세 곳이 함께 실어 나르고 있어 네 곳을 함께 걷었습니다.

**2.** 사용자의 정정은 사용자가 방금 스스로 정한 방향이라 settled direction 그 자체입니다. 그것을 재확인받는 것은 막 결정된 것을 게이트하는 일이고, 같은 절의 Context provision이 "즉시 반영"인 것과도 비대칭이었습니다. 되돌림은 게이트가 아니라 재개 직후의 중계가 보장합니다.

OpenAI의 GPT-6 Astra 모델 안내는 가역 작업·읽기 전용·수정에 허가가 필요 없다고, 그리고 요청받으면 방향을 바꾼다고 명시합니다. 이 프로젝트의 프리미스는 그 원칙을 Decision Tiering에 이미 담고 있었고, 위 절들이 그것을 다시 뒤집고 있었습니다.

## 검증

- `node .claude/skills/verify/scripts/static-checks.js .` fail 0, warn 0 (두 커밋 모두).
- `node --test route/scripts/route-premise.test.mjs route/scripts/route-session.test.mjs` 32 pass.

## 같은 점검에서 나온 나머지 발견 (이 PR 범위 밖)

OpenAI 안내(Initiative and follow-through, Instruction following)에 비춰 게이트 인지 부하를 점검한 결과입니다. 승인 게이트, 초안 검토 게이트, 발화 구성 게이트를 나눠 보면 앞의 둘에만 "먼저 만들고 마지막에 한 번 승인"이 적용되고, 셋째는 초안 선제시가 앵커링을 만들어 적용에서 제외됩니다.

- `/conduct`는 활성화마다 Phase 0 Qc → Phase 1 Sc → Phase 2 DraftGate 세 직렬 정지를 거친 뒤 계획이 생깁니다. 앞의 둘은 초안 검토형이라 DraftGate 한 표면에 접을 수 있습니다. `/frame` Q1 → Sc, `/realign`의 범위 확인 → Horizon A 바인딩도 같은 모양입니다.
- 영-발견 게이트가 프로토콜마다 다릅니다. `/ground` ZeroGapRead, `/bound` ZeroSignalConfirm, `/contextualize` Qz, `/grasp` ZeroGapConfirm은 정지하고, 나머지 여덟 프로토콜은 relay로 진행합니다.
- `/realign`은 Phase 2 Confirm을 받은 융합 문장을 Phase 3에서 다시 승인받습니다. `/steer` Phase 5는 mismatch_signals가 비고 클러스터 충돌이 없으면 Phase 3 판정의 기계적 조립입니다.
- `/inquire` Intensity의 Light 행은 Marginal 우선순위만 남아도 Dismiss 기본값을 단 정지를 겁니다.
- `route/scripts/route-prompt.mjs`의 매 턴 지시문은 요청이 완전히 명시적이지 않으면 `/route`를 호출하게 하고, 지배적 매치는 첫 게이트가 정지하는 프로토콜입니다. 사용자 지시가 스킬보다 우선한다는 절은 어느 표면에도 없습니다.
- 게이트 배치 원칙이 프리미스에 없습니다. 답에 의존하지 않는 단계 뒤에 게이트를 두고, 검토 가능한 구성물 위의 직렬 게이트는 되돌림 여지를 가진 전체 초안 게이트 하나로 접는다는 절입니다.

## 교차 검증 — Codex gpt-6-astra (xhigh), 수정 전 스냅샷에 대해 같은 세 질문

**수렴한 발견.** 이 PR이 걷는 `recognition-and-authority.md`의 Constitution 정의(:22)와 Decision Tiering(:57)을 Codex도 "blanket mutation reapproval"로 짚고 2위로 올렸습니다. 그 밖에 `/conduct`의 직렬 선행 게이트, `/realign` Phase 2→3 이중 확인, `/steer`의 이중 게이트, `/bound`·`/contextualize`의 영-발견 게이트, route 지시문의 조기 정지, 사용자 지시 우선 절의 부재가 같은 file:line으로 수렴했습니다. "사용자의 증거를 선제 초안화하지 말라"는 예외도 같은 자리(`/realign` 선이해, `/grasp` 프로브, `/inquire` 사용자 의존 항목)를 짚었습니다.

**Codex가 추가로 찾은 것 (검증 완료, 저장소 소유자 동의).**
- `premise/session-and-handoff.md` Direction change의 재확인 → **이 PR의 두 번째 커밋으로 반영.**
- `.claude/skills/verify/SKILL.md:99` Fix critical을 고른 뒤에도 수정마다 승인을 기다립니다.
- `epistemic-cooperative/skills/triage/SKILL.md:78` 명시적 전체 감사 요청에도 본문 읽기를 첫 체크포인트 뒤로 미룹니다.
- `analogia/skills/ground/SKILL.md:111` TurnReading이 한 턴에 한 disposition만 허용해 "A는 repair, B는 withdraw"가 Explore로 읽힙니다.
- `route/skills/route/SKILL.md:57` Rule #1 "Routing is the whole turn"을 1위로 올렸습니다.
- `gate-design.md:9` Priority Override는 지시 우선순위 충돌로 분류됩니다.

**갈렸다가 정리된 곳.** Codex는 `/preview` Qspec(:278)과 `/sketch` Qround(:222)의 생성 전 스펙 게이트를 과잉으로, `/apportion`의 조건 도출 전 컷 승인을 미완성으로 봤고, 이 점검은 앵커링 예외로 유지 쪽이었습니다. 저장소 소유자의 판정은 Codex 쪽입니다. 축 수준의 스펙 초안을 AI가 채우고 relay로 생성에 들어간 뒤, 버릴지 세부로 들어갈지를 사용자가 고치는 `/conduct`·`/apportion`의 whole-draft 모양으로 갑니다. 이 두 프로토콜의 재설계는 후속 PR입니다.

**이 점검만 찾은 것.** `/inquire` Light 행, `/frame` Q1→Sc, `/grasp` 영-발견(floor 근거로 논쟁 여지), 설치된 route 플러그인이 저장소 HEAD보다 오래된 점.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrwyL88pW1Dae5N7bFdkJx