### PR TITLE
fix(epistemic-cooperative): 리뷰 준비를 첫 실제 호출에 통합

### DIFF
--- a/epistemic-cooperative/.claude-plugin/plugin.json
+++ b/epistemic-cooperative/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-cooperative",
   "description": "Utility skills layered on top of the core protocols; each utility skill's own SKILL.md carries its contract.",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "outputStyles": "./styles/",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/.codex-plugin/plugin.json
+++ b/epistemic-cooperative/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-cooperative",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "Utility skills layered on top of the core protocols; each utility skill's own SKILL.md carries its contract.",
   "author": {
     "name": "Jongwon Choi",

--- a/epistemic-cooperative/README.md
+++ b/epistemic-cooperative/README.md
@@ -162,6 +162,10 @@ claude plugin install epistemic-cooperative@epistemic-protocols
 /goal-research <question>
 ```
 
+`/review-loop` reuses matching reviewer capability evidence and confirms the command
+and scope during the first read-only review. For PRs, an omitted `head`/`stacked`
+repair destination is settled before the first edit; it does not delay the review.
+
 ## Author
 
 Jongwon Choi (https://github.com/jongwony)

--- a/epistemic-cooperative/README_ko.md
+++ b/epistemic-cooperative/README_ko.md
@@ -154,6 +154,10 @@ epistemic-cooperative/
 /goal-research <question>
 ```
 
+`/review-loop`는 환경이 일치하는 리뷰어 기능 확인 기록을 재사용하고, 첫 읽기 전용
+리뷰에서 명령과 범위를 확인합니다. PR의 `head`/`stacked` 수정 반영 위치를 생략하면
+첫 수정 전에 확정하며, 그 선택 때문에 리뷰를 늦추지 않습니다.
+
 ## 저자
 
 Jongwon Choi (https://github.com/jongwony)

--- a/epistemic-cooperative/skills/review-loop/SKILL.md
+++ b/epistemic-cooperative/skills/review-loop/SKILL.md
@@ -76,10 +76,13 @@ reach nor a source direction by inference.
    include staged, unstaged, and recursively enumerated untracked paths, and retain
    the captured `HEAD` as base even after loop commits. No changes means ask what to
    review and stop. For a PR, read [PR scope](references/pr-scope.md) **before the
-   first review** for checkout, base, and landing preparation.
+   first review** for checkout and base preparation, and again before repairs for landing.
 3. For PR repairs, relay an already-settled `head` or `stacked` landing, including a
-   stated standing practice. State the reading and its basis. Otherwise ask; silence
-   stops. Hold the landing for this invocation while keeping the captured review base.
+   stated standing practice. State the reading and its basis. When unsettled, proceed
+   with read-only review and finding disposition; ask before the first repair.
+   Silence at that gate stops repairs. Hold the settled landing for this invocation
+   while keeping the captured review base. An invocation ending without repairs
+   needs no landing choice.
    A correction before repairs are committed replaces a misread designation; after
    commits, show what landed where and stop for recovery direction. A deliberately
    different settled landing belongs to a new invocation.
@@ -108,6 +111,13 @@ reach nor a source direction by inference.
 Use the selected host route and source adapter with the captured pointer and current
 intent bundle. Read the returned review and diagnostics in full. Record actual call
 settings and any reported failure cause as provenance, not coverage.
+
+Use the first read-only review call to confirm the selected command and its contract
+through startup, any skill expansion, and returned output. Reuse matching implementation
+evidence as the adapter specifies. Before accepting a verdict, establish that the
+selected source actually reviewed the captured surface and completed successfully.
+When execution contradicts the expected contract, diagnose that mismatch; unresolved
+source or scope mismatches contribute no verdict and follow the incomplete-call rule.
 
 A call ending without a usable review contributes no verdict and satisfies neither
 convergence arm. Show what returned and ask whether to continue without that round,
@@ -191,6 +201,9 @@ trends. Separate introduced, fix-induced, and pre-existing-side work when decidi
 what this unit carries. A rising count changes neither the criterion nor source scope.
 
 ### Phase 4 — Apply and check the bundle
+
+For PR scope, settle any pending landing choice under Phase 0 and prepare that
+destination through [PR scope](references/pr-scope.md) before the first edit.
 
 1. The driving session scans planned change points, adjacent interactions, and repeated
    instances. Name each fix's predicate and enumerate its sites across the artifact.

--- a/epistemic-cooperative/skills/review-loop/references/host-claude-code.md
+++ b/epistemic-cooperative/skills/review-loop/references/host-claude-code.md
@@ -3,10 +3,10 @@
 Load at source selection. Availability is the running host's advertised capability,
 not the model name or the presence of a plugin directory alone.
 
-- `code-review`: resolve the installed/built-in Claude review skill and its contract.
-  It must accept the captured local diff pointer and intent bundle and return review
-  results to the caller. Inspect its scope, output limits, reach channel, and whether
-  it is a `context: fork` skill. Invoke that fork with the advertised skill name;
+- `code-review`: resolve the advertised skill and isolation route. Reuse matching
+  contract evidence under [Claude review output](source-adapter-code-review.md), and
+  confirm scope and reporting limits through the first read-only review call.
+  When exposed metadata establishes `context: fork`, invoke that fork with the advertised skill name;
   otherwise use an available isolated reviewer subagent that calls the skill with
   only the review request. An inline `Skill(...)` call alone does not establish a
   fork. If neither route exists, report this source unavailable.

--- a/epistemic-cooperative/skills/review-loop/references/host-codex.md
+++ b/epistemic-cooperative/skills/review-loop/references/host-codex.md
@@ -1,18 +1,16 @@
 # Codex Host
 
-Load at source selection. Codex driving the loop does not make either CLI available:
-resolve the executable, authentication/configuration, and required skills separately.
-A child process starts with its own tools and configuration; parent tools, credentials,
-and mounted paths are not a promised child capability.
+Load at source selection. Resolve the executable, version, and selected configuration
+in the reviewed checkout. Use the first read-only review call to establish the child
+process's authentication and advertised skills in that environment.
 
 - `codex`: spawn a fresh `codex exec` in the reviewed checkout. Use
   [Codex CLI](source-adapter-codex.md) after designation. Do not resume/fork the
   driving conversation: the reviewer receives the diff pointer and design intent.
-- `code-review`: requires `claude` and a `/code-review` implementation available to
-  its print-mode session. Inspect its local contract before advertising it, including
-  local-scope support and output/reach limits. A plugin with the same display name
-  may implement a different review. Load [Claude review output](source-adapter-code-review.md)
-  after designation, then launch as below.
+- `code-review`: load [Claude review output](source-adapter-code-review.md), reuse
+  matching invocation evidence, and launch the read-only review below. Confirm the
+  selected `/code-review` implementation from the print-mode session's startup and
+  skill expansion; a matching plugin display name alone leaves that identity open.
 
 ## Claude print-mode call
 
@@ -24,21 +22,25 @@ Pass the prompt as data, not shell source:
 
 ```bash
 review_request=$(cat "$review_dir/prompt.txt")
-claude -p "$review_request" --output-format json \
-  > "$review_dir/result.json" 2> "$review_dir/stderr.txt"
+claude -p "$review_request" --output-format stream-json --verbose \
+  > "$review_dir/events.jsonl" 2> "$review_dir/stderr.txt"
 review_status=$?
 printf '%s\n' "$review_status" > "$review_dir/status.txt"
 ```
 
-Use the host's supervised execution and completion mechanism. Collect `status.txt`, the whole JSON envelope, and all stderr.
+Use the host's supervised execution and completion mechanism. Collect `status.txt`,
+the event stream including its terminal result envelope, and all stderr.
 The status file preserves the child exit code after the launcher shell ends. A successful result requires a present, readable status file containing zero
 and a successful terminal envelope (including `is_error`/`subtype` where present) and readable review
 content in `result`. Authentication failures can arrive in stdout; a nonempty result
 is not enough. Normalize the inner review with the selected adapter, retaining the
 raw envelope when it cannot be understood. Remove temporary files after capture.
 
-Check `claude --help` and the installed skill for the supported invocation. Print
-mode can expand user-invoked skills; terminal-only commands cannot be assumed to work.
+For an unfamiliar CLI version or changed invocation options, check `claude --help`.
+Preflight ends with executable, version, configuration, and invocation resolution;
+remaining capability evidence comes from the review call. For a contract mismatch,
+inspect the relevant help, exposed skill text, or call diagnostics and retain any
+unresolved limit on the trace.
 Keep the selected skill discoverable: `--bare` skips automatic discovery, and
 `--disable-slash-commands` removes skills. Use the host's normal permission settings;
 this recipe grants no bypass or write permission. Missing skill expansion, denied

--- a/epistemic-cooperative/skills/review-loop/references/pr-scope.md
+++ b/epistemic-cooperative/skills/review-loop/references/pr-scope.md
@@ -1,6 +1,7 @@
 # PR Scope and Landing
 
-Load for PR scope before the first review and consult again when repairs change head.
+Load for PR scope before the first review; prepare landing before the first repair
+and consult again when repairs change head.
 Use repository/GitHub tools available to the host; `gh` below is an example binding.
 
 1. Resolve the explicit PR, or detect the current branch's PR with `gh pr view`.
@@ -15,7 +16,9 @@ Use repository/GitHub tools available to the host; `gh` below is an example bind
    captured cut remains its ancestor. An ordinary advance preserves that relation;
    a rewrite may not. On a broken relation, present the cut, lower PR head, and
    intervening changes and stop for recovery direction.
-4. Follow the landing settled at Phase 0. `head` appends repairs to the reviewed head.
+4. Before the first repair, resolve any pending landing under Phase 0 and prepare it.
+   Read-only review proceeds from the PR checkout while landing is unsettled.
+   `head` appends repairs to the reviewed head.
    `stacked` cuts a layer from that head. Where using GitHub stacks, check the
    `github/gh-stack` extension, resolve existing ordered membership and the bottom
    base first. Follow `gh stack link --help` to link the repair layer while preserving

--- a/epistemic-cooperative/skills/review-loop/references/source-adapter-code-review.md
+++ b/epistemic-cooperative/skills/review-loop/references/source-adapter-code-review.md
@@ -3,10 +3,19 @@
 The host reference supplies isolation and invocation. This adapter maps the available
 Claude `/code-review` implementation to the Source Interface in `SKILL.md`.
 
-Before selection, inspect the implementation's accepted scope and output contract.
-Pass the resolved **local** base/head (or captured working-tree base and untracked
-paths) and design-intent bundle. Establish that the review examined that surface.
-A raw PR number alone addresses remote PR state and can omit local or stacked repairs.
+- At selection, reuse an available contract record matching the executable/version,
+  selected skill implementation/version, and relevant configuration. Keep its exact
+  command, accepted scope, output format, finding cap, reach channel, and evidence
+  pointer on the trace for later invocations. Reuse capability evidence only; each
+  call establishes its own authentication, reviewed scope, and completed result.
+- When a record is absent or its identity changes, start with the host's read-only
+  review invocation and determine the contract from its skill expansion and output.
+  Mark unknown limits until observed; refresh the affected record fields when runtime
+  evidence differs. A contract that cannot be established remains an explicit gap.
+- For every call, pass the resolved **local** base/head (or captured working-tree base
+  and untracked paths) and design-intent bundle. Establish that the review examined
+  that surface before normalizing it. A raw PR number alone addresses remote PR state
+  and can omit local or stacked repairs.
 
 Preserve the native result, then normalize only a completed review:
 


### PR DESCRIPTION
`/review-loop`가 첫 리뷰 전에 별도 기능 조사로 시간을 쓰고, 수정 반영 위치가 미정이라는 이유로 읽기 전용 리뷰까지 멈추는 문제를 수정합니다.

- 실행 파일·버전·설정·호출 방법을 확인한 뒤 첫 실제 리뷰에서 명령 확장, 요청 범위, 정상 종료를 검증합니다. 환경이 일치하는 기능 기록은 재사용하고 실제 실행의 불일치만 진단합니다.
- `head`/`stacked` 선택은 첫 수정 직전에 확정합니다. 수정 없이 끝나는 리뷰에는 선택이 필요하지 않습니다. 기존에 지정한 반영 위치와 고정 리뷰 base는 유지합니다.
- Claude/Codex 호스트 지침, PR scope, 한·영 README를 동기화하고 플러그인 버전을 6.4.0으로 올렸습니다.

검증: 저장소 정적 검사 118개 통과(오류·경고 0), `git diff --check` 통과. 기능 기록 부재·버전 변경·범위 불일치와 landing 미정의 종료·수정 경로를 변경 전후 직접 점검했습니다. 독립 전문가 리뷰 및 실제 실행 시간 측정은 하지 않았습니다. 기본 Codex 스킬 검증기는 기존 `skills:` frontmatter를 지원하지 않으며, 이 저장소 전용 검증은 통과합니다.

이 PR을 병합하고 플러그인을 업데이트하면 이후 호출부터 새 흐름이 적용됩니다. 현재 실행 중인 리뷰의 설치 캐시나 세션 상태는 이 변경에서 갱신하지 않았습니다.
